### PR TITLE
【DEMO】add gpu profiler plugin

### DIFF
--- a/backends/gpu_profiler/CMakeLists.txt
+++ b/backends/gpu_profiler/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+cmake_minimum_required(VERSION 3.10)
+
+project(paddle-gpu-profiler CXX C)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+
+set(PLUGIN_NAME        "paddle-gpu-profiler")
+set(PLUGIN_VERSION     "0.0.1")
+
+include(paddle)
+
+include_directories(/usr/local/cuda-10.1/extras/CUPTI/include/ 
+                    /usr/local/cuda-10.1/include 
+                    ${PADDLE_INC_DIR} 
+                    ${CMAKE_SOURCE_DIR})
+
+link_directories(/usr/local/cuda-10.1/lib64/ 
+                /usr/local/cuda-10.1/extras/CUPTI/lib64/ 
+                ${PADDLE_LIB_DIR})
+
+add_library(${PLUGIN_NAME} SHARED runtime.cc process_data.cc os_info.cc)
+target_link_libraries(${PLUGIN_NAME} cudart cupti ${PADDLE_CORE_LIB})
+
+# packing wheel package
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+
+add_custom_command(TARGET ${PLUGIN_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    COMMENT "Creating plugin dirrectories------>>>"
+)
+
+find_package(Python COMPONENTS Interpreter REQUIRED)
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py bdist_wheel
+    DEPENDS ${PLUGIN_NAME}
+    COMMENT "Packing whl packages------>>>"
+)
+
+add_custom_target(python_package ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp)

--- a/backends/gpu_profiler/cmake/paddle.cmake
+++ b/backends/gpu_profiler/cmake/paddle.cmake
@@ -1,0 +1,44 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(Python ${PYTHON_VERSION} REQUIRED COMPONENTS Interpreter Development)
+
+if(DEFINED ENV{PADDLE_CUSTOM_PATH})
+    set(PADDLE_DIR $ENV{PADDLE_CUSTOM_PATH})
+else()
+    set(PADDLE_DIR ${Python_SITEARCH}/paddle)
+endif()
+
+if(NOT EXISTS ${PADDLE_DIR})
+    message (FATAL_ERROR "NO Installed Paddle Found in ${PADDLE_DIR}")
+endif()
+
+set(PADDLE_INC_DIR     "${PADDLE_DIR}/include/")
+set(PADDLE_LIB_DIR     "${PADDLE_DIR}/fluid/")
+
+INCLUDE_DIRECTORIES(${PADDLE_INC_DIR})
+
+if (EXISTS "${PADDLE_LIB_DIR}/core_avx.so")
+    set(paddle_lib_name  core_avx.so)
+else()
+    set(paddle_lib_name  core_noavx.so)
+    message(WANRING "Cannot find core_avx.so, using core_noavx.so instead.") 
+endif()
+
+find_library(PADDLE_CORE_LIB ${paddle_lib_name} PATHS ${PADDLE_LIB_DIR})
+if (NOT PADDLE_CORE_LIB)
+    message(FATAL "${paddle_lib_name} NOT found in ${PADDLE_LIB_DIR}")
+else()
+    message(STATUS "Found PADDLE_CORE_LIB: ${PADDLE_CORE_LIB}")
+endif()

--- a/backends/gpu_profiler/os_info.cc
+++ b/backends/gpu_profiler/os_info.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "os_info.h"
+
+#include "thread_data_registry.h"
+
+uint32_t GetProcessId() { return static_cast<uint32_t>(getpid()); }
+
+std::unordered_map<uint64_t, ThreadId> GetAllThreadIds() {
+  auto tids =
+      paddle::framework::ThreadDataRegistry<InternalThreadId>::GetInstance()
+          .GetAllThreadDataByValue();
+  std::unordered_map<uint64_t, ThreadId> res;
+  for (const auto &kv : tids) {
+    res[kv.first] = kv.second.GetTid();
+  }
+  return res;
+}
+
+void *AlignedMalloc(size_t size, size_t alignment) {
+  assert(alignment >= sizeof(void *) && (alignment & (alignment - 1)) == 0);
+  size = (size + alignment - 1) / alignment * alignment;
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+  void *aligned_mem = nullptr;
+  if (posix_memalign(&aligned_mem, alignment, size) != 0) {
+    aligned_mem = nullptr;
+  }
+  return aligned_mem;
+#elif defined(_WIN32)
+  return _aligned_malloc(size, alignment);
+#else
+  void *mem = malloc(size + alignment);
+  if (mem == nullptr) {
+    return nullptr;
+  }
+  size_t adjust = alignment - reinterpret_cast<uint64_t>(mem) % alignment;
+  void *aligned_mem = reinterpret_cast<char *>(mem) + adjust;
+  *(reinterpret_cast<void **>(aligned_mem) - 1) = mem;
+  assert(reinterpret_cast<uint64_t>(aligned_mem) % alignment == 0);
+  return aligned_mem;
+#endif
+}
+
+void AlignedFree(void *mem_ptr) {
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+  free(mem_ptr);
+#elif defined(_WIN32)
+  _aligned_free(mem_ptr);
+#else
+  if (mem_ptr) {
+    free(*(reinterpret_cast<void **>(mem_ptr) - 1));
+  }
+#endif
+}

--- a/backends/gpu_profiler/os_info.h
+++ b/backends/gpu_profiler/os_info.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <iostream>
+#include <unordered_map>
+
+// All kinds of Ids for OS thread
+struct ThreadId {
+  uint64_t std_tid = 0;    // std::hash<std::thread::id>
+  uint64_t sys_tid = 0;    // OS-specific, Linux: gettid
+  uint32_t cupti_tid = 0;  // thread_id used by Nvidia CUPTI
+};
+
+class InternalThreadId {
+ public:
+  InternalThreadId();
+
+  const ThreadId &GetTid() const { return id_; }
+
+ private:
+  ThreadId id_;
+};
+
+uint32_t GetProcessId();
+
+std::unordered_map<uint64_t, ThreadId> GetAllThreadIds();
+
+void *AlignedMalloc(size_t size, size_t alignment);
+
+void AlignedFree(void *mem_ptr);

