### PR TITLE
[NPU] Fix_assign

### DIFF
--- a/backends/npu/kernels/assign_kernel.cc
+++ b/backends/npu/kernels/assign_kernel.cc
@@ -22,10 +22,7 @@ void AssignKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
                   phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
-
-  const auto& runner = NpuOpRunner("Assign", {*out, x}, {*out}, {});
-  auto stream = dev_ctx.stream();
-  runner.Run(stream);
+  TensorCopy(dev_ctx, x, true, out);
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
修改assign写法，由于Input.AT(0)设置了set_allbackends, 这里kernel写法与gpu保持对齐，