### PR TITLE
[NPU]fix equal kernel

### DIFF
--- a/backends/npu/kernels/compare_kernel.cc
+++ b/backends/npu/kernels/compare_kernel.cc
@@ -31,64 +31,28 @@ void EqualRawKernel(const Context& dev_ctx,
     transformed_y.set_meta(meta);
     if (x.dtype() == phi::DataType::BOOL) {
       dev_ctx.template Alloc<bool>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::INT16) {
       dev_ctx.template Alloc<int16_t>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::INT32) {
       dev_ctx.template Alloc<int>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::INT64) {
       dev_ctx.template Alloc<int64_t>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::FLOAT32) {
       dev_ctx.template Alloc<float>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::FLOAT16) {
       dev_ctx.template Alloc<phi::dtype::float16>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else if (x.dtype() == phi::DataType::FLOAT64) {
       dev_ctx.template Alloc<double>(&transformed_y);
-      const auto& cast_runner =
-          NpuOpRunner("Cast",
-                      {y},
-                      {transformed_y},
-                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
-      cast_runner.Run(stream);
     } else {
       phi::errors::InvalidArgument("Unsupported dtype %s for equal kernel",
                                    x.dtype());
     }
+    const auto& cast_runner =
+        NpuOpRunner("Cast",
+                    {y},
+                    {transformed_y},
+                    {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+    cast_runner.Run(stream);
   } else {
     transformed_y = y;
   }

--- a/backends/npu/kernels/compare_kernel.cc
+++ b/backends/npu/kernels/compare_kernel.cc
@@ -18,13 +18,83 @@ namespace custom_kernel {
 
 template <typename T, typename Context>
 void EqualRawKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 int axis,
-                 phi::DenseTensor* out) {
-  dev_ctx.template Alloc<bool>(out);
-  const auto& runner = NpuOpRunner("Equal", {x, y}, {*out}, {});
+                    const phi::DenseTensor& x,
+                    const phi::DenseTensor& y,
+                    int axis,
+                    phi::DenseTensor* out) {
   auto stream = dev_ctx.stream();
+  dev_ctx.template Alloc<bool>(out);
+
+  phi::DenseTensor transformed_x(x), transformed_y;
+  if (x.dtype() != y.dtype()) {
+    phi::DenseTensorMeta meta = {x.dtype(), y.dims()};
+    transformed_y.set_meta(meta);
+    if (x.dtype() == phi::DataType::BOOL) {
+      dev_ctx.template Alloc<bool>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::INT16) {
+      dev_ctx.template Alloc<int16_t>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::INT32) {
+      dev_ctx.template Alloc<int>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::INT64) {
+      dev_ctx.template Alloc<int64_t>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::FLOAT32) {
+      dev_ctx.template Alloc<float>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::FLOAT16) {
+      dev_ctx.template Alloc<phi::dtype::float16>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else if (x.dtype() == phi::DataType::FLOAT64) {
+      dev_ctx.template Alloc<double>(&transformed_y);
+      const auto& cast_runner =
+          NpuOpRunner("Cast",
+                      {y},
+                      {transformed_y},
+                      {{"dst_type", ConvertToNpuDtype(x.dtype())}});
+      cast_runner.Run(stream);
+    } else {
+      phi::errors::InvalidArgument("Unsupported dtype %s for equal kernel",
+                                   x.dtype());
+    }
+  } else {
+    transformed_y = y;
+  }
+
+  const auto& runner =
+      NpuOpRunner("Equal", {transformed_x, transformed_y}, {*out}, {});
   runner.Run(stream);
 }
 
@@ -38,10 +108,10 @@ void EqualKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void NotEqualRawKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    const phi::DenseTensor& y,
-                    int axis,
-                    phi::DenseTensor* out) {
+                       const phi::DenseTensor& x,
+                       const phi::DenseTensor& y,
+                       int axis,
+                       phi::DenseTensor* out) {
   dev_ctx.template Alloc<bool>(out);
   const auto& runner = NpuOpRunner("NotEqual", {x, y}, {*out}, {});
   auto stream = dev_ctx.stream();
@@ -50,19 +120,18 @@ void NotEqualRawKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void NotEqualKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 phi::DenseTensor* out) {
+                    const phi::DenseTensor& x,
+                    const phi::DenseTensor& y,
+                    phi::DenseTensor* out) {
   custom_kernel::NotEqualRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
-
 template <typename T, typename Context>
 void LessEqualRawKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     const phi::DenseTensor& y,
-                     int axis,
-                     phi::DenseTensor* out) {
+                        const phi::DenseTensor& x,
+                        const phi::DenseTensor& y,
+                        int axis,
+                        phi::DenseTensor* out) {
   dev_ctx.template Alloc<bool>(out);
   auto stream = dev_ctx.stream();
 
@@ -72,18 +141,18 @@ void LessEqualRawKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void LessEqualKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 phi::DenseTensor* out) {
+                     const phi::DenseTensor& x,
+                     const phi::DenseTensor& y,
+                     phi::DenseTensor* out) {
   custom_kernel::LessEqualRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
 template <typename T, typename Context>
 void LessThanRawKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    const phi::DenseTensor& y,
-                    int axis,
-                    phi::DenseTensor* out) {
+                       const phi::DenseTensor& x,
+                       const phi::DenseTensor& y,
+                       int axis,
+                       phi::DenseTensor* out) {
   dev_ctx.template Alloc<bool>(out);
   const auto& runner = NpuOpRunner("Less", {x, y}, {*out}, {});
   auto stream = dev_ctx.stream();
@@ -92,18 +161,18 @@ void LessThanRawKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void LessThanKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 phi::DenseTensor* out) {
+                    const phi::DenseTensor& x,
+                    const phi::DenseTensor& y,
+                    phi::DenseTensor* out) {
   custom_kernel::LessThanRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
 template <typename T, typename Context>
 void GreaterEqualRawKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& x,
-                        const phi::DenseTensor& y,
-                        int axis,
-                        phi::DenseTensor* out) {
+                           const phi::DenseTensor& x,
+                           const phi::DenseTensor& y,
+                           int axis,
+                           phi::DenseTensor* out) {
   dev_ctx.template Alloc<bool>(out);
   const auto& runner = NpuOpRunner("GreaterEqual", {x, y}, {*out}, {});
   auto stream = dev_ctx.stream();
@@ -112,18 +181,18 @@ void GreaterEqualRawKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void GreaterEqualKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 phi::DenseTensor* out) {
+                        const phi::DenseTensor& x,
+                        const phi::DenseTensor& y,
+                        phi::DenseTensor* out) {
   custom_kernel::GreaterEqualRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
 template <typename T, typename Context>
 void GreaterThanRawKernel(const Context& dev_ctx,
-                       const phi::DenseTensor& x,
-                       const phi::DenseTensor& y,
-                       int axis,
-                       phi::DenseTensor* out) {
+                          const phi::DenseTensor& x,
+                          const phi::DenseTensor& y,
+                          int axis,
+                          phi::DenseTensor* out) {
   dev_ctx.template Alloc<bool>(out);
   const auto& runner = NpuOpRunner("Greater", {x, y}, {*out}, {});
   auto stream = dev_ctx.stream();
@@ -132,9 +201,9 @@ void GreaterThanRawKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void GreaterThanKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 const phi::DenseTensor& y,
-                 phi::DenseTensor* out) {
+                       const phi::DenseTensor& x,
+                       const phi::DenseTensor& y,
+                       phi::DenseTensor* out) {
   custom_kernel::GreaterThanRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
@@ -175,7 +244,6 @@ PD_REGISTER_PLUGIN_KERNEL(not_equal,
                           float,
                           phi::dtype::float16,
                           double) {}
-
 
 PD_REGISTER_PLUGIN_KERNEL(not_equal_raw,
                           npu,

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -71,6 +71,20 @@ def create_test_class(op_type, typename, callback):
             out = op(x, y)
             self.assertEqual((out.numpy() == real_result).all(), True)
 
+        def test_dynamic_api_different_type(self):
+            if op_type != 'equal':
+                return
+            paddle.disable_static()
+            paddle.set_device('npu:0')
+            x = np.random.random(size=(10, 7)).astype(typename)
+            y = np.random.random(size=(10, 7)).astype('int32')
+            real_result = callback(x, y)
+            x = paddle.to_tensor(x, dtype=typename)
+            y = paddle.to_tensor(y, dtype='float32')
+            op = eval("paddle.%s" % (self.op_type))
+            out = op(x, y)
+            self.assertEqual((out.numpy() == real_result).all(), True)
+
         @unittest.skipIf(typename == 'float16', "float16 is not supported now")
         def test_broadcast_api_1(self):
             paddle.enable_static()


### PR DESCRIPTION
训练模型时遇到CANN算子Equal的两个输入x、y数据类型不同报错的问题，这里通过判断x、y数据类型是否相同，如果不同将y cast成x的数据类型来解决。