### PR TITLE
[NPU] Fix tensor sync copy

### DIFF
--- a/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
+++ b/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
@@ -79,7 +79,7 @@ void CheckFiniteAndUnscale(const Context& dev_ctx,
 
     const auto& runner_logical_or =
         NpuOpRunner("LogicalOr", {xs_is_inf, xs_is_nan}, {xs_is_finite}, {});
-    runner_logical_and.Run(stream);
+    runner_logical_or.Run(stream);
 
     const auto& runner_cast = NpuOpRunner(
         "Cast",

--- a/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
+++ b/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
@@ -77,7 +77,7 @@ void CheckFiniteAndUnscale(const Context& dev_ctx,
         NpuOpRunner("IsNan", {*xs_item}, {xs_is_nan}, {});
     runner_check_nan.Run(stream);
 
-    const auto& runner_logical_and =
+    const auto& runner_logical_or =
         NpuOpRunner("LogicalOr", {xs_is_inf, xs_is_nan}, {xs_is_finite}, {});
     runner_logical_and.Run(stream);
 

--- a/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
+++ b/backends/npu/kernels/amp/check_finite_and_unscale_kernel.cc
@@ -78,7 +78,7 @@ void CheckFiniteAndUnscale(const Context& dev_ctx,
     runner_check_nan.Run(stream);
 
     const auto& runner_logical_and =
-        NpuOpRunner("LogicalAnd", {xs_is_inf, xs_is_nan}, {xs_is_finite}, {});
+        NpuOpRunner("LogicalOr", {xs_is_inf, xs_is_nan}, {xs_is_finite}, {});
     runner_logical_and.Run(stream);
 
     const auto& runner_cast = NpuOpRunner(

--- a/backends/npu/kernels/batch_norm_kernel.cc
+++ b/backends/npu/kernels/batch_norm_kernel.cc
@@ -40,8 +40,7 @@ void BatchNormKernel(const Context& dev_ctx,
   bool test_mode = is_test && (!trainable_stats);
   bool training = !test_mode && !use_global_stats;
 
-  phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_layout_str);
+  phi::DataLayout data_layout = phi::StringToDataLayout(data_layout_str);
 
   const auto& x_dims = x.dims();
   PADDLE_ENFORCE_EQ((x_dims.size() == 4UL || x_dims.size() == 3UL),
@@ -131,8 +130,7 @@ void BatchNormGradKernel(
     phi::DenseTensor* d_x,
     phi::DenseTensor* d_scale,
     phi::DenseTensor* d_bias) {
-  phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_layout_str);
+  phi::DataLayout data_layout = phi::StringToDataLayout(data_layout_str);
 
   use_global_stats = is_test || use_global_stats;
 

--- a/backends/npu/kernels/conv_transpose_kernel.cc
+++ b/backends/npu/kernels/conv_transpose_kernel.cc
@@ -117,7 +117,7 @@ void Conv2dTransposeGradKernel(const Context& dev_ctx,
   auto dilations = dilation;
   if ((!dx) && (!dfilter)) return;
 
-  const phi::DataLayout data_layout = phi : StringToDataLayout(data_format);
+  const phi::DataLayout data_layout = phi::StringToDataLayout(data_format);
 
   auto in_dims = x.dims();
   auto filter_dims = filter.dims();

--- a/backends/npu/kernels/conv_transpose_kernel.cc
+++ b/backends/npu/kernels/conv_transpose_kernel.cc
@@ -117,8 +117,7 @@ void Conv2dTransposeGradKernel(const Context& dev_ctx,
   auto dilations = dilation;
   if ((!dx) && (!dfilter)) return;
 
-  const phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_format);
+  const phi::DataLayout data_layout = phi : StringToDataLayout(data_format);
 
   auto in_dims = x.dims();
   auto filter_dims = filter.dims();

--- a/backends/npu/kernels/funcs/npu_funcs.h
+++ b/backends/npu/kernels/funcs/npu_funcs.h
@@ -111,6 +111,7 @@ inline void TensorFromVector(const phi::CustomContext& ctx,
                    dst_ptr,
                    src_ptr,
                    size);
+    dev_ctx.Wait();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));
@@ -143,6 +144,7 @@ inline void TensorFromVector<bool>(const phi::CustomContext& ctx,
                    dst_ptr,
                    src_ptr,
                    size);
+    dev_ctx.Wait();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));
@@ -171,7 +173,12 @@ inline void TensorFromVector(const phi::CustomContext& ctx,
             << ", size: " << size;
     std::memcpy(dst_ptr, src_ptr, size);
   } else if (dst_place.GetType() == phi::AllocationType::CUSTOM) {
-    MemCpyH2D(nullptr, dst_ptr, src_ptr, size);
+    AsyncMemCpyH2D(nullptr,
+                   static_cast<C_Stream>(dev_ctx.stream()),
+                   dst_ptr,
+                   src_ptr,
+                   size);
+    dev_ctx.Wait();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));
@@ -206,6 +213,7 @@ void TensorFromArray(const phi::CustomContext& ctx,
                    dst_ptr,
                    src_ptr,
                    size);
+    dev_ctx.Wait();
   } else {  // NOLINT
     PADDLE_THROW(phi::errors::Unimplemented(
         "TensorFromArray on %s is not supported.", dst_place));

--- a/backends/npu/kernels/funcs/npu_funcs.h
+++ b/backends/npu/kernels/funcs/npu_funcs.h
@@ -64,26 +64,23 @@ inline void TensorCopy(const Context& dev_ctx,
 
   if (src_place.GetType() == phi::AllocationType::CPU &&
       dst_place_.GetType() == phi::AllocationType::CUSTOM) {
+    AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
     if (blocking) {
-      MemCpyH2D(nullptr, dst_ptr, src_ptr, size);
-    } else {
-      AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
+      dev_ctx.Wait();
     }
   } else if (src_place.GetType() == phi::AllocationType::CUSTOM &&
              dst_place_.GetType() == phi::AllocationType::CPU) {
+    AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
     if (blocking) {
-      MemCpyD2H(nullptr, dst_ptr, src_ptr, size);
-    } else {
-      AsyncMemCpyD2H(nullptr, stream, dst_ptr, src_ptr, size);
+      dev_ctx.Wait();
     }
   } else if (src_place.GetType() == phi::AllocationType::CUSTOM &&
              dst_place_.GetType() == phi::AllocationType::CUSTOM) {
     if (src_place.GetDeviceType() == dst_place_.GetDeviceType()) {
       if (src_place.GetDeviceId() == dst_place_.GetDeviceId()) {
+        AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
         if (blocking) {
-          MemCpyD2D(nullptr, dst_ptr, src_ptr, size);
-        } else {
-          AsyncMemCpyD2D(nullptr, stream, dst_ptr, src_ptr, size);
+          dev_ctx.Wait();
         }
       } else {
       }

--- a/backends/npu/kernels/funcs/npu_funcs.h
+++ b/backends/npu/kernels/funcs/npu_funcs.h
@@ -173,12 +173,7 @@ inline void TensorFromVector(const phi::CustomContext& ctx,
             << ", size: " << size;
     std::memcpy(dst_ptr, src_ptr, size);
   } else if (dst_place.GetType() == phi::AllocationType::CUSTOM) {
-    AsyncMemCpyH2D(nullptr,
-                   static_cast<C_Stream>(dev_ctx.stream()),
-                   dst_ptr,
-                   src_ptr,
-                   size);
-    dev_ctx.Wait();
+    MemCpyH2D(nullptr, dst_ptr, src_ptr, size);
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
         "TensorFromVector on %s is not supported.", dst_place));

--- a/backends/npu/kernels/funcs/npu_funcs.h
+++ b/backends/npu/kernels/funcs/npu_funcs.h
@@ -70,7 +70,7 @@ inline void TensorCopy(const Context& dev_ctx,
     }
   } else if (src_place.GetType() == phi::AllocationType::CUSTOM &&
              dst_place_.GetType() == phi::AllocationType::CPU) {
-    AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
+    AsyncMemCpyD2H(nullptr, stream, dst_ptr, src_ptr, size);
     if (blocking) {
       dev_ctx.Wait();
     }
@@ -78,7 +78,7 @@ inline void TensorCopy(const Context& dev_ctx,
              dst_place_.GetType() == phi::AllocationType::CUSTOM) {
     if (src_place.GetDeviceType() == dst_place_.GetDeviceType()) {
       if (src_place.GetDeviceId() == dst_place_.GetDeviceId()) {
-        AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);
+        AsyncMemCpyD2D(nullptr, stream, dst_ptr, src_ptr, size);
         if (blocking) {
           dev_ctx.Wait();
         }

--- a/backends/npu/kernels/funcs/npu_op_runner.cc
+++ b/backends/npu/kernels/funcs/npu_op_runner.cc
@@ -34,13 +34,12 @@ static std::map<paddle::experimental::DataType, aclDataType>  //
         {paddle::experimental::DataType::FLOAT64, ACL_DOUBLE},
 };
 
-static std::map<paddle::experimental::DataLayout, aclFormat>
-    DATA_LAYOUT_2_ACL_FORMAT = {
-        {paddle::experimental::DataLayout::NCHW, ACL_FORMAT_NCHW},
-        {paddle::experimental::DataLayout::NHWC, ACL_FORMAT_NHWC},
-        {paddle::experimental::DataLayout::kNCDHW, ACL_FORMAT_NCDHW},
-        {paddle::experimental::DataLayout::kNDHWC, ACL_FORMAT_NDHWC},
-        {paddle::experimental::DataLayout::ANY, ACL_FORMAT_ND},
+static std::map<phi::DataLayout, aclFormat> DATA_LAYOUT_2_ACL_FORMAT = {
+    {phi::DataLayout::NCHW, ACL_FORMAT_NCHW},
+    {phi::DataLayout::NHWC, ACL_FORMAT_NHWC},
+    {phi::DataLayout::kNCDHW, ACL_FORMAT_NCDHW},
+    {phi::DataLayout::kNDHWC, ACL_FORMAT_NDHWC},
+    {phi::DataLayout::ANY, ACL_FORMAT_ND},
 };
 
 aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype) {
@@ -53,7 +52,7 @@ aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype) {
   return iter->second;
 }
 
-aclFormat ConvertToNpuFormat(paddle::experimental::DataLayout layout) {
+aclFormat ConvertToNpuFormat(phi::DataLayout layout) {
   auto iter = DATA_LAYOUT_2_ACL_FORMAT.find(layout);
   PADDLE_ENFORCE_NE(
       iter,

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -21,7 +21,7 @@
 #include "paddle/utils/variant.h"
 
 aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype);
-aclFormat ConvertToNpuFormat(paddle::experimental::DataLayout layout);
+aclFormat ConvertToNpuFormat(phi::DataLayout layout);
 
 using NPUAttribute = paddle::variant<paddle::blank,
                                      int,

--- a/backends/npu/kernels/group_norm_kernel.cc
+++ b/backends/npu/kernels/group_norm_kernel.cc
@@ -153,8 +153,7 @@ void GroupNormKernel(const Context& dev_ctx,
                      phi::DenseTensor* mean,
                      phi::DenseTensor* variance) {
   auto stream = dev_ctx.stream();
-  const phi::DataLayout data_layout_data =
-      paddle::framework::StringToDataLayout(data_layout);
+  const phi::DataLayout data_layout_data = phi::StringToDataLayout(data_layout);
 
   phi::DenseTensor xnorm;
   phi::DenseTensorMeta xnorm_meta = {x.dtype(), x.dims()};


### PR DESCRIPTION
### 原写法
TensorCopy()函数中通过输入参数blocking决定选用同步内存拷贝或异步内存拷贝，同步内存拷贝为调用接口`MemCpyD2H(nullptr, dst_ptr, src_ptr, size);`，异步内存拷贝为调用接口`AsyncMemCpyH2D(nullptr, stream, dst_ptr, src_ptr, size);`  

### 问题及修改
原来的写法中同步内存拷贝中仅为等待内存拷贝操作完成，并没有考虑到tensorcopy前后的kernel计算；所以需要把tensorcpoy和kernel计算给定在同一stream上，所以这里改为使用能穿入stream的异步内存拷贝接口，并在后面使用`dev_ctx.Wait()`同步strem来实现