--- a/backends/gpu_profiler/process_data.cc
+++ b/backends/gpu_profiler/process_data.cc
@@ -1,0 +1,445 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "process_data.h"
+
+#include <sys/syscall.h>
+
+#include <sstream>
+#include <thread>
+
+#include "os_info.h"
+#include "thread_data_registry.h"
+
+pid_t gettid() { return syscall(SYS_gettid); }
+
+#define CUPTI_CALL(call)                                                   \
+  do {                                                                     \
+    CUptiResult _status = call;                                            \
+    if (_status != CUPTI_SUCCESS) {                                        \
+      const char *errstr;                                                  \
+      cuptiGetResultString(_status, &errstr);                              \
+      std::cerr << "Function " << #call << " failed with error " << errstr \
+                << std::endl;                                              \
+      exit(-1);                                                            \
+    }                                                                      \
+  } while (0)
+
+inline std::string demangle(std::string name) { return name; }
+
+float CalculateEstOccupancy(uint32_t DeviceId,
+                            uint16_t RegistersPerThread,
+                            int32_t StaticSharedMemory,
+                            int32_t DynamicSharedMemory,
+                            int32_t BlockX,
+                            int32_t BlockY,
+                            int32_t BlockZ,
+                            float BlocksPerSm) {
+  float occupancy = 0.0;
+
+  cudaDeviceProp device_property;
+  cudaGetDeviceProperties(&device_property, DeviceId);
+
+  cudaOccFuncAttributes occFuncAttr;
+  occFuncAttr.maxThreadsPerBlock = INT_MAX;
+  occFuncAttr.numRegs = RegistersPerThread;
+  occFuncAttr.sharedSizeBytes = StaticSharedMemory;
+  occFuncAttr.partitionedGCConfig = PARTITIONED_GC_OFF;
+  occFuncAttr.shmemLimitConfig = FUNC_SHMEM_LIMIT_DEFAULT;
+  occFuncAttr.maxDynamicSharedSizeBytes = 0;
+  const cudaOccDeviceState occDeviceState = {};
+  int blockSize = BlockX * BlockY * BlockZ;
+  size_t dynamicSmemSize = DynamicSharedMemory;
+  cudaOccResult occ_result;
+  cudaOccDeviceProp prop(device_property);
+  cudaOccError status =
+      cudaOccMaxActiveBlocksPerMultiprocessor(&occ_result,
+                                              &prop,
+                                              &occFuncAttr,
+                                              &occDeviceState,
+                                              blockSize,
+                                              dynamicSmemSize);
+  if (status == CUDA_OCC_SUCCESS) {
+    if (occ_result.activeBlocksPerMultiprocessor < BlocksPerSm) {
+      BlocksPerSm = occ_result.activeBlocksPerMultiprocessor;
+    }
+    occupancy = BlocksPerSm * blockSize /
+                static_cast<float>(device_property.maxThreadsPerMultiProcessor);
+  } else {
+    std::cerr << "Failed to calculate estimated occupancy, status = " << status
+              << std::endl;
+  }
+  return occupancy;
+}
+
+void AddKernelRecord(const CUpti_ActivityKernel4 *kernel,
+                     uint64_t start_ns,
+                     C_Profiler collector) {
+  if (kernel->start < start_ns) {
+    return;
+  }
+  paddle::platform::DeviceTraceEvent event;
+  event.name = demangle(kernel->name);
+  event.type = paddle::platform::TracerEventType::Kernel;
+  event.start_ns = kernel->start;
+  event.end_ns = kernel->end;
+  event.device_id = kernel->deviceId;
+  event.context_id = kernel->contextId;
+  event.stream_id = kernel->streamId;
+  event.correlation_id = kernel->correlationId;
+  event.kernel_info.block_x = kernel->blockX;
+  event.kernel_info.block_y = kernel->blockY;
+  event.kernel_info.block_z = kernel->blockZ;
+  event.kernel_info.grid_x = kernel->gridX;
+  event.kernel_info.grid_y = kernel->gridY;
+  event.kernel_info.grid_z = kernel->gridZ;
+  event.kernel_info.dynamic_shared_memory = kernel->dynamicSharedMemory;
+  event.kernel_info.static_shared_memory = kernel->staticSharedMemory;
+  event.kernel_info.registers_per_thread = kernel->registersPerThread;
+  event.kernel_info.local_memory_per_thread = kernel->localMemoryPerThread;
+  event.kernel_info.local_memory_total = kernel->localMemoryTotal;
+  event.kernel_info.queued = kernel->queued;
+  event.kernel_info.submitted = kernel->submitted;
+  event.kernel_info.completed = kernel->completed;
+
+  float blocks_per_sm = 0.0;
+  float warps_per_sm = 0.0;
+  float occupancy = 0.0;
+
+  constexpr int threads_per_warp = 32;
+  cudaDeviceProp device_property;
+  cudaGetDeviceProperties(&device_property, kernel->deviceId);
+  blocks_per_sm =
+      static_cast<float>(event.kernel_info.grid_x * event.kernel_info.grid_y *
+                         event.kernel_info.grid_z) /
+      device_property.multiProcessorCount;
+  warps_per_sm = blocks_per_sm *
+                 (event.kernel_info.block_x * event.kernel_info.block_y *
+                  event.kernel_info.block_z) /
+                 threads_per_warp;
+  occupancy = CalculateEstOccupancy(kernel->deviceId,
+                                    event.kernel_info.registers_per_thread,
+                                    event.kernel_info.static_shared_memory,
+                                    event.kernel_info.dynamic_shared_memory,
+                                    event.kernel_info.block_x,
+                                    event.kernel_info.block_y,
+                                    event.kernel_info.block_z,
+                                    blocks_per_sm);
+  event.kernel_info.blocks_per_sm = blocks_per_sm;
+  event.kernel_info.warps_per_sm = warps_per_sm;
+  event.kernel_info.occupancy = occupancy;
+
+  profiler_add_device_trace_event(collector, &event);
+}
+
+const char *MemcpyKind(uint8_t kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOD:
+      return "MEMCPY_HtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOH:
+      return "MEMCPY_DtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOA:
+      return "MEMCPY_HtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOH:
+      return "MEMCPY_AtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOA:
+      return "MEMCPY_AtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_ATOD:
+      return "MEMCPY_AtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOA:
+      return "MEMCPY_DtoA";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_DTOD:
+      return "MEMCPY_DtoD";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_HTOH:
+      return "MEMCPY_HtoH";
+    case CUPTI_ACTIVITY_MEMCPY_KIND_PTOP:
+      return "MEMCPY_PtoP";
+    default:
+      return "MEMCPY";
+  }
+}
+
+const char *MemoryKind(uint16_t kind) {
+  switch (kind) {
+    case CUPTI_ACTIVITY_MEMORY_KIND_UNKNOWN:
+      return "Unknown";
+    case CUPTI_ACTIVITY_MEMORY_KIND_PAGEABLE:
+      return "Pageable";
+    case CUPTI_ACTIVITY_MEMORY_KIND_PINNED:
+      return "Pinned";
+    case CUPTI_ACTIVITY_MEMORY_KIND_DEVICE:
+      return "Device";
+    case CUPTI_ACTIVITY_MEMORY_KIND_ARRAY:
+      return "Array";
+    case CUPTI_ACTIVITY_MEMORY_KIND_MANAGED:
+      return "Managed";
+    case CUPTI_ACTIVITY_MEMORY_KIND_DEVICE_STATIC:
+      return "Device Static";
+    case CUPTI_ACTIVITY_MEMORY_KIND_MANAGED_STATIC:
+      return "Managed Static";
+    default:
+      return "Unknown";
+  }
+}
+
+void AddMemcpyRecord(const CUpti_ActivityMemcpy *memcpy,
+                     uint64_t start_ns,
+                     C_Profiler collector) {
+  if (memcpy->start < start_ns) {
+    return;
+  }
+  paddle::platform::DeviceTraceEvent event;
+  event.name = MemcpyKind(memcpy->copyKind);
+  event.type = paddle::platform::TracerEventType::Memcpy;
+  event.start_ns = memcpy->start;
+  event.end_ns = memcpy->end;
+  event.device_id = memcpy->deviceId;
+  event.context_id = memcpy->contextId;
+  event.stream_id = memcpy->streamId;
+  event.correlation_id = memcpy->correlationId;
+  event.memcpy_info.num_bytes = memcpy->bytes;
+  // snprintf(event.memcpy_info.copy_kind, kMemKindMaxLen, "%s",
+  //         MemcpyKind(memcpy->copyKind));
+  snprintf(event.memcpy_info.src_kind,
+           paddle::platform::kMemKindMaxLen,
+           "%s",
+           MemcpyKind(memcpy->srcKind));
+  snprintf(event.memcpy_info.dst_kind,
+           paddle::platform::kMemKindMaxLen,
+           "%s",
+           MemcpyKind(memcpy->dstKind));
+  // collector->AddDeviceEvent(std::move(event));
+  profiler_add_device_trace_event(collector, &event);
+}
+
+void AddMemcpy2Record(const CUpti_ActivityMemcpy2 *memcpy2,
+                      uint64_t start_ns,
+                      C_Profiler collector) {
+  if (memcpy2->start < start_ns) {
+    return;
+  }
+  paddle::platform::DeviceTraceEvent event;
+  event.name = MemcpyKind(memcpy2->copyKind);
+  event.type = paddle::platform::TracerEventType::Memcpy;
+  event.start_ns = memcpy2->start;
+  event.end_ns = memcpy2->end;
+  event.device_id = memcpy2->deviceId;
+  event.context_id = memcpy2->contextId;
+  event.stream_id = memcpy2->streamId;
+  event.correlation_id = memcpy2->correlationId;
+  event.memcpy_info.num_bytes = memcpy2->bytes;
+  // snprintf(event.memcpy_info.copy_kind, kMemKindMaxLen, "%s",
+  // MemcpyKind(memcpy2->copyKind));
+  snprintf(event.memcpy_info.src_kind,
+           paddle::platform::kMemKindMaxLen,
+           "%s",
+           MemcpyKind(memcpy2->srcKind));
+  snprintf(event.memcpy_info.dst_kind,
+           paddle::platform::kMemKindMaxLen,
+           "%s",
+           MemcpyKind(memcpy2->dstKind));
+  // collector->AddDeviceEvent(std::move(event));
+  profiler_add_device_trace_event(collector, &event);
+}
+
+void AddMemsetRecord(const CUpti_ActivityMemset *memset,
+                     uint64_t start_ns,
+                     C_Profiler collector) {
+  if (memset->start < start_ns) {
+    return;
+  }
+  paddle::platform::DeviceTraceEvent event;
+  event.name = "MEMSET";
+  event.type = paddle::platform::TracerEventType::Memset;
+  event.start_ns = memset->start;
+  event.end_ns = memset->end;
+  event.device_id = memset->deviceId;
+  event.context_id = memset->contextId;
+  event.stream_id = memset->streamId;
+  event.correlation_id = memset->correlationId;
+  event.memset_info.num_bytes = memset->bytes;
+  snprintf(event.memset_info.memory_kind,
+           paddle::platform::kMemKindMaxLen,
+           "%s",
+           MemoryKind(memset->memoryKind));
+  event.memset_info.value = memset->value;
+  // collector->AddDeviceEvent(std::move(event));
+  profiler_add_device_trace_event(collector, &event);
+}
+
+class CuptiRuntimeCbidStr {
+ public:
+  static const CuptiRuntimeCbidStr &GetInstance() {
+    static CuptiRuntimeCbidStr inst;
+    return inst;
+  }
+
+  std::string RuntimeKind(CUpti_CallbackId cbid) const {
+    auto iter = cbid_str_.find(cbid);
+    if (iter == cbid_str_.end()) {
+      return "Runtime API " + std::to_string(cbid);
+    }
+    return iter->second;
+  }
+
+ private:
+  CuptiRuntimeCbidStr();
+
+  std::unordered_map<CUpti_CallbackId, std::string> cbid_str_;
+};
+
+CuptiRuntimeCbidStr::CuptiRuntimeCbidStr() {
+#define REGISTER_RUNTIME_CBID_STR(cbid) \
+  cbid_str_[CUPTI_RUNTIME_TRACE_CBID_##cbid] = #cbid
+  REGISTER_RUNTIME_CBID_STR(cudaBindTexture_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaConfigureCall_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaDeviceGetAttribute_v5000);
+  REGISTER_RUNTIME_CBID_STR(cudaDeviceGetStreamPriorityRange_v5050);
+  REGISTER_RUNTIME_CBID_STR(cudaDeviceSynchronize_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaDriverGetVersion_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaEventCreateWithFlags_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaEventDestroy_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaEventDestroy_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaEventQuery_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaEventRecord_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaFreeHost_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaFree_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaFuncGetAttributes_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaGetDeviceCount_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaGetDeviceProperties_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaGetDevice_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaGetErrorString_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaGetLastError_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaHostAlloc_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaHostGetDevicePointer_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaLaunchKernel_v7000);
+  REGISTER_RUNTIME_CBID_STR(cudaMallocHost_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaMalloc_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaMemcpyAsync_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaMemcpy_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaMemsetAsync_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaMemset_v3020);
+  REGISTER_RUNTIME_CBID_STR(
+      cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_v7000);
+  REGISTER_RUNTIME_CBID_STR(cudaPeekAtLastError_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaRuntimeGetVersion_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaSetDevice_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamCreate_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamCreateWithFlags_v5000);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamCreateWithPriority_v5050);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamDestroy_v5050);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamSynchronize_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaStreamWaitEvent_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaUnbindTexture_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaSetupArgument_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaLaunch_v3020);
+  REGISTER_RUNTIME_CBID_STR(cudaDeviceGetPCIBusId_v4010);
+#if CUDA_VERSION >= 9000
+  REGISTER_RUNTIME_CBID_STR(cudaLaunchCooperativeKernel_v9000);
+  REGISTER_RUNTIME_CBID_STR(cudaLaunchCooperativeKernelMultiDevice_v9000);
+#endif
+#undef REGISTER_RUNTIME_CBID_STR
+}
+
+void AddApiRecord(const CUpti_ActivityAPI *api,
+                  uint64_t start_ns,
+                  const std::unordered_map<uint32_t, uint64_t> tid_mapping,
+                  C_Profiler collector) {
+  if (api->start < start_ns) {
+    return;
+  }
+  paddle::platform::RuntimeTraceEvent event;
+  event.name = CuptiRuntimeCbidStr::GetInstance().RuntimeKind(api->cbid);
+  event.start_ns = api->start;
+  event.end_ns = api->end;
+  event.process_id = GetProcessId();
+  uint64_t tid = 0;
+  auto iter = tid_mapping.find(api->threadId);
+  if (iter == tid_mapping.end()) {
+    tid = gettid();
+  } else {
+    tid = iter->second;
+  }
+#ifdef PADDLE_WITH_HIP
+  event.thread_id = api->threadId;
+#else
+  event.thread_id = tid;
+#endif
+  event.correlation_id = api->correlationId;
+  event.callback_id = api->cbid;
+  // collector->AddRuntimeEvent(std::move(event));
+  profiler_add_runtime_trace_event(collector, &event);
+}
+
+void ProcessCuptiActivityRecord(
+    const CUpti_Activity *record,
+    uint64_t start_ns,
+    const std::unordered_map<uint32_t, uint64_t> tid_mapping,
+    C_Profiler collector) {
+  switch (record->kind) {
+    case CUPTI_ACTIVITY_KIND_KERNEL:
+    case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL:
+      AddKernelRecord(reinterpret_cast<const CUpti_ActivityKernel4 *>(record),
+                      start_ns,
+                      collector);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMCPY:
+      AddMemcpyRecord(reinterpret_cast<const CUpti_ActivityMemcpy *>(record),
+                      start_ns,
+                      collector);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMCPY2:
+      AddMemcpy2Record(reinterpret_cast<const CUpti_ActivityMemcpy2 *>(record),
+                       start_ns,
+                       collector);
+      break;
+    case CUPTI_ACTIVITY_KIND_MEMSET:
+      AddMemsetRecord(reinterpret_cast<const CUpti_ActivityMemset *>(record),
+                      start_ns,
+                      collector);
+      break;
+    case CUPTI_ACTIVITY_KIND_DRIVER:
+    case CUPTI_ACTIVITY_KIND_RUNTIME:
+      AddApiRecord(reinterpret_cast<const CUpti_ActivityAPI *>(record),
+                   start_ns,
+                   tid_mapping,
+                   collector);
+      break;
+    default:
+      break;
+  }
+}
+
+void Tracer::AllocateBuffer(uint8_t **buffer, size_t *size) {
+  constexpr size_t kBufSize = 1 << 23;  // 8 MB
+  constexpr size_t kBufAlign = 8;       // 8 B
+  *buffer = reinterpret_cast<uint8_t *>(AlignedMalloc(kBufSize, kBufAlign));
+  *size = kBufSize;
+}
+
+void Tracer::ProduceBuffer(uint8_t *buffer, size_t valid_size) {
+  std::lock_guard<std::mutex> guard(activity_buffer_lock_);
+  activity_buffers_.emplace_back(buffer, valid_size);
+}
+
+std::vector<ActivityBuffer> Tracer::ConsumeBuffers() {
+  std::vector<ActivityBuffer> buffers;
+  {
+    std::lock_guard<std::mutex> guard(activity_buffer_lock_);
+    buffers.swap(activity_buffers_);
+  }
+  return buffers;
+}
+
+void Tracer::ReleaseBuffer(uint8_t *buffer) { AlignedFree(buffer); }

