### PR TITLE
add npu profiler

### DIFF
--- a/backends/npu/runtime/runtime.cc
+++ b/backends/npu/runtime/runtime.cc
@@ -529,28 +529,32 @@ C_Status XcclRecv(void *recv_buf,
   return C_SUCCESS;
 }
 
+ENV_string(ascend_profiling_dir, "ascend_profiling");
+ENV_uint64(ascend_profiling_data_type,
+           ACL_PROF_ACL_API | ACL_PROF_TASK_TIME | ACL_PROF_AICORE_METRICS |
+               ACL_PROF_AICPU | ACL_PROF_HCCL_TRACE | ACL_PROF_RUNTIME_API);
+ENV_uint64(ascend_profiling_metrics,
+           static_cast<uint64_t>(ACL_AICORE_ARITHMETIC_UTILIZATION));
+
 C_Status ProfilerInitialize(C_Profiler prof, void **user_data) {
   // NOTE(wangran16):
   // https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/60RC1alpha001/infacldevg/aclcppdevg/aclcppdevg_03_0784.html
   std::vector<uint32_t> device_ids(
       {static_cast<uint32_t>(get_current_device_id())});
-  aclprofAicoreMetrics metrics = ACL_AICORE_ARITHMETIC_UTILIZATION;
-  aclprofAicoreEvents *events = nullptr;
-  uint64_t type = ACL_PROF_ACL_API | ACL_PROF_TASK_TIME |
-                  ACL_PROF_AICORE_METRICS | ACL_PROF_AICPU | ACL_PROF_L2CACHE |
-                  ACL_PROF_HCCL_TRACE | ACL_PROF_RUNTIME_API;
-
-  AscendProfiler::Instance().update_config(device_ids, metrics, events, type);
-  std::string path = "./ascend_profiling";
-  ACL_CHECK(aclprofInit(path.c_str(), path.size()));
-
-  LOG(INFO) << "ascend profiling data will be saved in " << path;
+  AscendProfiler::Instance().update_config(
+      device_ids,
+      static_cast<aclprofAicoreMetrics>(FLAGS_ascend_profiling_metrics),
+      nullptr,
+      FLAGS_ascend_profiling_data_type);
+  ACL_CHECK(aclprofInit(FLAGS_ascend_profiling_dir.c_str(),
+                        FLAGS_ascend_profiling_dir.size()));
+  LOG(INFO) << "ascend profiling data will be saved in "
+            << FLAGS_ascend_profiling_dir;
   return C_SUCCESS;
 }
 
 C_Status ProfilerFinalize(C_Profiler prof, void *user_data) {
-  AscendProfiler::Instance().step_stop();
-  AscendProfiler::Instance().destroy_step_info();
+  AscendProfiler::Instance().stop();
   AscendProfiler::Instance().destroy_config();
   // ACL_CHECK(aclprofFinalize());
   return C_SUCCESS;
@@ -560,17 +564,10 @@ C_Status ProfilerPrepare(C_Profiler prof, void *user_data) { return C_SUCCESS; }
 
 C_Status ProfilerStart(C_Profiler prof, void *user_data) {
   AscendProfiler::Instance().start();
-
-  AscendProfiler::Instance().destroy_step_info();
-  AscendProfiler::Instance().get_step_info();
-  AscendProfiler::Instance().step_start();
   return C_SUCCESS;
 }
 
 C_Status ProfilerStop(C_Profiler prof, void *user_data) {
-  AscendProfiler::Instance().step_stop();
-  AscendProfiler::Instance().destroy_step_info();
-
   AscendProfiler::Instance().stop();
   return C_SUCCESS;
 }

--- a/backends/npu/runtime/runtime.h
+++ b/backends/npu/runtime/runtime.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <acl/acl.h>
+#include <acl/acl_prof.h>
 #include <hccl/hccl.h>
 #include <hccl/hccl_types.h>
 
@@ -69,3 +70,113 @@ C_Status AsyncMemCpyD2H(const C_Device device,
                         void *dst,
                         const void *src,
                         size_t size);
+
+class AscendProfiler {
+ public:
+  static AscendProfiler &Instance() {
+    static AscendProfiler ins;
+    return ins;
+  }
+
+  AscendProfiler() {}
+
+  ~AscendProfiler() {
+    destroy_step_info();
+    destroy_config();
+  }
+
+  void update_config(std::vector<uint32_t> device_ids,
+                     aclprofAicoreMetrics metrics,
+                     aclprofAicoreEvents *events,
+                     uint64_t type) {
+    devices_ids_ = device_ids;
+    metrics_ = metrics;
+    data_type_ = type;
+  }
+
+  void destroy_config() {
+    if (config_) {
+      ACL_CHECK(aclprofDestroyConfig(config_));
+      config_ = nullptr;
+    }
+  }
+
+  aclprofConfig *get_config() {
+    if (config_ == nullptr) {
+      config_ = aclprofCreateConfig(devices_ids_.data(),
+                                    devices_ids_.size(),
+                                    metrics_,
+                                    nullptr,
+                                    data_type_);
+    }
+    return config_;
+  }
+
+  aclprofStepInfo *get_step_info() {
+    if (step_info_ == nullptr) {
+      step_info_ = aclprofCreateStepInfo();
+    }
+    return step_info_;
+  }
+
+  void destroy_step_info() {
+    if (step_info_) {
+      aclprofDestroyStepInfo(step_info_);
+      step_info_ = nullptr;
+    }
+  }
+
+  void update_stream(aclrtStream stream) {
+    if (stream_ == nullptr) {
+      stream_ = stream;
+      if (step_info_) {
+        ACL_CHECK(aclprofGetStepTimestamp(step_info_, ACL_STEP_START, stream_));
+      }
+    }
+  }
+
+  aclrtStream get_stream() { return stream_; }
+
+  void clear_stream() { stream_ = nullptr; }
+
+  void start() {
+    if (!start_) {
+      ACL_CHECK(aclrtSynchronizeDevice());
+      ACL_CHECK(aclprofStart(AscendProfiler::Instance().get_config()));
+      start_ = true;
+    }
+  }
+
+  void stop() {
+    if (start_) {
+      ACL_CHECK(aclrtSynchronizeDevice());
+      ACL_CHECK(aclprofStop(AscendProfiler::Instance().get_config()));
+      start_ = false;
+    }
+  }
+
+  void step_start() {
+    get_step_info();
+    if (stream_ && step_info_) {
+      ACL_CHECK(aclprofGetStepTimestamp(step_info_, ACL_STEP_START, stream_));
+    }
+  }
+
+  void step_stop() {
+    if (stream_ && step_info_) {
+      ACL_CHECK(aclprofGetStepTimestamp(step_info_, ACL_STEP_END, stream_));
+    }
+    destroy_step_info();
+  }
+
+ private:
+  std::vector<uint32_t> devices_ids_;
+  aclprofAicoreMetrics metrics_;
+  uint64_t data_type_;
+
+  aclprofConfig *config_ = nullptr;
+  aclprofStepInfo *step_info_ = nullptr;
+  aclrtStream stream_ = nullptr;
+
+  bool start_ = false;
+};

--- a/backends/npu/runtime/runtime.h
+++ b/backends/npu/runtime/runtime.h
@@ -43,6 +43,17 @@
 #define ACL_CHECK(func) RUNTIME_CHECK(func, ACL_ERROR_NONE)
 #define HCCL_CHECK(func) RUNTIME_CHECK(func, HCCL_SUCCESS)
 
+#define ENV_Cat(x, y) x##y
+#define ENV_Str(x) #x
+#define ENV_Call(x, y) x(y)
+#define ENV_DEFINE(type, name, value, parser)                        \
+  type FLAGS_##name =                                                \
+      getenv(ENV_Call(ENV_Str, ENV_Cat(FLAGS_, name)))               \
+          ? parser(getenv(ENV_Call(ENV_Str, ENV_Cat(FLAGS_, name)))) \
+          : value
+#define ENV_uint64(x, value) ENV_DEFINE(uint64_t, x, value, std::stoul)
+#define ENV_string(x, value) ENV_DEFINE(std::string, x, value, std::string)
+
 C_Status MemCpyH2D(const C_Device device,
                    void *dst,
                    const void *src,


### PR DESCRIPTION
修改 test_MINIST_model.py

![image](https://user-images.githubusercontent.com/25691046/196939237-f0df344f-5fb4-479f-a7f8-df05e9197942.png)

```bash
$ python test_MINIST_model.py

I1020 19:41:09.561262 52729 init.cc:262] ENV [CUSTOM_DEVICE_ROOT]=/usr/local/lib/python3.7/dist-packages/paddle-plugins
I1020 19:41:09.561327 52729 init.cc:150] Try loading custom device libs from: [/usr/local/lib/python3.7/dist-packages/paddle-plugins]
I1020 19:41:12.188797 52729 custom_device.cc:1080] Successed in loading custom runtime in lib: /usr/local/lib/python3.7/dist-packages/paddle-plugins/libpaddle-custom-npu.so
I1020 19:41:12.192376 52729 custom_kernel.cc:70] Successed in loading 242 custom kernel(s) from loaded lib(s), will be used like native ones.
I1020 19:41:12.192592 52729 init.cc:162] Finished in LoadCustomDevice with libs_path: [/usr/local/lib/python3.7/dist-packages/paddle-plugins]
I1020 19:41:12.192648 52729 init.cc:268] CustomDevice: ascend, visible devices count: 1
WARNING: Logging before InitGoogleLogging() is written to STDERR
I1020 19:41:18.435073 52729 runtime.cc:546] ascend profiling data will be saved in ./ascend_profiling
Epoch 0 step 0, Loss = [2.3142004], Accuracy = [0.078125]
Epoch 0 step 100, Loss = [1.7828059], Accuracy = [0.6875]
Epoch 0 step 200, Loss = [1.8365659], Accuracy = [0.640625]
Epoch 0 step 300, Loss = [1.686101], Accuracy = [0.78125]
Epoch 0 step 400, Loss = [1.7403495], Accuracy = [0.75]
Epoch 0 step 500, Loss = [1.6934838], Accuracy = [0.78125]
Epoch 0 step 600, Loss = [1.6392534], Accuracy = [0.828125]
Epoch 0 step 700, Loss = [1.7020411], Accuracy = [0.78125]
Epoch 0 step 800, Loss = [1.6744789], Accuracy = [0.8125]
Epoch 0 step 900, Loss = [1.6682684], Accuracy = [0.8125]
I1020 19:42:30.009277 52729 chrometracing_logger.cc:46] writing profiling data to ./profiler_log/host_yq01-sys-rpm09b0b83.yq01.baidu.compid_52729_time_2022_10_20_19_42_30_009045.paddle_trace.json
```

使用 ascend 工具解析并导出summary，timeline 信息

```bash
alias msprof='python /usr/local/Ascend/ascend-toolkit/latest/tools/profiler/profiler_tool/analysis/msprof/msprof.py'
msprof import -dir ascend_profiling
msprof export summary -dir ascend_profiling
msprof export timeline -dir ascend_profiling
```


profiling 数据说明 https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/60RC1alpha003/developmenttools/devtool/atlasprofiling_16_0105.html

使用 [chrome://tracing/](chrome://tracing/) 查看 timeline

![image](https://user-images.githubusercontent.com/25691046/196941546-c690c63f-7692-4a52-86d4-06cec2587663.png)

查看 summary

![image](https://user-images.githubusercontent.com/25691046/197101100-1344932c-faa3-4f4e-a0c6-683d698086a3.png)

![image](https://user-images.githubusercontent.com/25691046/197101035-d8f773af-afe2-4e2f-9151-27d54b9d33ec.png)



| ENV | default | description | |
|---|---|---|:---|
| FLAGS_ascend_profiling_dir | ascend_profiling | 设置profiling数据保存目录 | | 
| FLAGS_ascend_profiling_data_type | `ACL_PROF_ACL_API \| ACL_PROF_TASK_TIME \| ACL_PROF_AICORE_METRICS \| ACL_PROF_AICPU \| ACL_PROF_HCCL_TRACE \| ACL_PROF_RUNTIME_API` | 指定需要采集的Profiling数据内容范围 |  #define ACL_PROF_ACL_API 0x0001ULL <br> #define ACL_PROF_TASK_TIME 0x0002ULL <br> #define ACL_PROF_AICORE_METRICS 0x0004ULL <br> #define ACL_PROF_AICPU 0x0008ULL <br> #define ACL_PROF_L2CACHE 0x0010ULL <br> #define ACL_PROF_HCCL_TRACE 0x0020ULL <br> #define ACL_PROF_TRAINING_TRACE 0x0040ULL <br> #define ACL_PROF_MSPROFTX 0x0080ULL <br> #define ACL_PROF_RUNTIME_API 0x0100ULL  | 
| FLAGS_ascend_profiling_metrics | `ACL_AICORE_ARITHMETIC_UTILIZATION` | AI Core metrics | ACL_AICORE_ARITHMETIC_UTILIZATION = 0 <br> ACL_AICORE_PIPE_UTILIZATION = 1 <br> ACL_AICORE_MEMORY_BANDWIDTH = 2 <br> ACL_AICORE_L0B_AND_WIDTH = 3 <br> ACL_AICORE_RESOURCE_CONFLICT_RATIO = 4 <br> ACL_AICORE_MEMORY_UB = 5 | 

