### PR TITLE
[NPU]Fix datalayout and implement one_hot kernel for PARL DQN

### DIFF
--- a/backends/npu/kernels/batch_norm_kernel.cc
+++ b/backends/npu/kernels/batch_norm_kernel.cc
@@ -40,8 +40,7 @@ void BatchNormKernel(const Context& dev_ctx,
   bool test_mode = is_test && (!trainable_stats);
   bool training = !test_mode && !use_global_stats;
 
-  phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_layout_str);
+  phi::DataLayout data_layout = phi::StringToDataLayout(data_layout_str);
 
   const auto& x_dims = x.dims();
   PADDLE_ENFORCE_EQ((x_dims.size() == 4UL || x_dims.size() == 3UL),
@@ -131,8 +130,7 @@ void BatchNormGradKernel(
     phi::DenseTensor* d_x,
     phi::DenseTensor* d_scale,
     phi::DenseTensor* d_bias) {
-  phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_layout_str);
+  phi::DataLayout data_layout = phi::StringToDataLayout(data_layout_str);
 
   use_global_stats = is_test || use_global_stats;
 

--- a/backends/npu/kernels/conv_transpose_kernel.cc
+++ b/backends/npu/kernels/conv_transpose_kernel.cc
@@ -117,8 +117,7 @@ void Conv2dTransposeGradKernel(const Context& dev_ctx,
   auto dilations = dilation;
   if ((!dx) && (!dfilter)) return;
 
-  const phi::DataLayout data_layout =
-      paddle::framework::StringToDataLayout(data_format);
+  const phi::DataLayout data_layout = phi::StringToDataLayout(data_format);
 
   auto in_dims = x.dims();
   auto filter_dims = filter.dims();

--- a/backends/npu/kernels/funcs/npu_op_runner.cc
+++ b/backends/npu/kernels/funcs/npu_op_runner.cc
@@ -34,13 +34,12 @@ static std::map<paddle::experimental::DataType, aclDataType>  //
         {paddle::experimental::DataType::FLOAT64, ACL_DOUBLE},
 };
 
-static std::map<paddle::experimental::DataLayout, aclFormat>
-    DATA_LAYOUT_2_ACL_FORMAT = {
-        {paddle::experimental::DataLayout::NCHW, ACL_FORMAT_NCHW},
-        {paddle::experimental::DataLayout::NHWC, ACL_FORMAT_NHWC},
-        {paddle::experimental::DataLayout::kNCDHW, ACL_FORMAT_NCDHW},
-        {paddle::experimental::DataLayout::kNDHWC, ACL_FORMAT_NDHWC},
-        {paddle::experimental::DataLayout::ANY, ACL_FORMAT_ND},
+static std::map<phi::DataLayout, aclFormat> DATA_LAYOUT_2_ACL_FORMAT = {
+    {phi::DataLayout::NCHW, ACL_FORMAT_NCHW},
+    {phi::DataLayout::NHWC, ACL_FORMAT_NHWC},
+    {phi::DataLayout::kNCDHW, ACL_FORMAT_NCDHW},
+    {phi::DataLayout::kNDHWC, ACL_FORMAT_NDHWC},
+    {phi::DataLayout::ANY, ACL_FORMAT_ND},
 };
 
 aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype) {
@@ -53,7 +52,7 @@ aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype) {
   return iter->second;
 }
 
-aclFormat ConvertToNpuFormat(paddle::experimental::DataLayout layout) {
+aclFormat ConvertToNpuFormat(phi::DataLayout layout) {
   auto iter = DATA_LAYOUT_2_ACL_FORMAT.find(layout);
   PADDLE_ENFORCE_NE(
       iter,

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -21,7 +21,7 @@
 #include "paddle/utils/variant.h"
 
 aclDataType ConvertToNpuDtype(paddle::experimental::DataType dtype);
-aclFormat ConvertToNpuFormat(paddle::experimental::DataLayout layout);
+aclFormat ConvertToNpuFormat(phi::DataLayout layout);
 
 using NPUAttribute = paddle::variant<paddle::blank,
                                      int,

--- a/backends/npu/kernels/group_norm_kernel.cc
+++ b/backends/npu/kernels/group_norm_kernel.cc
@@ -153,8 +153,7 @@ void GroupNormKernel(const Context& dev_ctx,
                      phi::DenseTensor* mean,
                      phi::DenseTensor* variance) {
   auto stream = dev_ctx.stream();
-  const phi::DataLayout data_layout_data =
-      paddle::framework::StringToDataLayout(data_layout);
+  const phi::DataLayout data_layout_data = phi::StringToDataLayout(data_layout);
 
   phi::DenseTensor xnorm;
   phi::DenseTensorMeta xnorm_meta = {x.dtype(), x.dims()};

--- a/backends/npu/kernels/one_hot_kernel.cc
+++ b/backends/npu/kernels/one_hot_kernel.cc
@@ -71,7 +71,8 @@ void OneHotKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
-  PADDLE_THROW(phi::errors::Unimplemented("OneHotKernel is not need?"));
+  custom_kernel::OneHotRawKernel<T, Context>(
+      dev_ctx, x, num_classes_s, phi::DataType::FLOAT32, false, out);
 }
 
 }  // namespace custom_kernel


### PR DESCRIPTION
1.[this PR](https://github.com/PaddlePaddle/Paddle/pull/46869) in Paddle changed DataLayout's namespace, we also need to change the namespace.
2.implement one_hot kernel.