--- a/backends/gpu_profiler/process_data.h
+++ b/backends/gpu_profiler/process_data.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+
+#include "cuda.h"
+#include "cuda_occupancy.h"
+#include "cupti.h"
+#include "os_info.h"
+#include "paddle/phi/backends/custom/trace_event.h"
+#include "paddle/phi/backends/device_ext.h"
+
+struct ActivityBuffer {
+  ActivityBuffer(uint8_t* addr, size_t size) : addr(addr), valid_size(size) {}
+  uint8_t* addr;
+  size_t valid_size;
+};
+
+void ProcessCuptiActivityRecord(
+    const CUpti_Activity* record,
+    uint64_t start_ns,
+    const std::unordered_map<uint32_t, uint64_t> tid_mapping,
+    C_Profiler collector);
+
+class Tracer {
+ public:
+  static Tracer& Instance() {
+    static Tracer instance;
+    return instance;
+  }
+
+  void AllocateBuffer(uint8_t** buffer, size_t* size);
+  void ProduceBuffer(uint8_t* buffer, size_t valid_size);
+  std::vector<ActivityBuffer> ConsumeBuffers();
+  void ReleaseBuffer(uint8_t* buffer);
+
+ private:
+  Tracer(){};
+
+  std::mutex activity_buffer_lock_;
+  std::vector<ActivityBuffer> activity_buffers_;
+};
+
+int ProcessCuptiActivity(C_Profiler prof, uint64_t tracing_start_ns_);

