### PR TITLE
[NPU] update MemcpyD2H

### DIFF
--- a/backends/npu/kernels/memcpy_kernel.cc
+++ b/backends/npu/kernels/memcpy_kernel.cc
@@ -55,13 +55,6 @@ void MemcpyD2HKernel(const Context& dev_ctx,
                      const phi::DenseTensor& x,
                      int dst_place_type,
                      phi::DenseTensor* out) {
-  if (out->numel() == 0) {
-    phi::CPUContext dev_ctx_cpu;
-    dev_ctx_cpu.SetZeroAllocator(&(dev_ctx.GetHostAllocator()));
-    dev_ctx_cpu.template Alloc<T>(out);
-  } else {
-    dev_ctx.template HostAlloc<T>(out);
-  }
   TensorCopy(dev_ctx, x, false, out, phi::CPUPlace());
   dev_ctx.Wait();
 }


### PR DESCRIPTION
custom_device 临时修改PR：https://github.com/PaddlePaddle/PaddleCustomDevice/pull/178
Paddle框架为解决此问题，新增host_zero_allocator，可解决memcpyD2H问题，[PR](https://github.com/PaddlePaddle/Paddle/pull/48108)
因此撤销custom_device层面修改