### PR TITLE
[NPU] Fix roi_align kernel

### DIFF
--- a/backends/npu/kernels/roi_align_kernel.cc
+++ b/backends/npu/kernels/roi_align_kernel.cc
@@ -29,7 +29,6 @@ void RoiAlignKernel(const Context& dev_ctx,
                     bool aligned,
                     phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
-
   auto roi_end_mode = 0;
   PADDLE_ENFORCE_EQ(
       aligned,
@@ -43,34 +42,92 @@ void RoiAlignKernel(const Context& dev_ctx,
                                 {"sample_num", sampling_ratio},
                                 {"roi_end_mode", roi_end_mode}};
 
-  auto stream = dev_ctx.stream();
-
-  // Combine boxes_num with boxes to get new boxes
-  // change boxes_num's datatype & resize
-  int dtype = static_cast<int>(
-      ConvertToNpuDtype(phi::DenseTensorMeta::DataType::FLOAT32));
+  int dtype = static_cast<int>(ConvertToNpuDtype(phi::DataType::FLOAT32));
   NPUAttributeMap attr_cast = {{"dst_type", dtype}};
-  phi::DenseTensor boxes_num_fp;
-  phi::DenseTensorMeta boxes_num_fp_meta = {
-      boxes.dtype(), phi::make_ddim({boxes.dims()[0], 1})};
-  boxes_num_fp.set_meta(boxes_num_fp_meta);
-  dev_ctx.template Alloc<T>(&boxes_num_fp);
 
-  const auto& runner_c =
-      NpuOpRunner("Cast", {*boxes_num}, {boxes_num_fp}, attr_cast);
-  runner_c.Run(stream);
+  auto stream = dev_ctx.stream();
+  int boxes_batch_size;
+  std::vector<float> roi_batch_id_data((boxes.dims()[0]));
+  int batch_size = x.dims()[0];
+  if (boxes_num) {
+    boxes_batch_size = boxes_num->numel();
+    PADDLE_ENFORCE_EQ(
+        boxes_batch_size,
+        batch_size,
+        phi::errors::InvalidArgument(
+            "The batch size of rois and the batch size of images "
+            " must be the same. But received the batch size of rois is %d, "
+            "and the batch size of images is %d",
+            boxes_batch_size,
+            batch_size));
+
+    std::vector<int> boxes_num_data;
+    TensorToVector(dev_ctx, *boxes_num, dev_ctx, &boxes_num_data);
+    int start = 0;
+    // transfrom boxes_num to roi_batch_id_data
+    for (int n = 0; n < boxes_batch_size; ++n) {
+      for (int i = start; i < start + boxes_num_data[n]; ++i) {
+        roi_batch_id_data[i] = static_cast<float>(n);
+      }
+      start += boxes_num_data[n];
+    }
+  } else {
+    auto lod = boxes.lod();
+    PADDLE_ENFORCE_EQ(
+        lod.empty(),
+        false,
+        phi::errors::InvalidArgument("Input(ROIs) Tensor of ROIAlignOp "
+                                     "does not contain LoD information."));
+    auto boxes_lod = lod.back();
+    boxes_batch_size = boxes_lod.size() - 1;
+    PADDLE_ENFORCE_EQ(
+        boxes_batch_size,
+        batch_size,
+        phi::errors::InvalidArgument(
+            "The boxes_batch_size and imgs "
+            "batch_size must be the same. But received boxes_batch_size = %d, "
+            "batch_size = %d",
+            boxes_batch_size,
+            batch_size));
+    int boxes_num_with_lod = boxes_lod[boxes_batch_size];
+    PADDLE_ENFORCE_EQ(
+        boxes.dims()[0],
+        boxes_num_with_lod,
+        phi::errors::InvalidArgument(
+            "The actual number of rois and the number of rois "
+            "provided from Input(RoIsLoD) in RoIAlign must be the same."
+            " But received actual number of rois is %d, and the number "
+            "of rois from RoIsLoD is %d",
+            boxes.dims()[0],
+            boxes_num_with_lod));
+    for (int n = 0; n < boxes_batch_size; ++n) {
+      for (std::size_t i = boxes_lod[n]; i < boxes_lod[n + 1]; ++i) {
+        roi_batch_id_data[i] = n;
+      }
+    }
+  }
+  phi::DenseTensor boxes_num_fp;
+  TensorFromVector<float>(dev_ctx, roi_batch_id_data, dev_ctx, &boxes_num_fp);
+  boxes_num_fp.Resize({boxes.dims()[0], 1});
+  phi::DenseTensor boxes_fp(boxes);
+  if (x.dtype() != phi::DataType::FLOAT32) {
+    // cast boxes dtype to float32
+    const auto& runner_c = NpuOpRunner("Cast", {boxes}, {boxes_fp}, attr_cast);
+    runner_c.Run(stream);
+  }
 
   // concate to make (N, 5)
   std::vector<phi::DenseTensor> x_list;
   x_list.push_back(boxes_num_fp);
-  x_list.push_back(boxes);
+  x_list.push_back(boxes_fp);
+
   auto axis = 1;
   // output of concate
   phi::DenseTensor boxes_N5;
-  phi::DenseTensorMeta boxes_N5_meta = {boxes.dtype(),
+  phi::DenseTensorMeta boxes_N5_meta = {phi::DataType::FLOAT32,
                                         phi::make_ddim({boxes.dims()[0], 5})};
   boxes_N5.set_meta(boxes_N5_meta);
-  dev_ctx.template Alloc<T>(&boxes_N5);
+  dev_ctx.template Alloc<float>(&boxes_N5);
 
   // attribute of concate
   auto EleNum = 2;
@@ -84,9 +141,37 @@ void RoiAlignKernel(const Context& dev_ctx,
       .AddAttrs(attr_concat);
   runner0.Run(stream);
 
-  const auto& runner =
-      NpuOpRunner("ROIAlign", {x, boxes_N5}, {*out}, attr_boxes);
-  runner.Run(stream);
+  if (x.dtype() == phi::DataType::FLOAT32) {
+    const auto& runner =
+        NpuOpRunner("ROIAlign", {x, boxes_N5}, {*out}, attr_boxes);
+    runner.Run(stream);
+  } else {
+    // cast x to float32
+    phi::DenseTensor x_fp;
+    phi::DenseTensorMeta x_meta = {phi::DataType::FLOAT32, x.dims()};
+    x_fp.set_meta(x_meta);
+    dev_ctx.template Alloc<float>(&x_fp);
+    const auto& runner_c1 = NpuOpRunner("Cast", {x}, {x_fp}, attr_cast);
+    runner_c1.Run(stream);
+
+    // cast out
+    phi::DenseTensor out_fp;
+    phi::DenseTensorMeta out_meta = {phi::DataType::FLOAT32, out->dims()};
+    out_fp.set_meta(out_meta);
+    dev_ctx.template Alloc<float>(&out_fp);
+    const auto& runner_c2 = NpuOpRunner("Cast", {*out}, {out_fp}, attr_cast);
+    runner_c2.Run(stream);
+
+    const auto& runner =
+        NpuOpRunner("ROIAlign", {x_fp, boxes_N5}, {out_fp}, attr_boxes);
+    runner.Run(stream);
+
+    // cast output tp given dtype
+    int src_dtype = static_cast<int>(ConvertToNpuDtype(out->dtype()));
+    const auto& runner_c3 =
+        NpuOpRunner("Cast", {out_fp}, {*out}, {{"dst_type", src_dtype}});
+    runner_c3.Run(stream);
+  }
 }
 
 template <typename T, typename Context>
@@ -102,9 +187,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                         bool aligned,
                         phi::DenseTensor* dx) {
   auto in_dims = x.dims();
-
   int rois_num = boxes.dims()[0];
-
   auto stream = dev_ctx.stream();
 
   if (!dx) {
@@ -118,64 +201,126 @@ void RoiAlignGradKernel(const Context& dev_ctx,
       phi::errors::InvalidArgument(
           "ROIAlignGradNPU only support Aligned attribute equaled to False"));
 
-  PADDLE_ENFORCE_EQ(
-      boxes.dtype(),
-      phi::DenseTensorMeta::DataType::FLOAT32,
-      phi::errors::InvalidArgument(
-          "ROIAlignGradNPU only support ROIs type equaled to FP32."));
+  //   PADDLE_ENFORCE_EQ(
+  //       boxes.dtype(),
+  //       phi::DenseTensorMeta::DataType::FLOAT32,
+  //       phi::errors::InvalidArgument(
+  //           "ROIAlignGradNPU only support ROIs type equaled to FP32."));
+
+  int dtype = static_cast<int>(ConvertToNpuDtype(phi::DataType::FLOAT32));
+  NPUAttributeMap attr_cast = {{"dst_type", dtype}};
+
+  int boxes_batch_size;
+  int batch_size = x.dims()[0];
+  std::vector<float> box_batch_id_data((boxes.dims()[0]));
+
+  if (boxes_num) {
+    boxes_batch_size = boxes_num->numel();
+    std::vector<int> boxes_num_data;
+    TensorToVector(dev_ctx, *boxes_num, dev_ctx, &boxes_num_data);
+    int start = 0;
+    // transfrom boxes_num to box_batch_id_data
+    for (int n = 0; n < boxes_batch_size; ++n) {
+      for (int i = start; i < start + boxes_num_data[n]; ++i) {
+        box_batch_id_data[i] = static_cast<float>(n);
+      }
+      start += boxes_num_data[n];
+    }
+  } else {
+    auto boxes_lod = boxes.lod().back();
+    boxes_batch_size = boxes_lod.size() - 1;
+    for (int n = 0; n < boxes_batch_size; ++n) {
+      for (std::size_t i = boxes_lod[n]; i < boxes_lod[n + 1]; ++i) {
+        box_batch_id_data[i] = n;
+      }
+    }
+  }
+  phi::DenseTensor boxes_num_fp;
+  TensorFromVector<float>(dev_ctx, box_batch_id_data, dev_ctx, &boxes_num_fp);
+  boxes_num_fp.Resize({boxes.dims()[0], 1});
+  phi::DenseTensor boxes_fp(boxes);
+  if (x.dtype() != phi::DataType::FLOAT32) {
+    // cast boxes dtype to float32
+    const auto& runner_c = NpuOpRunner("Cast", {boxes}, {boxes_fp}, attr_cast);
+    runner_c.Run(stream);
+  }
 
   // Cast boxes_num to fp32 tensor
   phi::DenseTensor boxes_N5;
-  boxes_N5.Resize({rois_num, 5});
-  dev_ctx.template Alloc<T>(&boxes_N5);
-  phi::DenseTensor boxes_num_fp;
-  boxes_num_fp.Resize(boxes_num->dims());
-  dev_ctx.template Alloc<T>(&boxes_num_fp);
+  phi::DenseTensorMeta boxes_N5_meta = {phi::DataType::FLOAT32,
+                                        phi::make_ddim({rois_num, 5})};
+  boxes_N5.set_meta(boxes_N5_meta);
+  dev_ctx.template Alloc<float>(&boxes_N5);
 
-  int nputype_fp32 = static_cast<int>(
-      ConvertToNpuDtype(phi::DenseTensorMeta::DataType::FLOAT32));
-  const auto& runner_cast = NpuOpRunner(
-      "Cast", {*boxes_num}, {boxes_num_fp}, {{"dst_type", nputype_fp32}});
-  runner_cast.Run(stream);
-  boxes_num_fp.Resize({rois_num, 1});
-
-  // Combine *ROIsNum with ROIs to get new ROIs
   std::vector<phi::DenseTensor> x_list;
   x_list.push_back(boxes_num_fp);
-  x_list.push_back(boxes);
+  x_list.push_back(boxes_fp);
   const auto& runner_concat = NpuOpRunner(
       "ConcatD", {x_list}, {boxes_N5}, {{"N", 2}, {"concat_dim", 1}});
   runner_concat.Run(stream);
 
-  //  Call ascend RoiAlignGrad function
   int roi_end_mode = 0;
-  const auto& runner_roi_align_grad =
-      NpuOpRunner("ROIAlignGrad",
-                  {out_grad, boxes_N5},
-                  {*dx},
-                  {{"xdiff_shape", phi::vectorize<int>(in_dims)},
-                   {"pooled_width", pooled_width},
-                   {"pooled_height", pooled_height},
-                   {"spatial_scale", spatial_scale},
-                   {"sample_num", sampling_ratio},
-                   {"roi_end_mode", roi_end_mode}});
-  runner_roi_align_grad.Run(stream);
+  if (x.dtype() == phi::DataType::FLOAT32) {
+    const auto& runner_roi_align_grad =
+        NpuOpRunner("ROIAlignGrad",
+                    {out_grad, boxes_N5},
+                    {*dx},
+                    {{"xdiff_shape", phi::vectorize<int>(in_dims)},
+                     {"pooled_width", pooled_width},
+                     {"pooled_height", pooled_height},
+                     {"spatial_scale", spatial_scale},
+                     {"sample_num", sampling_ratio},
+                     {"roi_end_mode", roi_end_mode}});
+    runner_roi_align_grad.Run(stream);
+  } else {
+    // cast out_grad
+    phi::DenseTensor out_grad_fp;
+    phi::DenseTensorMeta out_grad_meta = {phi::DataType::FLOAT32,
+                                          out_grad.dims()};
+    out_grad_fp.set_meta(out_grad_meta);
+    dev_ctx.template Alloc<float>(&out_grad_fp);
+    const auto& runner_c1 =
+        NpuOpRunner("Cast", {out_grad}, {out_grad_fp}, attr_cast);
+    runner_c1.Run(stream);
+
+    // cast output
+    phi::DenseTensor out_fp;
+    phi::DenseTensorMeta out_meta = {phi::DataType::FLOAT32, dx->dims()};
+    out_fp.set_meta(out_meta);
+    dev_ctx.template Alloc<float>(&out_fp);
+    const auto& runner_c2 = NpuOpRunner("Cast", {*dx}, {out_fp}, attr_cast);
+    runner_c2.Run(stream);
+
+    //  Call ascend RoiAlignGrad function
+    int roi_end_mode = 0;
+    const auto& runner_roi_align_grad =
+        NpuOpRunner("ROIAlignGrad",
+                    {out_grad_fp, boxes_N5},
+                    {out_fp},
+                    {{"xdiff_shape", phi::vectorize<int>(in_dims)},
+                     {"pooled_width", pooled_width},
+                     {"pooled_height", pooled_height},
+                     {"spatial_scale", spatial_scale},
+                     {"sample_num", sampling_ratio},
+                     {"roi_end_mode", roi_end_mode}});
+    runner_roi_align_grad.Run(stream);
+
+    // cast output to given dtype
+    int src_dtype = static_cast<int>(ConvertToNpuDtype(dx->dtype()));
+    const auto& runner_c3 =
+        NpuOpRunner("Cast", {out_fp}, {*dx}, {{"dst_type", src_dtype}});
+    runner_c3.Run(stream);
+  }
 }
 
 }  // namespace custom_kernel
 
-PD_REGISTER_PLUGIN_KERNEL(roi_align,
-                          npu,
-                          ALL_LAYOUT,
-                          custom_kernel::RoiAlignKernel,
-                          float,
-                          double,
-                          int) {}
+PD_REGISTER_PLUGIN_KERNEL(
+    roi_align, npu, ALL_LAYOUT, custom_kernel::RoiAlignKernel, float, double) {}
 
 PD_REGISTER_PLUGIN_KERNEL(roi_align_grad,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::RoiAlignGradKernel,
                           float,
-                          double,
-                          int) {}
+                          double) {}


### PR DESCRIPTION
### 问题说明：
在运行PaddleDetection TIPC的时候，发现运行至roi_align算子会出现ACL ERROR的问题，经梳理roi_align逻辑发现，原roi_align算子与其单测逻辑有问题，具体说明如下：

- Pytorch中roi_align算子定义如下：

<img width="877" alt="f5f4dd7848bc346e0d43a15003ab2400" src="https://user-images.githubusercontent.com/45005871/202103798-99a574e7-0fa2-4fdd-8886-4f7593c6dbbe.png">

- Paddle中roi_align算子定义如下：

<img width="875" alt="9eeab9c0b499a7f21841f0ee5b588cce" src="https://user-images.githubusercontent.com/45005871/202103871-2326828a-eba0-4b42-b64e-12fe1a858b88.png">

- 昇腾中ROIAlign算子定义如下：

![image](https://user-images.githubusercontent.com/45005871/202104013-e62f112a-230a-4efb-a37a-4b7ef2dc00ef.png)

经确认，昇腾中ROIAlign算子与torch roi_align算子定义一致，即输入为features, rois, rois_n，其中rois shape为(N, 5)，第一列代表多batch情况下每个box对应的batch id，而paddle的boxes_num表示每个batch box的个数，需要进行转换；

举例说明：
Paddle中boxes_num为[3, 2]，对应于torch中rois第一列为[0, 0, 0, 1, 1]

### 具体修改
1. 增加了对于是否存在boxes_num输入的判断；
2. 增加了boxes, boxes_num向rois转换的逻辑；
3. 增加了对于double类型的支持，CANN中ROIAlign仅支持float32输入，对输入的double类型进行转换，前向单测可满足要求，反向单测需要调整相对精度范围；

具体修改将在代码处进行说明