--- a/backends/gpu_profiler/runtime.cc
+++ b/backends/gpu_profiler/runtime.cc
@@ -1,0 +1,345 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include "cuda.h"
+#include "cupti.h"
+#include "paddle/phi/backends/custom/trace_event.h"
+#include "paddle/phi/backends/device_ext.h"
+#include "process_data.h"
+
+#define CUDA_CHECK(x) x
+#define CUPTI_CALL(call)                                                   \
+  do {                                                                     \
+    CUptiResult _status = call;                                            \
+    if (_status != CUPTI_SUCCESS) {                                        \
+      const char *errstr;                                                  \
+      cuptiGetResultString(_status, &errstr);                              \
+      std::cerr << "Function " << #call << " failed with error " << errstr \
+                << std::endl;                                              \
+      exit(-1);                                                            \
+    }                                                                      \
+  } while (0)
+
+#define INTERFACE_UNIMPLEMENT                      \
+  throw std::runtime_error(std::string(__func__) + \
+                           " is not implemented on gpu_profiler.")
+
+int device_count() {
+  int count = 0;
+  CUDA_CHECK(cudaGetDeviceCount(&count));
+  return count;
+}
+
+int get_device_count() {
+  static int count = device_count();
+  return count;
+}
+
+C_Status SetDevice(const C_Device device) {
+  CUDA_CHECK(cudaSetDevice(device->id));
+  return C_SUCCESS;
+}
+
+C_Status GetDevice(const C_Device device) {
+  CUDA_CHECK(cudaGetDevice(&(device->id)));
+  return C_SUCCESS;
+}
+
+C_Status GetDevicesCount(size_t *count) {
+  *count = get_device_count();
+  return C_SUCCESS;
+}
+
+C_Status GetDevicesList(size_t *devices) {
+  for (auto i = 0; i < get_device_count(); ++i) {
+    devices[i] = i;
+  }
+  return C_SUCCESS;
+}
+
+C_Status MemCpy(const C_Device device,
+                void *dst,
+                const void *src,
+                size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  CUDA_CHECK(cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice));
+  return C_SUCCESS;
+}
+
+C_Status AsyncMemCpy(const C_Device device,
+                     C_Stream stream,
+                     void *dst,
+                     const void *src,
+                     size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  CUDA_CHECK(cudaMemcpyAsync(dst,
+                             src,
+                             size,
+                             cudaMemcpyHostToDevice,
+                             reinterpret_cast<cudaStream_t>(stream)));
+  return C_SUCCESS;
+}
+
+C_Status MemCpyP2P(const C_Device dst_device,
+                   const C_Device src_device,
+                   void *dst,
+                   const void *src,
+                   size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status AsyncMemCpyP2P(const C_Device dst_device,
+                        const C_Device src_device,
+                        C_Stream stream,
+                        void *dst,
+                        const void *src,
+                        size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status Allocate(const C_Device device, void **ptr, size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  return C_FAILED;
+}
+
+C_Status Deallocate(const C_Device device, void *ptr, size_t size) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status CreateStream(const C_Device device, C_Stream *stream) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status DestroyStream(const C_Device device, C_Stream stream) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status CreateEvent(const C_Device device, C_Event *event) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status RecordEvent(const C_Device device, C_Stream stream, C_Event event) {
+  INTERFACE_UNIMPLEMENT;
+
+  return C_SUCCESS;
+}
+
+C_Status DestroyEvent(const C_Device device, C_Event event) {
+  INTERFACE_UNIMPLEMENT;
+
+  return C_SUCCESS;
+}
+
+C_Status SyncStream(const C_Device device, C_Stream stream) {
+  INTERFACE_UNIMPLEMENT;
+
+  return C_SUCCESS;
+}
+
+C_Status SyncEvent(const C_Device device, C_Event event) {
+  INTERFACE_UNIMPLEMENT;
+
+  return C_SUCCESS;
+}
+
+C_Status StreamWaitEvent(const C_Device device,
+                         C_Stream stream,
+                         C_Event event) {
+  INTERFACE_UNIMPLEMENT;
+
+  return C_SUCCESS;
+}
+
+C_Status VisibleDevices(size_t *devices) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status DeviceMemStats(const C_Device device,
+                        size_t *total_memory,
+                        size_t *free_memory) {
+  INTERFACE_UNIMPLEMENT;
+  return C_SUCCESS;
+}
+
+C_Status DeviceMinChunkSize(const C_Device device, size_t *size) {
+  *size = 4096;
+  return C_SUCCESS;
+}
+
+C_Status SyncDevice(const C_Device device) {
+  CUDA_CHECK(cudaDeviceSynchronize());
+  return C_SUCCESS;
+}
+
+///////// CUPTI
+
+void CUPTIAPI BufferRequestedCallback(uint8_t **buffer,
+                                      size_t *size,
+                                      size_t *max_num_records) {
+  Tracer::Instance().AllocateBuffer(buffer, size);
+  *max_num_records = 0;
+}
+
+void CUPTIAPI BufferCompletedCallback(CUcontext ctx,
+                                      uint32_t stream_id,
+                                      uint8_t *buffer,
+                                      size_t size,
+                                      size_t valid_size) {
+  Tracer::Instance().ProduceBuffer(buffer, valid_size);
+  size_t dropped = 0;
+  CUPTI_CALL(cuptiActivityGetNumDroppedRecords(ctx, stream_id, &dropped));
+  if (dropped != 0) {
+    std::cerr << "Stream " << stream_id << " Dropped " << dropped
+              << " activity records";
+  }
+}
+
+std::unordered_map<uint32_t, uint64_t> CreateThreadIdMapping() {
+  std::unordered_map<uint32_t, uint64_t> mapping;
+  std::unordered_map<uint64_t, ThreadId> ids = GetAllThreadIds();
+  for (const auto &id : ids) {
+    mapping[id.second.cupti_tid] = id.second.sys_tid;
+  }
+  return mapping;
+}
+
+int ProcessCuptiActivity(C_Profiler prof, uint64_t tracing_start_ns_) {
+  int record_cnt = 0;
+  CUPTI_CALL(cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+  auto mapping = CreateThreadIdMapping();
+  std::vector<ActivityBuffer> buffers = Tracer::Instance().ConsumeBuffers();
+  for (auto &buffer : buffers) {
+    if (buffer.addr == nullptr || buffer.valid_size == 0) {
+      continue;
+    }
+
+    CUpti_Activity *record = nullptr;
+    while (true) {
+      CUptiResult status =
+          cuptiActivityGetNextRecord(buffer.addr, buffer.valid_size, &record);
+      if (status == CUPTI_SUCCESS) {
+        ProcessCuptiActivityRecord(record, tracing_start_ns_, mapping, prof);
+        ++record_cnt;
+      } else if (status == CUPTI_ERROR_MAX_LIMIT_REACHED) {
+        break;
+      } else {
+        CUPTI_CALL(status);
+      }
+    }
+
+    Tracer::Instance().ReleaseBuffer(buffer.addr);
+  }
+  return record_cnt;
+}
+
+C_Status ProfilerInitialize(C_Profiler prof, void **user_data) {
+  return C_SUCCESS;
+}
+
+C_Status ProfilerFinalize(C_Profiler prof, void *user_data) {
+  return C_SUCCESS;
+}
+
+C_Status ProfilerPrepare(C_Profiler prof, void *user_data) {
+  CUPTI_CALL(cuptiActivityRegisterCallbacks(BufferRequestedCallback,
+                                            BufferCompletedCallback));
+
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY));
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER));
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME));
+  CUPTI_CALL(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET));
+  std::cout << "enable cupti activity\n";
+  return C_SUCCESS;
+}
+
+C_Status ProfilerStart(C_Profiler prof, void *user_data) {
+  Tracer::Instance().ConsumeBuffers();
+  return C_SUCCESS;
+}
+
+C_Status ProfilerStop(C_Profiler prof, void *user_data) {
+  CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY));
+  CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+  CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER));
+  CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME));
+  CUPTI_CALL(cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMSET));
+  std::cout << "disable cupti activity\n";
+  return C_SUCCESS;
+}
+
+C_Status ProfilerCollectData(C_Profiler prof,
+                             uint64_t tracing_start_ns_,
+                             void *user_data) {
+  ProcessCuptiActivity(prof, tracing_start_ns_);
+  return C_SUCCESS;
+}
+
+void InitPlugin(CustomRuntimeParams *params) {
+  PADDLE_CUSTOM_RUNTIME_CHECK_VERSION(params);
+  params->device_type = "gpu_profiler";
+  params->sub_device_type = "v0.1";
+
+  memset(reinterpret_cast<void *>(params->interface),
+         0,
+         sizeof(C_DeviceInterface));
+
+  // params->interface->initialize = Init;
+  // params->interface->finalize = Finalize;
+  // params->interface->init_device = InitDevice;
+  // params->interface->deinit_device = DestroyDevice;
+
+  params->interface->set_device = SetDevice;
+  params->interface->get_device = GetDevice;
+  params->interface->create_stream = CreateStream;
+  params->interface->destroy_stream = DestroyStream;
+  params->interface->create_event = CreateEvent;
+  params->interface->destroy_event = DestroyEvent;
+  params->interface->record_event = RecordEvent;
+  params->interface->synchronize_stream = SyncStream;
+  params->interface->synchronize_event = SyncEvent;
+  params->interface->stream_wait_event = StreamWaitEvent;
+  params->interface->memory_copy_h2d = MemCpy;
+  params->interface->memory_copy_d2d = MemCpy;
+  params->interface->memory_copy_d2h = MemCpy;
+  params->interface->async_memory_copy_h2d = AsyncMemCpy;
+  params->interface->async_memory_copy_d2d = AsyncMemCpy;
+  params->interface->async_memory_copy_d2h = AsyncMemCpy;
+  params->interface->device_memory_allocate = Allocate;
+  params->interface->device_memory_deallocate = Deallocate;
+  params->interface->device_memory_stats = DeviceMemStats;
+  params->interface->device_min_chunk_size = DeviceMinChunkSize;
+
+  params->interface->get_device_count = GetDevicesCount;
+  params->interface->get_device_list = GetDevicesList;
+  params->interface->synchronize_device = SyncDevice;
+  params->interface->profiler_collect_trace_data = ProfilerCollectData;
+  params->interface->profiler_initialize = ProfilerInitialize;
+  params->interface->profiler_finalize = ProfilerFinalize;
+  params->interface->profiler_start_tracing = ProfilerStart;
+  params->interface->profiler_stop_tracing = ProfilerStop;
+  params->interface->profiler_prepare_tracing = ProfilerPrepare;
+}

