### PR TITLE
[NPU] Fills op replace

### DIFF
--- a/backends/npu/kernels/full_kernel.cc
+++ b/backends/npu/kernels/full_kernel.cc
@@ -25,16 +25,14 @@ void FullKernel(const Context& dev_ctx,
                 phi::DataType dtype,
                 phi::DenseTensor* out) {
   auto shape_vec = shape.GetData();
-  out->ResizeAndAllocate(phi::make_ddim(shape_vec));
+  auto out_dim = phi::make_ddim(shape_vec);
+  out->ResizeAndAllocate(out_dim);
   dev_ctx.template Alloc<T>(out);
   aclrtStream stream = static_cast<aclrtStream>(dev_ctx.stream());
 
-  NpuOpRunner runner;
-  runner.SetType("Fills")
-      .AddInput(*out)
-      .AddOutput(*out)
-      .AddAttrs({{"value", val.to<float>()}})
-      .Run(stream);
+  FillNpuTensorWithConstant<T>(out, dev_ctx, static_cast<T>(val.to<T>()));
+
+  out->Resize(out_dim);
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
Fills will be compiled when its attr changes, which use too long time in every iter.
This PR uses `FillNpuTensorWithConstant` to replace it to save compiling time.

![image](https://user-images.githubusercontent.com/5997715/204226015-bf410ebc-1c5b-4984-ab56-90486926031d.png)

related: https://gitee.com/ascend/modelzoo/issues/I62ZPE

aarch64
<img width="900" alt="8aba173b95c5e7bd4ee3b879dd60b486" src="https://user-images.githubusercontent.com/5997715/204515146-973ebd64-1a94-4c00-bf59-e328c25fc352.png">

x86_64
<img width="874" alt="6f85b6e96be944e0a097224d9872dbef" src="https://user-images.githubusercontent.com/5997715/204515162-760ad6cb-e83f-4d5b-b8a1-94511947160f.png">
