### PR TITLE
[OpAttr]Adapt tensor attrs for reduce kernel

### DIFF
--- a/backends/custom_cpu/kernels/reduce_kernel.cc
+++ b/backends/custom_cpu/kernels/reduce_kernel.cc
@@ -22,12 +22,12 @@ namespace custom_kernel {
 template <typename T>
 void MeanRawKernel(const phi::Context& dev_ctx,
                    const phi::DenseTensor& x,
-                   const std::vector<int64_t>& dims,
+                   const phi::IntArray& dims,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* out) {
   auto x_dims = x.dims();
-  auto reduce_dims = dims;
+  auto reduce_dims = dims.GetData();
   if (reduce_all) {
     reduce_dims.clear();
     for (auto i = 0; i < x_dims.size(); ++i) {
@@ -69,7 +69,7 @@ void MeanRawKernel(const phi::Context& dev_ctx,
 template <typename T>
 void MeanKernel(const phi::Context& dev_ctx,
                 const phi::DenseTensor& x,
-                const std::vector<int64_t>& dims,
+                const phi::IntArray& dims,
                 bool keep_dim,
                 phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -79,13 +79,13 @@ void MeanKernel(const phi::Context& dev_ctx,
 template <typename T>
 void SumRawKernel(const phi::Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& dims,
+                  const phi::IntArray& dims,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DataType out_dtype,
                   phi::DenseTensor* out) {
   auto x_dims = x.dims();
-  auto reduce_dims = dims;
+  auto reduce_dims = dims.GetData();
   if (reduce_all) {
     reduce_dims.clear();
     for (auto i = 0; i < x_dims.size(); ++i) {
@@ -126,7 +126,7 @@ void SumRawKernel(const phi::Context& dev_ctx,
 template <typename T>
 void SumKernel(const phi::Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                phi::DataType out_dtype,
                bool keep_dim,
                phi::DenseTensor* out) {
@@ -137,12 +137,12 @@ void SumKernel(const phi::Context& dev_ctx,
 template <typename T>
 void MinRawKernel(const phi::Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& dims,
+                  const phi::IntArray& dims,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DenseTensor* out) {
   auto x_dims = x.dims();
-  auto reduce_dims = dims;
+  auto reduce_dims = dims.GetData();
   if (reduce_all) {
     reduce_dims.clear();
     for (auto i = 0; i < x_dims.size(); ++i) {
@@ -188,7 +188,7 @@ void MinRawKernel(const phi::Context& dev_ctx,
 template <typename T>
 void MinKernel(const phi::Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                bool keep_dim,
                phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -198,12 +198,12 @@ void MinKernel(const phi::Context& dev_ctx,
 template <typename T>
 void MaxRawKernel(const phi::Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& dims,
+                  const phi::IntArray& dims,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DenseTensor* out) {
   auto x_dims = x.dims();
-  auto reduce_dims = dims;
+  auto reduce_dims = dims.GetData();
   if (reduce_all) {
     reduce_dims.clear();
     for (auto i = 0; i < x_dims.size(); ++i) {
@@ -248,7 +248,7 @@ void MaxRawKernel(const phi::Context& dev_ctx,
 template <typename T>
 void MaxKernel(const phi::Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                bool keep_dim,
                phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -264,12 +264,8 @@ PD_BUILD_PHI_KERNEL(mean_raw,
                     float,
                     double) {}
 
-PD_BUILD_PHI_KERNEL(mean,
-                    custom_cpu,
-                    ALL_LAYOUT,
-                    custom_kernel::MeanKernel,
-                    float,
-                    double) {}
+PD_BUILD_PHI_KERNEL(
+    mean, custom_cpu, ALL_LAYOUT, custom_kernel::MeanKernel, float, double) {}
 
 PD_BUILD_PHI_KERNEL(sum_raw,
                     custom_cpu,
@@ -278,12 +274,8 @@ PD_BUILD_PHI_KERNEL(sum_raw,
                     float,
                     double) {}
 
-PD_BUILD_PHI_KERNEL(sum,
-                    custom_cpu,
-                    ALL_LAYOUT,
-                    custom_kernel::SumKernel,
-                    float,
-                    double) {}
+PD_BUILD_PHI_KERNEL(
+    sum, custom_cpu, ALL_LAYOUT, custom_kernel::SumKernel, float, double) {}
 
 PD_BUILD_PHI_KERNEL(min_raw,
                     custom_cpu,

--- a/backends/custom_cpu/kernels/uniform_random_kernel.cc
+++ b/backends/custom_cpu/kernels/uniform_random_kernel.cc
@@ -35,8 +35,8 @@ template <typename T>
 void UniformRandomRawKernel(const phi::Context &dev_ctx,
                             const phi::IntArray &shape,
                             phi::DataType dtype,
-                            float min,
-                            float max,
+                            const phi::Scalar &min,
+                            const phi::Scalar &max,
                             int seed,
                             int diag_num,
                             int diag_step,
@@ -52,7 +52,8 @@ void UniformRandomRawKernel(const phi::Context &dev_ctx,
   engine = std::make_shared<std::mt19937_64>();
   engine->seed(seed);
 
-  UniformRealDistribution<T>(data, size, min, max, engine);
+  UniformRealDistribution<T>(
+      data, size, min.to<float>(), max.to<float>(), engine);
   if (diag_num > 0) {
     PD_CHECK(size > (diag_num - 1) * (diag_step + 1),
              "ShapeInvalid: the diagonal's elements is equal (num-1) "
@@ -73,8 +74,8 @@ template <typename T>
 void UniformRandomKernel(const phi::Context &dev_ctx,
                          const phi::IntArray &shape,
                          phi::DataType dtype,
-                         float min,
-                         float max,
+                         const phi::Scalar &min,
+                         const phi::Scalar &max,
                          int seed,
                          phi::DenseTensor *out) {
   UniformRandomRawKernel<T>(

--- a/backends/npu/kernels/reduce_max_kernel.cc
+++ b/backends/npu/kernels/reduce_max_kernel.cc
@@ -20,11 +20,11 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void MaxRawKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& axes,
+                  const phi::IntArray& axes,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   NPUAttributeMap attr_input = {{"axes", dims}, {"keep_dims", keep_dim}};
@@ -64,7 +64,7 @@ void MaxRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void MaxKernel(const Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                bool keep_dim,
                phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -76,11 +76,11 @@ void MaxGradKernel(const Context& dev_ctx,
                    const phi::DenseTensor& x,
                    const phi::DenseTensor& out,
                    const phi::DenseTensor& out_grad,
-                   const std::vector<int64_t>& reduce_dims_in,
+                   const phi::IntArray& reduce_dims_in,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* x_grad) {
-  auto reduce_dims = reduce_dims_in;
+  auto reduce_dims = reduce_dims_in.GetData();
   dev_ctx.template Alloc<T>(x_grad);
   auto stream = dev_ctx.stream();
 

--- a/backends/npu/kernels/reduce_mean_kernel.cc
+++ b/backends/npu/kernels/reduce_mean_kernel.cc
@@ -20,11 +20,11 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void MeanRawKernel(const Context& dev_ctx,
                    const phi::DenseTensor& x,
-                   const std::vector<int64_t>& axes,
+                   const phi::IntArray& axes,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   auto input_dims_vec = phi::vectorize(x.dims());
@@ -43,7 +43,7 @@ void MeanRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void MeanKernel(const Context& dev_ctx,
                 const phi::DenseTensor& x,
-                const std::vector<int64_t>& dims,
+                const phi::IntArray& dims,
                 bool keep_dim,
                 phi::DenseTensor* out) {
   bool reduce_all = false;
@@ -52,14 +52,14 @@ void MeanKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void MeanGradKernel(const Context& dev_ctx,
-                       const phi::DenseTensor& x,
-                       const phi::DenseTensor& out_grad,
-                       const std::vector<int64_t>& axes,
-                       bool keep_dim,
-                       bool reduce_all,
-                       phi::DenseTensor* x_grad) {
+                    const phi::DenseTensor& x,
+                    const phi::DenseTensor& out_grad,
+                    const phi::IntArray& axes,
+                    bool keep_dim,
+                    bool reduce_all,
+                    phi::DenseTensor* x_grad) {
   aclrtStream stream = static_cast<aclrtStream>(dev_ctx.stream());
-  auto reduce_dims = axes;
+  auto reduce_dims = axes.GetData();
   auto input_dims_vec = phi::vectorize(x.dims());
   dev_ctx.template Alloc<T>(x_grad);
 

--- a/backends/npu/kernels/reduce_min_kernel.cc
+++ b/backends/npu/kernels/reduce_min_kernel.cc
@@ -20,11 +20,11 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void MinRawKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& axes,
+                  const phi::IntArray& axes,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   NPUAttributeMap attr_input = {{"axes", dims}, {"keep_dims", keep_dim}};
@@ -64,7 +64,7 @@ void MinRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void MinKernel(const Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                bool keep_dim,
                phi::DenseTensor* out) {
   bool reduce_all = false;

--- a/backends/npu/kernels/reduce_prod_kernel.cc
+++ b/backends/npu/kernels/reduce_prod_kernel.cc
@@ -20,11 +20,11 @@ namespace custom_kernel {
 template <typename T, typename Context>
 void ProdRawKernel(const Context& dev_ctx,
                    const phi::DenseTensor& x,
-                   const std::vector<int64_t>& axes,
+                   const phi::IntArray& axes,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   NPUAttributeMap attr_input = {{"axes", dims}, {"keep_dims", keep_dim}};
@@ -64,7 +64,7 @@ void ProdRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void ProdKernel(const Context& dev_ctx,
                 const phi::DenseTensor& x,
-                const std::vector<int64_t>& dims,
+                const phi::IntArray& dims,
                 bool keep_dim,
                 phi::DenseTensor* out) {
   bool reduce_all = false;

--- a/backends/npu/kernels/reduce_sum_kernel.cc
+++ b/backends/npu/kernels/reduce_sum_kernel.cc
@@ -71,12 +71,12 @@ static phi::DDim GetOutputShape(const std::vector<int64_t> unsqz_dims,
 template <typename T, typename Context>
 void SumRawKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
-                  const std::vector<int64_t>& axes,
+                  const phi::IntArray& axes,
                   bool keep_dim,
                   bool reduce_all,
                   phi::DenseTensorMeta::DataType out_dtype,
                   phi::DenseTensor* out) {
-  auto dims = axes;
+  auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
 
   // special case
@@ -140,7 +140,7 @@ void SumRawKernel(const Context& dev_ctx,
 template <typename T, typename Context>
 void SumKernel(const Context& dev_ctx,
                const phi::DenseTensor& x,
-               const std::vector<int64_t>& dims,
+               const phi::IntArray& dims,
                phi::DenseTensorMeta::DataType out_dtype,
                bool keep_dim,
                phi::DenseTensor* out) {
@@ -153,7 +153,7 @@ template <typename T, typename Context>
 void SumGradKernel(const Context& dev_ctx,
                    const phi::DenseTensor& x,
                    const phi::DenseTensor& out_grad,
-                   const std::vector<int64_t>& dims,
+                   const phi::IntArray& dims,
                    bool keep_dim,
                    bool reduce_all,
                    phi::DenseTensor* x_grad) {
@@ -161,7 +161,8 @@ void SumGradKernel(const Context& dev_ctx,
 
   // The dims has full dim, set the reduce_all is True
   const auto& input_dim_size = x.dims().size();
-  std::set<int> dims_set(dims.begin(), dims.end());
+  auto vec_dims = dims.GetData();
+  std::set<int> dims_set(vec_dims.begin(), vec_dims.end());
   bool full_dim = true;
   for (auto i = 0; i < input_dim_size; i++) {
     if (dims_set.find(i) == dims_set.end()) {
@@ -182,7 +183,7 @@ void SumGradKernel(const Context& dev_ctx,
     runner.Run(stream);
   } else {
     phi::DDim out_dims;
-    out_dims = GetOutputShape(dims, out_grad.dims());
+    out_dims = GetOutputShape(vec_dims, out_grad.dims());
 
     phi::DenseTensor out_grad_tmp;
     phi::DenseTensorMeta out_grad_tmp_meta = {out_grad.dtype(), out_dims};

--- a/backends/npu/kernels/uniform_random_kernel.cc
+++ b/backends/npu/kernels/uniform_random_kernel.cc
@@ -34,8 +34,8 @@ template <typename T, typename Context>
 void UniformRandomRawKernel(const Context& dev_ctx,
                             const phi::IntArray& shape,
                             phi::DataType dtype,
-                            float min,
-                            float max,
+                            const phi::Scalar& min,
+                            const phi::Scalar& max,
                             int seed,
                             int diag_num,
                             int diag_step,
@@ -59,7 +59,8 @@ void UniformRandomRawKernel(const Context& dev_ctx,
   } else {
     engine = dev_ctx.GetGenerator()->GetCPUEngine();
   }
-  UniformRealDistribution<T>(cpu_data, size, min, max, engine);
+  UniformRealDistribution<T>(
+      cpu_data, size, min.to<float>(), max.to<float>(), engine);
   if (diag_num > 0) {
     PADDLE_ENFORCE_GT(
         size,
@@ -86,8 +87,8 @@ template <typename T, typename Context>
 void UniformRandomKernel(const Context& dev_ctx,
                          const phi::IntArray& shape,
                          phi::DataType dtype,
-                         float min,
-                         float max,
+                         const phi::Scalar& min,
+                         const phi::Scalar& max,
                          int seed,
                          phi::DenseTensor* out) {
   custom_kernel::UniformRandomRawKernel<T>(


### PR DESCRIPTION
[OpAttr]Adapt tensor attrs for reduce kernel
对uniform_random、reduce_min/max/sum/mean/prod 6 个算子进行了适配