--- a/backends/gpu_profiler/setup.py.in
+++ b/backends/gpu_profiler/setup.py.in
@@ -1,0 +1,40 @@
+from setuptools import setup, Distribution
+
+packages = []
+package_data = {}
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
+
+setup(
+    name = '@CMAKE_PROJECT_NAME@',
+    version='@PLUGIN_VERSION@',
+    description='Paddle GPU Profiler plugin',
+    long_description='',
+    long_description_content_type="text/markdown",
+    author_email="Paddle-better@baidu.com",
+    maintainer="PaddlePaddle",
+    maintainer_email="Paddle-better@baidu.com",
+    project_urls={},
+    license='Apache Software License',
+    packages= [
+        'paddle-plugins',
+    ],
+    include_package_data=True,
+    package_data = {
+        '': ['*.so', '*.h', '*.py', '*.hpp'],
+    },
+    package_dir = {
+        '': 'python',
+    },
+    zip_safe=False,
+    distclass=BinaryDistribution,
+    entry_points={
+        'console_scripts': [
+        ]
+    },
+    classifiers=[
+    ],
+    keywords='Paddle GPU Profiler plugin',
+)

--- a/backends/gpu_profiler/thread_data_registry.h
+++ b/backends/gpu_profiler/thread_data_registry.h
@@ -1,0 +1,177 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+
+namespace paddle {
+namespace framework {
+
+template <typename T>
+class ThreadDataRegistry {
+ public:
+  // Singleton
+  static ThreadDataRegistry& GetInstance() {
+    static ThreadDataRegistry instance;
+    return instance;
+  }
+
+  T* GetMutableCurrentThreadData() { return &CurrentThreadData(); }
+
+  const T& GetCurrentThreadData() { return CurrentThreadData(); }
+
+  template <typename Alias = T,
+            typename = std::enable_if_t<std::is_copy_assignable<Alias>::value>>
+  void SetCurrentThreadData(const T& val) {
+    CurrentThreadData() = val;
+  }
+
+  // Returns current snapshot of all threads. Make sure there is no thread
+  // create/destory when using it.
+  template <
+      typename Alias = T,
+      typename = std::enable_if_t<std::is_copy_constructible<Alias>::value>>
+  std::unordered_map<uint64_t, T> GetAllThreadDataByValue() {
+    return impl_->GetAllThreadDataByValue();
+  }
+
+  // Returns current snapshot of all threads. Make sure there is no thread
+  // create/destory when using it.
+  std::unordered_map<uint64_t, std::reference_wrapper<T>>
+  GetAllThreadDataByRef() {
+    return impl_->GetAllThreadDataByRef();
+  }
+
+ private:
+// types
+// Lock types
+#if defined(__clang__) || defined(__GNUC__)  // CLANG or GCC
+#ifndef __APPLE__
+#if __cplusplus >= 201703L
+  using LockType = std::shared_mutex;
+  using SharedLockGuardType = std::shared_lock<std::shared_mutex>;
+#elif __cplusplus >= 201402L
+  using LockType = std::shared_timed_mutex;
+  using SharedLockGuardType = std::shared_lock<std::shared_timed_mutex>;
+#else
+  using LockType = std::mutex;
+  using SharedLockGuardType = std::lock_guard<std::mutex>;
+#endif
+// Special case : mac. https://github.com/facebook/react-native/issues/31250
+#else
+  using LockType = std::mutex;
+  using SharedLockGuardType = std::lock_guard<std::mutex>;
+#endif
+#elif defined(_MSC_VER)  // MSVC
+#if _MSVC_LANG >= 201703L
+  using LockType = std::shared_mutex;
+  using SharedLockGuardType = std::shared_lock<std::shared_mutex>;
+#elif _MSVC_LANG >= 201402L
+  using LockType = std::shared_timed_mutex;
+  using SharedLockGuardType = std::shared_lock<std::shared_timed_mutex>;
+#else
+  using LockType = std::mutex;
+  using SharedLockGuardType = std::lock_guard<std::mutex>;
+#endif
+#else  // other compilers
+  using LockType = std::mutex;
+  using SharedLockGuardType = std::lock_guard<std::mutex>;
+#endif
+
+  class ThreadDataHolder;
+  class ThreadDataRegistryImpl {
+   public:
+    void RegisterData(uint64_t tid, ThreadDataHolder* tls_obj) {
+      std::lock_guard<LockType> guard(lock_);
+      tid_map_[tid] = tls_obj;
+    }
+
+    void UnregisterData(uint64_t tid) {
+      std::lock_guard<LockType> guard(lock_);
+      tid_map_.erase(tid);
+    }
+
+    template <
+        typename Alias = T,
+        typename = std::enable_if_t<std::is_copy_constructible<Alias>::value>>
+    std::unordered_map<uint64_t, T> GetAllThreadDataByValue() {
+      std::unordered_map<uint64_t, T> data_copy;
+      SharedLockGuardType guard(lock_);
+      data_copy.reserve(tid_map_.size());
+      for (auto& kv : tid_map_) {
+        data_copy.emplace(kv.first, kv.second->GetData());
+      }
+      return data_copy;
+    }
+
+    std::unordered_map<uint64_t, std::reference_wrapper<T>>
+    GetAllThreadDataByRef() {
+      std::unordered_map<uint64_t, std::reference_wrapper<T>> data_ref;
+      SharedLockGuardType guard(lock_);
+      data_ref.reserve(tid_map_.size());
+      for (auto& kv : tid_map_) {
+        data_ref.emplace(kv.first, std::ref(kv.second->GetData()));
+      }
+      return data_ref;
+    }
+
+   private:
+    LockType lock_;
+    std::unordered_map<uint64_t, ThreadDataHolder*> tid_map_;  // not owned
+  };
+
+  class ThreadDataHolder {
+   public:
+    explicit ThreadDataHolder(
+        std::shared_ptr<ThreadDataRegistryImpl> registry) {
+      registry_ = std::move(registry);
+      tid_ = std::hash<std::thread::id>()(std::this_thread::get_id());
+      registry_->RegisterData(tid_, this);
+    }
+
+    ~ThreadDataHolder() { registry_->UnregisterData(tid_); }
+
+    T& GetData() { return data_; }
+
+   private:
+    std::shared_ptr<ThreadDataRegistryImpl> registry_;
+    uint64_t tid_;
+    T data_;
+  };
+
+  // methods
+  ThreadDataRegistry() { impl_ = std::make_shared<ThreadDataRegistryImpl>(); }
+
+  ThreadDataRegistry(const ThreadDataRegistry&) = delete;
+
+  ThreadDataRegistry& operator=(const ThreadDataRegistry&) = delete;
+
+  T& CurrentThreadData() {
+    static thread_local ThreadDataHolder thread_data(impl_);
+    return thread_data.GetData();
+  }
+
+  // data
+  std::shared_ptr<ThreadDataRegistryImpl> impl_;
+};
+
+}  // namespace framework
+}  // namespace paddle


