### PR TITLE
add ops for YOLOv3

### DIFF
--- a/backends/npu/kernels/funcs/npu_op_runner.cc
+++ b/backends/npu/kernels/funcs/npu_op_runner.cc
@@ -211,7 +211,7 @@ NpuOpRunner &NpuOpRunner::AddInput(const phi::DenseTensor &tensor,
 }
 
 NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
-                                   std::vector<int32_t> &&dims) {
+                                   const std::vector<int32_t> &&dims) {
   phi::DenseTensor host_tensor;
   custom_kernel::TensorFromVector(
       dev_ctx, dims, phi::CPUContext(), &host_tensor);
@@ -226,7 +226,7 @@ NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
 }
 
 NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
-                                   std::vector<int64_t> &&dims) {
+                                   const std::vector<int64_t> &&dims) {
   phi::DenseTensor host_tensor;
   custom_kernel::TensorFromVector(
       dev_ctx, dims, phi::CPUContext(), &host_tensor);
@@ -241,7 +241,7 @@ NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
 }
 
 NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
-                                   std::vector<float> &&values) {
+                                   const std::vector<float> &&values) {
   phi::DenseTensor host_tensor;
   custom_kernel::TensorFromVector(
       dev_ctx, values, phi::CPUContext(), &host_tensor);
@@ -256,7 +256,7 @@ NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
 }
 
 NpuOpRunner &NpuOpRunner::AddInput(const phi::CustomContext &dev_ctx,
-                                   std::vector<double> &&values) {
+                                   const std::vector<double> &&values) {
   phi::DenseTensor host_tensor;
   custom_kernel::TensorFromVector(
       dev_ctx, values, phi::CPUContext(), &host_tensor);

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -70,16 +70,16 @@ class NpuOpRunner {
   NpuOpRunner &AddInput(const phi::DenseTensor &tensor, aclMemType mem_type);
 
   NpuOpRunner &AddInput(const phi::CustomContext &dev_ctx,
-                        std::vector<int32_t> &&dims);
+                        const std::vector<int32_t> &&dims);
 
   NpuOpRunner &AddInput(const phi::CustomContext &dev_ctx,
-                        std::vector<int64_t> &&dims);
+                        const std::vector<int64_t> &&dims);
 
   NpuOpRunner &AddInput(const phi::CustomContext &dev_ctx,
-                        std::vector<float> &&values);
+                        const std::vector<float> &&values);
 
   NpuOpRunner &AddInput(const phi::CustomContext &dev_ctx,
-                        std::vector<double> &&values);
+                        const std::vector<double> &&values);
 
   NpuOpRunner &AddOutput(const phi::DenseTensor &tensor);
 

