### PR TITLE
[NPU] update npu ci script to skip failure ut, test=develop

### DIFF
--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -1,0 +1,5 @@
+disable_ut_npu
+test_assign_value_op_npu
+test_log_loss_op_npu
+test_zero_dim_tensor_npu
+test_argsort_op_npu


### PR DESCRIPTION
对于目前 NPU CI 中尚未修复的单测，先加入 disable_ut_npu 文件，并修改 pr_ci_npu.sh 脚本使其在运行的时候读取 disable_ut_npu 文件中的内容跳过这些单测。

后续待这些单测修复之后，从 disable_ut_npu 文件中删除对应的单测名称即可。

注意：disable_ut_npu文件修改和单测修复代码一起提交，来保证单测被成功修复。

