### PR TITLE
[NPU] reduce_prod modify

### DIFF
--- a/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
@@ -71,6 +71,19 @@ class TestNPUReduceProd3(TestNPUReduceProd):
         self.outputs = {'Out': self.inputs['X'].prod(axis=tuple([0]))}
 
 
+class TestNPUReduceProd4(TestNPUReduceProd):
+    def setUp(self):
+        self.op_type = "reduce_prod"
+        self.set_npu()
+        self.init_dtype()
+
+        self.inputs = {
+            'X': np.random.random((32, 888, 50, 2)).astype(self.dtype)
+        }
+        self.attrs = {'dim': [-1]}
+        self.outputs = {'Out': self.inputs['X'].prod(axis=tuple([-1]))}
+
+
 class TestNPUReduceProd6D(TestNPUReduceProd):
     def setUp(self):
         self.op_type = "reduce_prod"


### PR DESCRIPTION
npu ReduceProdD随shape增大性能退化严重，达到几十ms级别，不可接受。
此PR针对模型优化中的特殊case使用Split+Mul方式替换。
<img width="759" alt="image" src="https://user-images.githubusercontent.com/5997715/203791681-35032033-c25f-482d-a49c-6853547ca3ae.png">
经验证有明显性能收益，profiling数据如下：
![image](https://user-images.githubusercontent.com/5997715/203791938-459ac775-66e8-426f-aba4-374d792be254.png)
