### PR TITLE
Normalize conv2d kernel signature

### DIFF
--- a/backends/mlu/kernels/conv_kernel.cc
+++ b/backends/mlu/kernels/conv_kernel.cc
@@ -23,12 +23,9 @@ void Conv2dKernel(const Context& dev_ctx,
                   const std::vector<int>& strides_t,
                   const std::vector<int>& paddings_t,
                   const std::string& padding_algorithm,
-                  int groups,
                   const std::vector<int>& dilations_t,
+                  int groups,
                   const std::string& data_format,
-                  bool use_addto,
-                  int workspace_size_MB,
-                  bool exhaustive_search,
                   phi::DenseTensor* output) {
   dev_ctx.template Alloc<T>(output);
   auto strides = strides_t;
@@ -127,12 +124,9 @@ void Conv2dGradKernel(const Context& dev_ctx,
                       const std::vector<int>& strides_t,
                       const std::vector<int>& paddings_t,
                       const std::string& padding_algorithm,
-                      int groups,
                       const std::vector<int>& dilations_t,
+                      int groups,
                       const std::string& data_format,
-                      bool use_addto,
-                      int workspace_size_MB,
-                      bool exhaustive_search,
                       phi::DenseTensor* input_grad,
                       phi::DenseTensor* filter_grad) {
   auto strides = strides_t;

--- a/backends/npu/kernels/conv_kernel.cc
+++ b/backends/npu/kernels/conv_kernel.cc
@@ -53,12 +53,9 @@ void Conv2dKernel(const Context& dev_ctx,
                   const std::vector<int>& strides_t,
                   const std::vector<int>& paddings_t,
                   const std::string& padding_algorithm,
-                  int groups,
                   const std::vector<int>& dilations_t,
+                  int groups,
                   const std::string& data_format,
-                  bool use_addto,
-                  int workspace_size_MB,
-                  bool exhaustive_search,
                   phi::DenseTensor* output) {
   dev_ctx.template Alloc<T>(output);
   auto strides = strides_t;
@@ -126,12 +123,9 @@ void Conv2dGradKernel(const Context& dev_ctx,
                       const std::vector<int>& strides_t,
                       const std::vector<int>& paddings_t,
                       const std::string& padding_algorithm,
-                      int groups,
                       const std::vector<int>& dilations_t,
+                      int groups,
                       const std::string& data_format,
-                      bool use_addto,
-                      int workspace_size_MB,
-                      bool exhaustive_search,
                       phi::DenseTensor* input_grad,
                       phi::DenseTensor* filter_grad) {
   auto strides = strides_t;


### PR DESCRIPTION
Normalize conv2d kernel signature

规范化Conv2D kernel的参数列表，尽可能与python端对齐，移除无用的参数，调整参数顺序等

The Python API signature of conv2d is as follows:

```python
def conv2d(x,
           weight,
           bias=None,
           stride=1,
           padding=0,
           dilation=1,
           groups=1,
           data_format="NCHW",
           name=None):
```