### PR DESCRIPTION
add gpu profiler plugin

##### 1. 使用 GPU profiler
```python
import paddle
import paddle.profiler as profiler

paddle.set_device('gpu')

x = paddle.to_tensor([1, 2, 3])

p = profiler.Profiler(targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.GPU])
p.start()
for iter in range(10):
    x = x + 1
    p.step()
p.stop()
p.summary()
```

```
-------------------Device Summary-------------------
------------------------------  --------------------  
Device                          Utilization (%)       
------------------------------  --------------------  
CPU(Process)                    23.52                 
CPU(System)                     99.98                 
GPU0                            0.00                  
------------------------------  --------------------  
Note:
CPU(Process) Utilization = Current process CPU time over all cpu cores / elapsed time, so max utilization can be reached 100% * number of cpu cores.
CPU(System) Utilization = All processes CPU time over all cpu cores(busy time) / (busy time + idle time).
GPU Utilization = Current process GPU time / elapsed time.
----------------------------------------------------


---------------------------------------------Overview Summary---------------------------------------------
Time unit: ms
-------------------------  -------------------------  -------------------------  -------------------------  
Event Type                 Calls                      CPU Time                   Ratio (%)                  
-------------------------  -------------------------  -------------------------  -------------------------  
ProfileStep                11                         4712.81                    100.00                     
  UserDefined              10                         4690.87                    99.53                      
  Operator                 10                         4690.70                    99.53                      
  OperatorInner            20                         4664.92                    98.98                      
  CudaRuntime              47                         4664.84                    98.98                      
-------------------------  -------------------------  -------------------------  -------------------------  
                           Calls                      GPU Time                   Ratio (%)                  
-------------------------  -------------------------  -------------------------  -------------------------  
  Kernel                   10                         0.02                       0.00                       
-------------------------  -------------------------  -------------------------  -------------------------  
Note:
In this table, We sum up all collected events in terms of event type.
The time of events collected on host are presented as CPU Time, and as GPU Time if on device.
Events with different types may overlap or inclusion, e.g. Operator includes OperatorInner, so the sum of ratios is not 100%.
The time of events in the same type with overlap will not calculate twice, and all time is summed after merged.
Example:
Thread 1:
  Operator: |___________|     |__________|
Thread 2:
  Operator:   |____________|     |___|
After merged:
  Result:   |______________|  |__________|

----------------------------------------------------------------------------------------------------------


-----------------------------------------------------------------Operator Summary-----------------------------------------------------------------
Time unit: ms
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  
Name                                                  Calls   CPU Total / Avg / Max / Min / Ratio(%)      GPU Total / Avg / Max / Min / Ratio(%)    
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  
------------------------------------------------------------Thread: All threads merged------------------------------------------------------------
scale dygraph                                         10      4690.70 / 469.07 / 4686.39 / 0.02 / 100.00  0.02 / 0.00 / 0.00 / 0.00 / 100.00        
  scale infer_meta                                    10      0.01 / 0.00 / 0.01 / 0.00 / 0.00            0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  scale compute                                       10      4664.91 / 466.49 / 4660.68 / 0.02 / 99.45   0.02 / 0.00 / 0.00 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  10      - / - / - / - / -                           0.02 / 0.00 / 0.00 / 0.00 / 100.00        
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  


---------------------------------------------------------------Kernel Summary---------------------------------------------------------------
Time unit: ms
------------------------------------------------------------------------------------------  ------  ----------------------------------------  
Name                                                                                        Calls   GPU Total / Avg / Max / Min / Ratio(%)    
------------------------------------------------------------------------------------------  ------  ----------------------------------------  
void phi::funcs::VectorizedElementwiseKernel<long, phi::ScaleFunctor<long>, 1, 1, 2>        10      0.02 / 0.00 / 0.00 / 0.00 / 100.00        
------------------------------------------------------------------------------------------  ------  ----------------------------------------      
```

