### PR TITLE
[NPU]fix masked_select kernel

### DIFF
--- a/backends/npu/kernels/masked_select_kernel.cc
+++ b/backends/npu/kernels/masked_select_kernel.cc
@@ -66,6 +66,8 @@ void MaskedSelectKernel(const Context& dev_ctx,
     // wait for ReduceSum complete
     dev_ctx.Wait();
     TensorToVector(dev_ctx, out_size, dev_ctx, &out_size_vec);
+    // wait for copy complete
+    dev_ctx.Wait();
   }
 
   out->Resize(phi::make_ddim({out_size_vec[0]}));
@@ -202,7 +204,9 @@ PD_REGISTER_PLUGIN_KERNEL(masked_select,
                           phi::dtype::float16,
                           float,
                           int,
-                          int64_t) {}
+                          int64_t) {
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
+}
 
 PD_REGISTER_PLUGIN_KERNEL(masked_select_grad,
                           npu,
@@ -211,4 +215,6 @@ PD_REGISTER_PLUGIN_KERNEL(masked_select_grad,
                           phi::dtype::float16,
                           float,
                           int,
-                          int64_t) {}
+                          int64_t) {
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
+}


### PR DESCRIPTION
训练DLRM模型时遇到reshape前后size不一致的问题，发现是masked_select kernel计算输出的元素个数时出错。具体错误原因是没有等待TensorToVec拷贝完就访问了vector的值。本PR解决了此问题。
且masked_select/masked_select_grad的第二个输入mask数据类型固定为bool，这里在注册时也进行了限制。

已在 #255 解决，关闭此PR