### PR TITLE
[NPU] auto re-install plugin wheel in compile.sh

### DIFF
--- a/backends/npu/tools/compile.sh
+++ b/backends/npu/tools/compile.sh
@@ -16,6 +16,9 @@
 
 set -ex
 
+# uninstall plugin wheel
+pip uninstall paddle-custom-npu -y
+
 SOURCE_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 
 # prepare build directory
@@ -68,3 +71,6 @@ if [ "$make_error" != 0 ];then
     echo "Make Error Found !!!"
     exit 7;
 fi
+
+# re-install plugin wheel
+pip install dist/*.whl


### PR DESCRIPTION
Errors are often reported while compiling with updated paddle wheel but old paddle-custom-npu, because we do not uninstall paddle-custom-npu before start compiling(which will import paddle and then old plugin will be loaded accordingly).

![1653b6dff7aa9af84e9ddf0b85a1226c](https://user-images.githubusercontent.com/5997715/208357736-f23ac9c0-08d3-42ab-8bb3-9d4e08a3d281.jpg)


This PR adds uninstall wheel command before compiling and re-install wheel after correctly compiled.