### PR TITLE
fix ci bugs

### DIFF
--- a/backends/npu/kernels/arg_min_max_kernel.cc
+++ b/backends/npu/kernels/arg_min_max_kernel.cc
@@ -20,7 +20,7 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void ArgMinKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  int64_t axis,
+                  const phi::Scalar& axis,
                   bool keepdims,
                   bool flatten,
                   int dtype,
@@ -30,7 +30,7 @@ void ArgMinKernel(const Context& dev_ctx,
   NpuOpRunner runner;
   runner.SetType("ArgMin")
       .AddInput(x)
-      .AddInput(dev_ctx, std::vector<int64_t>{axis})
+      .AddInput(dev_ctx, std::vector<int64_t>({axis.to<int64_t>()}))
       .AddOutput(*out)
       .AddAttr("dtype", dtype);
 
@@ -41,7 +41,7 @@ void ArgMinKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void ArgMaxKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  int64_t axis,
+                  const phi::Scalar& axis,
                   bool keepdims,
                   bool flatten,
                   int dtype,
@@ -58,7 +58,7 @@ void ArgMaxKernel(const Context& dev_ctx,
   runner.SetType("ArgMaxD")
       .AddInput(transformed_x)
       .AddOutput(*out)
-      .AddAttr("dimension", axis)
+      .AddAttr("dimension", axis.to<int64_t>())
       .AddAttrDataType("dtype", dtype)
       .Run(stream);
 }

--- a/backends/npu/kernels/elementwise_mod_kernel.cc
+++ b/backends/npu/kernels/elementwise_mod_kernel.cc
@@ -61,7 +61,7 @@ void ModuloKernel(const Context& dev_ctx,
 
 }  // namespace custom_kernel
 
-PD_REGISTER_PLUGIN_KERNEL(modulo,
+PD_REGISTER_PLUGIN_KERNEL(remainder,
                           ascend,
                           ALL_LAYOUT,
                           custom_kernel::ModuloKernel,
@@ -70,7 +70,7 @@ PD_REGISTER_PLUGIN_KERNEL(modulo,
                           float,
                           double,
                           phi::dtype::float16) {}
-PD_REGISTER_PLUGIN_KERNEL(modulo_raw,
+PD_REGISTER_PLUGIN_KERNEL(remainder_raw,
                           ascend,
                           ALL_LAYOUT,
                           custom_kernel::ModuloRawKernel,

--- a/backends/npu/kernels/reduce_mean_kernel.cc
+++ b/backends/npu/kernels/reduce_mean_kernel.cc
@@ -20,11 +20,11 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void MeanRawKernel(const Context& dev_ctx,
                    const phi::DenseTensor& x,
-                   const std::vector<int64_t>& axes,
+                   const phi::IntArray& axes,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   auto input_dims_vec = phi::vectorize(x.dims());
@@ -43,7 +43,7 @@ void MeanRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void MeanKernel(const Context& dev_ctx,
                 const phi::DenseTensor& x,
-                const std::vector<int64_t>& dims,
+                const phi::IntArray& dims,
                 bool keep_dim,
                 phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -52,14 +52,14 @@ void MeanKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void MeanGradKernel(const Context& dev_ctx,
-                       const phi::DenseTensor& x,
-                       const phi::DenseTensor& out_grad,
-                       const std::vector<int64_t>& axes,
-                       bool keep_dim,
-                       bool reduce_all,
-                       phi::DenseTensor* x_grad) {
+                    const phi::DenseTensor& x,
+                    const phi::DenseTensor& out_grad,
+                    const phi::IntArray& axes,
+                    bool keep_dim,
+                    bool reduce_all,
+                    phi::DenseTensor* x_grad) {
   aclrtStream stream = static_cast<aclrtStream>(dev_ctx.stream());
-  auto reduce_dims = axes;
+  auto reduce_dims = axes.GetData();
   auto input_dims_vec = phi::vectorize(x.dims());
   dev_ctx.template Alloc<T>(x_grad);
 

--- a/backends/npu/kernels/uniform_random_kernel.cc
+++ b/backends/npu/kernels/uniform_random_kernel.cc
@@ -34,8 +34,8 @@ template <typename T, typename Context>
 void UniformRandomRawKernel(const Context& dev_ctx,
                             const phi::IntArray& shape,
                             phi::DataType dtype,
-                            float min,
-                            float max,
+                            const phi::Scalar& min,
+                            const phi::Scalar& max,
                             int seed,
                             int diag_num,
                             int diag_step,
@@ -59,7 +59,8 @@ void UniformRandomRawKernel(const Context& dev_ctx,
   } else {
     engine = dev_ctx.GetGenerator()->GetCPUEngine();
   }
-  UniformRealDistribution<T>(cpu_data, size, min, max, engine);
+  UniformRealDistribution<T>(
+      cpu_data, size, min.to<float>(), max.to<float>(), engine);
   if (diag_num > 0) {
     PADDLE_ENFORCE_GT(
         size,
@@ -86,8 +87,8 @@ template <typename T, typename Context>
 void UniformRandomKernel(const Context& dev_ctx,
                          const phi::IntArray& shape,
                          phi::DataType dtype,
-                         float min,
-                         float max,
+                         const phi::Scalar& min,
+                         const phi::Scalar& max,
                          int seed,
                          phi::DenseTensor* out) {
   custom_kernel::UniformRandomRawKernel<T>(


### PR DESCRIPTION
Fix ci bugs including arg_max, arg_min, conv2d_transpose, is_empty, momentum, reduce_mean by updating the op_attr from float/int to scalar, from vector to interlay

- arg_min:

![1662085820](https://user-images.githubusercontent.com/45005871/188045923-e0236544-6ea5-469f-be68-00b9071a0ec9.png)

- arg_max:

![65ef2fad344f8fe54ec8e42330d9be32](https://user-images.githubusercontent.com/45005871/188046078-3bc4aa10-8aea-48b2-83e5-7f5dd8fa1275.png)

- conv2d_transpose:

![dff19c1663d29821399d81b07bfa177f](https://user-images.githubusercontent.com/45005871/188046393-2773b9ed-8f4f-4e7f-9ed8-a51677ce1342.png)

- is_empty:

![b0d72b02ae2cd91bd637877116020e9a](https://user-images.githubusercontent.com/45005871/188046524-25d54997-22a2-42c0-95ab-5de71568fd98.png)

- momentum:

![2ab33a979fd1f260b7c2bace8](https://user-images.githubusercontent.com/45005871/188049067-d66e5679-b97c-44b4-91a4-ef0b17791392.png)

- reduce_mean:

![4bc3e9187989d2eccb709fa7c](https://user-images.githubusercontent.com/45005871/188049029-bc4d870b-5cc3-40cf-8fc3-ba46998cd779.png)