--- a/backends/npu/kernels/stack_kernel.cc
+++ b/backends/npu/kernels/stack_kernel.cc
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/npu_funcs.h"
+#include "kernels/funcs/npu_op_runner.h"
+
+namespace custom_kernel {
+
+template <typename T, typename Context>
+void StackKernel(const Context& dev_ctx,
+                 const std::vector<const phi::DenseTensor*>& x,
+                 int axis,
+                 phi::DenseTensor* y) {
+  dev_ctx.template Alloc<T>(y);
+  auto stream = dev_ctx.stream();
+
+  if (axis < 0) axis += (x[0]->dims().size() + 1);
+  int num = static_cast<int>(x.size());
+
+  PADDLE_ENFORCE_GT(
+      num, 0, phi::errors::InvalidArgument("number of input Tensor <= 0"));
+
+  std::vector<phi::DenseTensor> x_list;
+  for (int i = 0; i < num; i++) {
+    x_list.push_back(*x[i]);
+  }
+
+  const auto& runner =
+      NpuOpRunner("Pack", {x_list}, {*y}, {{"axis", axis}, {"N", num}});
+  runner.Run(stream);
+}
+
+template <typename T, typename Context>
+void StackGradKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& dy,
+                     int axis,
+                     std::vector<phi::DenseTensor*> dx) {
+  auto stream = dev_ctx.stream();
+
+  if (axis < 0) axis += dy.dims().size();
+  int num = dy.dims()[axis];
+
+  PADDLE_ENFORCE_GT(
+      num, 0, phi::errors::InvalidArgument("number of input Tensor <= 0"));
+
+  std::vector<phi::DenseTensor> dx_list;
+  for (int i = 0; i < num; i++) {
+    dev_ctx.template Alloc<T>(dx[i]);
+    dx_list.push_back(*dx[i]);
+  }
+
+  const auto& runner =
+      NpuOpRunner("Unpack", {dy}, {dx_list}, {{"axis", axis}, {"num", num}});
+  runner.Run(stream);
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(stack,
+                          ascend,
+                          ALL_LAYOUT,
+                          custom_kernel::StackKernel,
+                          int,
+                          int64_t,
+                          float,
+                          double) {}
+
+PD_REGISTER_PLUGIN_KERNEL(stack_grad,
+                          ascend,
+                          ALL_LAYOUT,
+                          custom_kernel::StackGradKernel,
+                          int,
+                          int64_t,
+                          float,
+                          double) {}

--- a/backends/npu/kernels/transpose_kernel.cc
+++ b/backends/npu/kernels/transpose_kernel.cc
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/npu_funcs.h"
+#include "kernels/funcs/npu_op_runner.h"
+
+namespace custom_kernel {
+
+template <typename T, typename Context>
+void TransposeKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& x,
+                     const std::vector<int>& axis,
+                     phi::DenseTensor* out) {
+  dev_ctx.template Alloc<T>(out);
+  auto stream = dev_ctx.stream();
+
+  NpuOpRunner runner;
+  runner.SetType("Transpose")
+      .AddInput(x)
+      .AddInput(dev_ctx, std::move(axis))
+      .AddOutput(*out);
+  runner.Run(stream);
+}
+
+template <typename T, typename Context>
+void TransposeGradKernel(const Context& dev_ctx,
+                         const phi::DenseTensor& dout,
+                         const std::vector<int>& axis,
+                         phi::DenseTensor* dx) {
+  dev_ctx.template Alloc<T>(dx);
+  auto stream = dev_ctx.stream();
+
+  std::vector<int> reversed_axis(axis);
+  for (size_t i = 0; i < axis.size(); i++) {
+    reversed_axis[axis[i]] = i;
+  }
+  NpuOpRunner runner;
+  runner.SetType("Transpose")
+      .AddInput(dout)
+      .AddInput(dev_ctx, std::move(reversed_axis))
+      .AddOutput(*dx);
+  runner.Run(stream);
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(transpose,
+                          ascend,
+                          ALL_LAYOUT,
+                          custom_kernel::TransposeKernel,
+                          int,
+                          int64_t,
+                          uint8_t,
+                          int8_t,
+                          float,
+                          double) {}
+
+PD_REGISTER_PLUGIN_KERNEL(transpose_grad,
+                          ascend,
+                          ALL_LAYOUT,
+                          custom_kernel::TransposeGradKernel,
+                          int,
+                          int64_t,
+                          uint8_t,
+                          int8_t,
+                          float,
+                          double) {}

--- a/backends/npu/tests/unittests/test_stack_op_npu.py
+++ b/backends/npu/tests/unittests/test_stack_op_npu.py
@@ -1,0 +1,249 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+from tests.op_test import OpTest
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+paddle.enable_static()
+
+
+class TestStackOpBase(OpTest):
+    def initDefaultParameters(self):
+        self.num_inputs = 4
+        self.input_dim = (5, 6, 7)
+        self.axis = 0
+
+    def initParameters(self):
+        pass
+
+    def get_x_names(self):
+        x_names = []
+        for i in range(self.num_inputs):
+            x_names.append('x{}'.format(i))
+        return x_names
+
+    def setUp(self):
+        self.initDefaultParameters()
+        self.initParameters()
+        self.op_type = 'stack'
+        self.set_npu()
+        self.init_dtype()
+        self.x = []
+        for i in range(self.num_inputs):
+            self.x.append(
+                np.random.random(size=self.input_dim).astype(self.dtype))
+
+        tmp = []
+        x_names = self.get_x_names()
+        for i in range(self.num_inputs):
+            tmp.append((x_names[i], self.x[i]))
+
+        self.inputs = {'X': tmp}
+        self.outputs = {'Y': np.stack(self.x, axis=self.axis)}
+        self.attrs = {'axis': self.axis}
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+        self.place = paddle.CustomPlace('ascend', 0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        if self.dtype == np.int32 or self.dtype == np.int64:
+            return
+        self.check_grad_with_place(self.place, self.get_x_names(), 'Y')
+
+
+class TestStackOp1(TestStackOpBase):
+    def initParameters(self):
+        self.num_inputs = 16
+
+
+class TestStackOp2(TestStackOpBase):
+    def initParameters(self):
+        self.num_inputs = 20
+
+
+class TestStackOp3(TestStackOpBase):
+    def initParameters(self):
+        self.axis = -1
+
+
+class TestStackOp4(TestStackOpBase):
+    def initParameters(self):
+        self.axis = -4
+
+
+class TestStackOp5(TestStackOpBase):
+    def initParameters(self):
+        self.axis = 1
+
+
+class TestStackOp6(TestStackOpBase):
+    def initParameters(self):
+        self.axis = 3
+
+
+class TestStackOpINT32(TestStackOpBase):
+    def init_dtype(self):
+        self.dtype = np.int32
+
+
+class TestStackOpINT64(TestStackOpBase):
+    def init_dtype(self):
+        self.dtype = np.int64
+
+# TODO(windstamp)
+@unittest.skipIf(True, "Right now failed maybe caused by other reasons")
+class TestStackAPIWithLoDTensorArray(unittest.TestCase):
+    """
+    Test stack api when the input(x) is a LoDTensorArray.
+    """
+
+    def setUp(self):
+        self.axis = 1
+        self.iter_num = 3
+        self.input_shape = [2, 3]
+        self.x = np.random.random(self.input_shape).astype("float32")
+        self.place = paddle.CustomPlace('ascend', 0) \
+            if ('ascend' in paddle.fluid.core.get_all_custom_device_type()) else paddle.CPUPlace()
+        self.set_program()
+
+    def set_program(self):
+        self.program = fluid.Program()
+        with fluid.program_guard(self.program):
+            input = fluid.layers.assign(self.x)
+            tensor_array = fluid.layers.create_array(dtype='float32')
+            zero = fluid.layers.fill_constant(shape=[1], value=0, dtype="int64")
+
+            for i in range(self.iter_num):
+                fluid.layers.array_write(input, zero + i, tensor_array)
+
+            self.out_var = fluid.layers.stack(tensor_array, axis=self.axis)
+
+    def test_case(self):
+        self.assertTrue(self.out_var.shape[self.axis] == -1)
+        exe = fluid.Executor(self.place)
+        res = exe.run(self.program, fetch_list=self.out_var)
+        self.assertTrue(
+            np.array_equal(
+                res[0], np.stack(
+                    [self.x] * self.iter_num, axis=self.axis)))
+
+# TODO(windstamp)
+@unittest.skipIf(True, "Right now failed maybe caused by other reasons")
+class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
+    """
+    Test stack api when the input(x) is a LoDTensorArray.
+    """
+
+    def setUp(self):
+        self.axis = 1
+        self.iter_num = 3
+        self.input_shape = [2, 3]
+        self.x = np.random.random(self.input_shape).astype("float32")
+        self.place = paddle.CustomPlace('ascend', 0) \
+            if ('ascend' in paddle.fluid.core.get_all_custom_device_type()) else paddle.CPUPlace()
+        self.set_program()
+
+    def set_program(self):
+        self.program = fluid.Program()
+        with fluid.program_guard(self.program):
+            input = fluid.layers.assign(self.x)
+            tensor_array = fluid.layers.create_array(dtype='float32')
+            zero = fluid.layers.fill_constant(shape=[1], value=0, dtype="int64")
+
+            for i in range(self.iter_num):
+                fluid.layers.array_write(input, zero + i, tensor_array)
+
+            self.out_var = paddle.stack(tensor_array, axis=self.axis)
+
+    def test_case(self):
+        self.assertTrue(self.out_var.shape[self.axis] == -1)
+        exe = fluid.Executor(self.place)
+        res = exe.run(self.program, fetch_list=self.out_var)
+        self.assertTrue(
+            np.array_equal(
+                res[0], np.stack(
+                    [self.x] * self.iter_num, axis=self.axis)))
+
+# TODO(windstamp)
+@unittest.skipIf(True, "Right now failed maybe caused by other reasons")
+class API_test(unittest.TestCase):
+    def test_out(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            data1 = fluid.layers.data('data1', shape=[1, 2], dtype='float32')
+            data2 = fluid.layers.data('data2', shape=[1, 2], dtype='float32')
+            data3 = fluid.layers.data('data3', shape=[1, 2], dtype='float32')
+            result_stack = paddle.stack([data1, data2, data3], axis=0)
+            place = paddle.CustomPlace('ascend', 0)
+            exe = fluid.Executor(place)
+            input1 = np.random.random([1, 2]).astype('float32')
+            input2 = np.random.random([1, 2]).astype('float32')
+            input3 = np.random.random([1, 2]).astype('float32')
+            result, = exe.run(
+                feed={"data1": input1,
+                      "data2": input2,
+                      "data3": input3},
+                fetch_list=[result_stack])
+            expected_result = np.stack([input1, input2, input3], axis=0)
+            self.assertTrue(np.allclose(expected_result, result))
+
+    def test_single_tensor_error(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            x = paddle.rand([2, 3])
+            self.assertRaises(TypeError, paddle.stack, x)
+
+# TODO(windstamp)
+@unittest.skipIf(True, "Right now failed maybe caused by other reasons")
+class API_DygraphTest(unittest.TestCase):
+    def test_out(self):
+        data1 = np.array([[1.0, 2.0]])
+        data2 = np.array([[3.0, 4.0]])
+        data3 = np.array([[5.0, 6.0]])
+        with fluid.dygraph.guard(place=paddle.CustomPlace('ascend', 0)):
+            x1 = fluid.dygraph.to_variable(data1)
+            x2 = fluid.dygraph.to_variable(data2)
+            x3 = fluid.dygraph.to_variable(data3)
+            result = paddle.stack([x1, x2, x3])
+            result_np = result.numpy()
+        expected_result = np.stack([data1, data2, data3])
+        self.assertTrue(np.allclose(expected_result, result_np))
+
+        with fluid.dygraph.guard(place=paddle.CustomPlace('ascend', 0)):
+            y1 = fluid.dygraph.to_variable(data1)
+            result = paddle.stack([y1], axis=0)
+            result_np_2 = result.numpy()
+        expected_result_2 = np.stack([data1], axis=0)
+        self.assertTrue(np.allclose(expected_result_2, result_np_2))
+
+    def test_single_tensor_error(self):
+        with fluid.dygraph.guard(place=paddle.CustomPlace('ascend', 0)):
+            x = paddle.to_tensor([1, 2, 3])
+            self.assertRaises(Exception, paddle.stack, x)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backends/npu/tests/unittests/test_transpose_op_npu.py
+++ b/backends/npu/tests/unittests/test_transpose_op_npu.py
@@ -1,0 +1,133 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+from tests.op_test import OpTest, _set_use_system_allocator
+import paddle
+import paddle.fluid as fluid
+
+paddle.enable_static()
+
+
+class TestTransposeOp(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "transpose2"
+        self.place = paddle.CustomPlace('ascend', 0)
+        self.init_dtype()
+        self.init_shape_axis()
+
+        self.inputs = {'X': np.random.random(self.shape).astype(self.dtype)}
+        self.attrs = {'axis': self.axis, 'data_format': 'AnyLayout'}
+        self.outputs = {'Out': self.inputs['X'].transpose(self.axis)}
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def init_shape_axis(self):
+        self.shape = (3, 40)
+        self.axis = (1, 0)
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        self.check_grad_with_place(self.place, ['X'], 'Out')
+
+
+class TestCase0(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (100, )
+        self.axis = (0, )
+
+
+class TestCase1(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (3, 4, 10)
+        self.axis = (0, 2, 1)
+
+
+class TestCase2(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 3, 4, 5)
+        self.axis = (0, 2, 3, 1)
+
+
+class TestCase3(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 3, 4, 5, 6)
+        self.axis = (4, 2, 3, 1, 0)
+
+
+class TestCase4(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 3, 4, 5, 6, 1)
+        self.axis = (4, 2, 3, 1, 0, 5)
+
+
+class TestCase5(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 16, 96)
+        self.axis = (0, 2, 1)
+
+
+class TestCase6(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 10, 12, 16)
+        self.axis = (3, 1, 2, 0)
+
+
+class TestCase7(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 10, 2, 16)
+        self.axis = (0, 1, 3, 2)
+
+
+class TestCase8(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 3, 2, 3, 2, 4, 3, 3)
+        self.axis = (0, 1, 3, 2, 4, 5, 6, 7)
+
+
+class TestCase9(TestTransposeOp):
+    def init_shape_axis(self):
+        self.shape = (2, 3, 2, 3, 2, 4, 3, 3)
+        self.axis = (6, 1, 3, 5, 0, 2, 4, 7)
+
+
+class TestTransposeOpFP16(TestTransposeOp):
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def test_check_grad(self):
+        pass
+
+
+class TestTransposeOpInt64(TestTransposeOp):
+    def init_dtype(self):
+        self.dtype = np.int64
+
+    def test_check_grad(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
add ops for YOLOv3

目前，还有些单元测试的 Case 是失败的，但是原因应该是非算子本身问题引起的。比如，（1）有些可能是类似 https://github.com/PaddlePaddle/Paddle/pull/42817 这种原因导致的。（2）有些是由于还缺少其它算子导致的，特别是包含组网的 Case。（3）CustomDevice 功能可能还存在一些需要完善的地方。所以先注释了这些失败的 Case，并标注了 TODO 来记录，后续随着算子和功能的完善，再去掉注释即可。