### PR TITLE
Rename some kernel name

### DIFF
--- a/backends/mlu/kernels/activation_kernel.cc
+++ b/backends/mlu/kernels/activation_kernel.cc
@@ -133,9 +133,9 @@ void ReluGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void Relu6RawKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 float attr,
-                 phi::DenseTensor* out) {
+                    const phi::DenseTensor& x,
+                    float attr,
+                    phi::DenseTensor* out) {
   ActivationKernel<T, Context>(dev_ctx, x, 1.0, CNNL_ACTIVATION_RELU6, out);
 }
 
@@ -398,11 +398,11 @@ void ExpGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void HardSwishRawKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     float threshold,
-                     float scale,
-                     float offset,
-                     phi::DenseTensor* out) {
+                        const phi::DenseTensor& x,
+                        float threshold,
+                        float scale,
+                        float offset,
+                        phi::DenseTensor* out) {
   PADDLE_ENFORCE_EQ(
       threshold,
       6.0f,
@@ -434,7 +434,7 @@ template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,
                      const phi::DenseTensor& x,
                      phi::DenseTensor* out) {
-custom_kernel::HardSwishRawKernel<T, Context>(dev_ctx, x, 6, 6, 3, out);
+  custom_kernel::HardSwishRawKernel<T, Context>(dev_ctx, x, 6, 6, 3, out);
 }
 
 template <typename T, typename Context>
@@ -690,21 +690,21 @@ PD_REGISTER_PLUGIN_KERNEL(exp_grad,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish,
+PD_REGISTER_PLUGIN_KERNEL(hardswish,
                           CustomMLU,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishKernel,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish_raw,
+PD_REGISTER_PLUGIN_KERNEL(hardswish_raw,
                           CustomMLU,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishRawKernel,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish_grad,
+PD_REGISTER_PLUGIN_KERNEL(hardswish_grad,
                           CustomMLU,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishGradKernel,

--- a/backends/mlu/kernels/arg_max_kernel.cc
+++ b/backends/mlu/kernels/arg_max_kernel.cc
@@ -117,7 +117,7 @@ void ArgMaxKernel(const Context& dev_ctx,
 
 }  // namespace custom_kernel
 
-PD_REGISTER_PLUGIN_KERNEL(arg_max,
+PD_REGISTER_PLUGIN_KERNEL(argmax,
                           CustomMLU,
                           ALL_LAYOUT,
                           custom_kernel::ArgMaxKernel,

--- a/backends/npu/kernels/activation_kernel.cc
+++ b/backends/npu/kernels/activation_kernel.cc
@@ -106,8 +106,8 @@ void ExpGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void FloorKernel(const Context& dev_ctx,
-               const phi::DenseTensor& x,
-               phi::DenseTensor* out) {
+                 const phi::DenseTensor& x,
+                 phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -117,14 +117,14 @@ void FloorKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void FloorGradKernel(const Context& dev_ctx,
-                   const phi::DenseTensor& dout,
-                   phi::DenseTensor* dx) {
+                     const phi::DenseTensor& dout,
+                     phi::DenseTensor* dx) {
   dev_ctx.template Alloc<T>(dx);
   auto stream = dev_ctx.stream();
-  const auto& runner = NpuOpRunner("Fills", {*dx}, {*dx}, {{"value", static_cast<float>(0)}});
+  const auto& runner =
+      NpuOpRunner("Fills", {*dx}, {*dx}, {{"value", static_cast<float>(0)}});
   runner.Run(stream);
 }
-
 
 template <typename T, typename Context>
 void SinKernel(const Context& dev_ctx,
@@ -140,9 +140,9 @@ void SinKernel(const Context& dev_ctx,
 // Swish = x * sigmoid(beta * x)
 template <typename T, typename Context>
 void SwishRawKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 float beta,
-                 phi::DenseTensor* out) {
+                    const phi::DenseTensor& x,
+                    float beta,
+                    phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -234,9 +234,9 @@ void ReluGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void Relu6RawKernel(const Context& dev_ctx,
-                 const phi::DenseTensor& x,
-                 float attr,
-                 phi::DenseTensor* out) {
+                    const phi::DenseTensor& x,
+                    float attr,
+                    phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   const auto& runner = NpuOpRunner("Relu6", {x}, {*out}, {});
 
@@ -579,11 +579,11 @@ void HardSigmoidGradKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void HardSwishRawKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     float threshold,
-                     float scale,
-                     float offset,
-                     phi::DenseTensor* out) {
+                        const phi::DenseTensor& x,
+                        float threshold,
+                        float scale,
+                        float offset,
+                        phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -650,7 +650,7 @@ template <typename T, typename Context>
 void HardSwishKernel(const Context& dev_ctx,
                      const phi::DenseTensor& x,
                      phi::DenseTensor* out) {
-custom_kernel::HardSwishRawKernel<T, Context>(dev_ctx, x, 6, 6, 3, out);
+  custom_kernel::HardSwishRawKernel<T, Context>(dev_ctx, x, 6, 6, 3, out);
 }
 
 template <typename T, typename Context>
@@ -1020,21 +1020,21 @@ PD_REGISTER_PLUGIN_KERNEL(hard_sigmoid_grad,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish,
+PD_REGISTER_PLUGIN_KERNEL(hardswish,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishKernel,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish_raw,
+PD_REGISTER_PLUGIN_KERNEL(hardswish_raw,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishRawKernel,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(hard_swish_grad,
+PD_REGISTER_PLUGIN_KERNEL(hardswish_grad,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::HardSwishGradKernel,

--- a/backends/npu/kernels/arg_min_max_kernel.cc
+++ b/backends/npu/kernels/arg_min_max_kernel.cc
@@ -77,14 +77,14 @@ void ArgMaxKernel(const Context& dev_ctx,
 
 }  // namespace custom_kernel
 
-PD_REGISTER_PLUGIN_KERNEL(arg_min,
+PD_REGISTER_PLUGIN_KERNEL(argmin,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::ArgMinKernel,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(arg_max,
+PD_REGISTER_PLUGIN_KERNEL(argmax,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::ArgMaxKernel,


### PR DESCRIPTION
[PR48355](https://github.com/PaddlePaddle/Paddle/pull/48355)中对`argmin`, `argmax`, `hardswish`, `hardtanh`四个算子的Kernel名进行了规划化重命名，使之与Python API名保持统一。本PR中更新了上述算子NPU和MLU的kernel名。