### PR TITLE
[NPU]fix reduce max kernel

### DIFF
--- a/backends/npu/kernels/reduce_max_kernel.cc
+++ b/backends/npu/kernels/reduce_max_kernel.cc
@@ -132,7 +132,7 @@ void MaxGradKernel(const Context& dev_ctx,
   // compare
   phi::DenseTensor equal_cond;
   equal_cond.Resize(x_grad->dims());
-  dev_ctx.template Alloc<T>(&equal_cond);
+  dev_ctx.template Alloc<bool>(&equal_cond);
   const auto& r_equal =
       NpuOpRunner("Equal", {x, transformed_out}, {equal_cond}, {});
   r_equal.Run(stream);


### PR DESCRIPTION
equal_cond应为bool类型，这里错将其初始化为T类型，导致多个模型训练时出现aicpu timeout问题。