![image](https://user-images.githubusercontent.com/25691046/184608868-ae60d248-bf37-45f7-bd9e-9a1c925f8983.png)



##### 2. 使用 custom profiler
```python
import paddle
import paddle.profiler as profiler

paddle.set_device('gpu')

x = paddle.to_tensor([1, 2, 3])

p = profiler.Profiler(targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.CUSTOM_DEVICE])
# p = profiler.Profiler(targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.CUSTOM_DEVICE], custom_device_types=['gpu_profiler'])
p.start()
for iter in range(10):
    x = x + 1
    p.step()
p.stop()
p.summary()

```

```
-------------------Device Summary-------------------
------------------------------  --------------------  
Device                          Utilization (%)       
------------------------------  --------------------  
CPU(Process)                    33.81                 
CPU(System)                     99.99                 
GPU0                            0.00                  
------------------------------  --------------------  
Note:
CPU(Process) Utilization = Current process CPU time over all cpu cores / elapsed time, so max utilization can be reached 100% * number of cpu cores.
CPU(System) Utilization = All processes CPU time over all cpu cores(busy time) / (busy time + idle time).
GPU Utilization = Current process GPU time / elapsed time.
----------------------------------------------------


---------------------------------------------Overview Summary---------------------------------------------
Time unit: ms
-------------------------  -------------------------  -------------------------  -------------------------  
Event Type                 Calls                      CPU Time                   Ratio (%)                  
-------------------------  -------------------------  -------------------------  -------------------------  
ProfileStep                11                         3026.29                    100.00                     
  UserDefined              10                         3012.26                    99.54                      
  Operator                 10                         3012.10                    99.53                      
  OperatorInner            20                         2987.46                    98.72                      
  CudaRuntime              47                         2987.33                    98.71                      
-------------------------  -------------------------  -------------------------  -------------------------  
                           Calls                      GPU Time                   Ratio (%)                  
-------------------------  -------------------------  -------------------------  -------------------------  
  Kernel                   10                         0.02                       0.00                       
-------------------------  -------------------------  -------------------------  -------------------------  
Note:
In this table, We sum up all collected events in terms of event type.
The time of events collected on host are presented as CPU Time, and as GPU Time if on device.
Events with different types may overlap or inclusion, e.g. Operator includes OperatorInner, so the sum of ratios is not 100%.
The time of events in the same type with overlap will not calculate twice, and all time is summed after merged.
Example:
Thread 1:
  Operator: |___________|     |__________|
Thread 2:
  Operator:   |____________|     |___|
After merged:
  Result:   |______________|  |__________|

----------------------------------------------------------------------------------------------------------


-----------------------------------------------------------------Operator Summary-----------------------------------------------------------------
Time unit: ms
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  
Name                                                  Calls   CPU Total / Avg / Max / Min / Ratio(%)      GPU Total / Avg / Max / Min / Ratio(%)    
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  
------------------------------------------------------------Thread: All threads merged------------------------------------------------------------
scale dygraph                                         10      3012.10 / 301.21 / 3011.89 / 0.01 / 100.00  0.02 / 0.00 / 0.00 / 0.00 / 100.00        
  scale infer_meta                                    10      0.02 / 0.00 / 0.01 / 0.00 / 0.00            0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  scale compute                                       10      2987.44 / 298.74 / 2987.29 / 0.01 / 99.18   0.02 / 0.00 / 0.00 / 0.00 / 100.00        
    _ZN3phi5funcs27VectorizedElementwiseKernelIlN...  10      - / - / - / - / -                           0.02 / 0.00 / 0.00 / 0.00 / 100.00        
----------------------------------------------------  ------  ------------------------------------------  ----------------------------------------  


---------------------------------------------------------------Kernel Summary---------------------------------------------------------------
Time unit: ms
------------------------------------------------------------------------------------------  ------  ----------------------------------------  
Name                                                                                        Calls   GPU Total / Avg / Max / Min / Ratio(%)    
------------------------------------------------------------------------------------------  ------  ----------------------------------------  
_ZN3phi5funcs27VectorizedElementwiseKernelIlNS_12ScaleFunctorIlEELi1ELi1ELi2EEEvNS_5Arr...  10      0.02 / 0.00 / 0.00 / 0.00 / 100.00        
------------------------------------------------------------------------------------------  ------  ---------------------------------------- 
```

![image](https://user-images.githubusercontent.com/25691046/184608338-a03700ed-0ba8-40bc-9eb9-dabe047a207a.png)
