### PR TITLE
add multiple streams support within the kernel

### DIFF
--- a/backends/npu/runtime/runtime.cc
+++ b/backends/npu/runtime/runtime.cc
@@ -16,12 +16,83 @@
 
 #include <cstring>
 #include <iostream>
+#include <list>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "glog/logging.h"
+
+aclrtStream SecondaryStream::Get(aclrtStream aicore_stream) {
+  CHECK(aicpu_streams.find(aicore_stream) != aicpu_streams.cend());
+  return aicpu_streams[aicore_stream];
+}
+
+void SecondaryStream::Create(aclrtStream aicore_stream) {
+  CHECK(aicpu_streams.find(aicore_stream) == aicpu_streams.cend());
+  aclrtStream aicpu_stream;
+  ACL_CHECK(aclrtCreateStream(&aicpu_stream));
+  aicpu_streams[aicore_stream] = aicpu_stream;
+}
+
+void SecondaryStream::Destroy(aclrtStream aicore_stream) {
+  CHECK(aicpu_streams.find(aicore_stream) != aicpu_streams.cend());
+  ACL_CHECK(aclrtDestroyStream(aicpu_streams[aicore_stream]));
+  aicpu_streams.erase(aicore_stream);
+}
+
+void SecondaryStream::RecordBefore(aclrtStream aicore_stream) {
+  static std::list<aclrtEvent> events;
+
+  CHECK(aicpu_streams.find(aicore_stream) != aicpu_streams.cend());
+  auto aicpu_stream = aicpu_streams[aicore_stream];
+
+  for (auto iter = events.begin(); iter != events.end();) {
+    auto event = *iter;
+    aclrtEventStatus status = ACL_EVENT_STATUS_COMPLETE;
+    ACL_CHECK(aclrtQueryEvent(event, &status));
+    if (status == ACL_EVENT_STATUS_COMPLETE) {
+      ACL_CHECK(aclrtDestroyEvent(event));
+      iter = events.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+  {
+    aclrtEvent event;
+    ACL_CHECK(aclrtCreateEvent(&event));
+    ACL_CHECK(aclrtRecordEvent(event, aicpu_stream));
+    ACL_CHECK(aclrtStreamWaitEvent(aicore_stream, event));
+    events.push_back(event);
+  }
+}
+
+void SecondaryStream::RecordAfter(aclrtStream aicore_stream) {
+  static std::list<aclrtEvent> events;
+
+  CHECK(aicpu_streams.find(aicore_stream) != aicpu_streams.cend());
+  auto aicpu_stream = aicpu_streams[aicore_stream];
+
+  for (auto iter = events.begin(); iter != events.end();) {
+    auto event = *iter;
+    aclrtEventStatus status = ACL_EVENT_STATUS_COMPLETE;
+    ACL_CHECK(aclrtQueryEvent(event, &status));
+    if (status == ACL_EVENT_STATUS_COMPLETE) {
+      ACL_CHECK(aclrtDestroyEvent(event));
+      iter = events.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+  {
+    aclrtEvent event;
+    ACL_CHECK(aclrtCreateEvent(&event));
+    ACL_CHECK(aclrtRecordEvent(event, aicore_stream));
+    ACL_CHECK(aclrtStreamWaitEvent(aicpu_stream, event));
+    events.push_back(event);
+  }
+}
 
 class AlignnedAllocator {
  public:
@@ -277,11 +348,13 @@ C_Status HostDeallocate(const C_Device device, void *ptr, size_t size) {
 
 C_Status CreateStream(const C_Device device, C_Stream *stream) {
   ACL_CHECK(aclrtCreateStream(reinterpret_cast<aclrtStream *>(stream)));
+  SecondaryStream::Instance().Create(*reinterpret_cast<aclrtStream *>(stream));
   return C_SUCCESS;
 }
 
 C_Status DestroyStream(const C_Device device, C_Stream stream) {
   ACL_CHECK(aclrtDestroyStream(reinterpret_cast<aclrtStream>(stream)));
+  SecondaryStream::Instance().Destroy(reinterpret_cast<aclrtStream>(stream));
   return C_SUCCESS;
 }
 

--- a/backends/npu/runtime/runtime.h
+++ b/backends/npu/runtime/runtime.h
@@ -42,6 +42,7 @@
 
 #define ACL_CHECK(func) RUNTIME_CHECK(func, ACL_ERROR_NONE)
 #define HCCL_CHECK(func) RUNTIME_CHECK(func, HCCL_SUCCESS)
+#define CHECK(func) RUNTIME_CHECK(func, true)
 
 #define ENV_Cat(x, y) x##y
 #define ENV_Str(x) #x
@@ -190,4 +191,31 @@ class AscendProfiler {
   aclrtStream stream_ = nullptr;
 
   bool start_ = false;
+};
+
+struct SecondaryStream {
+  static SecondaryStream &Instance() {
+    static SecondaryStream ins;
+    return ins;
+  }
+
+  aclrtStream Get(aclrtStream aicore_stream);
+
+  void Create(aclrtStream aicore_stream);
+
+  void Destroy(aclrtStream aicore_stream);
+
+  // aicpu  --
+  //           \
+  // aicore ----  aicore
+  void RecordBefore(aclrtStream aicore_stream);
+
+  //          -- aicpu
+  //        /
+  // aicore ---- aicore
+  void RecordAfter(aclrtStream aicore_stream);
+
+ private:
+  SecondaryStream() = default;
+  std::unordered_map<aclrtStream, aclrtStream> aicpu_streams;
 };


### PR DESCRIPTION
支持 kernel 内使用多 stream，目前只有 2 个stream，默认 stream 用于 AICORE 计算，其对应的第 2 个 stream 用于 AICPU 计算

1. 当某个 CANN OP 是 AICPU OP，且不依赖 AICORE 的计算结果

```bash
AICPU ---
           \
AICORE ----  AICORE
```

2. 当某个 CANN OP 是 AICPU OP，且不被 AICORE  OP 依赖

```bash
        --- AICPU
       /
AICORE ---  AICORE 

```

背景参考 https://toscode.gitee.com/ascend/modelzoo/issues/I48DKD
