### PR TITLE
[NPU] replace FillNpuTensorWithConstant with ZerosLike Cann OP in gather_grad

### DIFF
--- a/backends/npu/kernels/gather_kernel.cc
+++ b/backends/npu/kernels/gather_kernel.cc
@@ -62,7 +62,9 @@ void GatherGradKernel(const Context& dev_ctx,
   zeroslike_xout.set_meta(meta);
   dev_ctx.template Alloc<T>(&zeroslike_xout);
 
-  FillNpuTensorWithConstant<T>(&zeroslike_xout, dev_ctx, static_cast<T>(0));
+  const auto& runner_tensor_zeros =
+      NpuOpRunner("ZerosLike", {*x_grad}, {zeroslike_xout}, {});
+  runner_tensor_zeros.Run(stream);
   zeroslike_xout.Resize(x.dims());
 
   // step3: scatter(x_grad)


### PR DESCRIPTION
gather_grad op中调用了FillNpuTensorWithConstant，当输入Tensor的shape很大时，调用的aclrtMallocHost与aclrtMallocFree耗时非常长，如下图红框中的是FillNpuTensorWithConstant引起的aclrtMallocHost与aclrtMallocFree：

![图片](https://user-images.githubusercontent.com/26408901/205571171-ea9aa036-88a4-4a1c-9343-1bffce12bd79.png)

将gather_grad op中的FillNpuTensorWithConstant替换为调用`ZerosLike` CANN OP，可以发现该耗时没有了：

<img width="507" alt="图片" src="https://user-images.githubusercontent.com/26408901/205571635-2d7614be-0d19-49bc-89fb-4a61479bcabb.png">
