### PR TITLE
npu delete funcs dependency

### DIFF
--- a/backends/npu/kernels/flatten_kernel.cc
+++ b/backends/npu/kernels/flatten_kernel.cc
@@ -14,11 +14,20 @@
 
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
-
 #include "paddle/phi/core/tensor_meta.h"
-#include "paddle/phi/kernels/funcs/common_shape.h"
 
 namespace custom_kernel {
+
+inline void SetXShape(const phi::DenseTensor& x, phi::DenseTensor* xshape) {
+  const auto& in_dims = x.meta().dims;
+  std::vector<int64_t> xshape_dims(in_dims.size() + 1);
+  xshape_dims[0] = 0;
+  for (int i = 0; i < in_dims.size(); ++i) {
+    xshape_dims[i + 1] = in_dims[i];
+  }
+  xshape->ResizeAndAllocate(phi::make_ddim(xshape_dims));
+  xshape->ResetLoD(x.meta().lod);
+}
 
 template <typename T, typename Context>
 void FlattenKernel(const Context& dev_ctx,
@@ -59,7 +68,7 @@ void FlattenWithXShape(const Context& dev_ctx,
                        phi::DenseTensor* xshape) {
   custom_kernel::FlattenKernel<T, Context>(
       dev_ctx, x, start_axis, stop_axis, out);
-  phi::funcs::SetXShape(x, xshape);
+  SetXShape(x, xshape);
 }
 
 }  // namespace custom_kernel

--- a/backends/npu/kernels/range_kernel.cc
+++ b/backends/npu/kernels/range_kernel.cc
@@ -15,9 +15,34 @@
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
 
-#include "paddle/phi/kernels/funcs/range_function.h"
-
 namespace custom_kernel {
+
+template <typename T>
+void GetSize(T start, T end, T step, int64_t* size) {
+  PADDLE_ENFORCE_NE(
+      step,
+      0,
+      phi::errors::InvalidArgument("The step of range op should not be 0."));
+
+  if (start < end) {
+    PADDLE_ENFORCE_GT(
+        step,
+        0,
+        phi::errors::InvalidArgument(
+            "The step should be greater than 0 while start < end."));
+  }
+
+  if (start > end) {
+    PADDLE_ENFORCE_LT(step,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The step should be less than 0 while start > end."));
+  }
+
+  *size = std::is_integral<T>::value
+              ? ((std::abs(end - start) + std::abs(step) - 1) / std::abs(step))
+              : std::ceil(std::abs((end - start) / step));
+}
 
 template <typename T, typename Context>
 void ArangeKernel(const Context& dev_ctx,
@@ -41,7 +66,7 @@ void ArangeKernel(const Context& dev_ctx,
   T step = n_data[0];
 
   int64_t size = 0;
-  phi::funcs::GetSize(start, end, step, &size);
+  GetSize(start, end, step, &size);
 
   out->Resize(phi::make_ddim({size}));
   dev_ctx.template Alloc<T>(out);


### PR DESCRIPTION
Paddle takes back unnecessary header files including paddle/phi/kernels/funcs/

related: https://github.com/PaddlePaddle/Paddle/pull/44831