### PR TITLE
[NPU] replace ReduceSumD with ReduceSum

### DIFF
--- a/backends/npu/kernels/elementwise_add_kernel.cc
+++ b/backends/npu/kernels/elementwise_add_kernel.cc
@@ -164,11 +164,12 @@ void AddGradKernel(const Context& dev_ctx,
       if (!reduce_axes.empty()) {
         phi::DenseTensor tmp(*dy);
         tmp.Resize(phi::make_ddim(dst_dims_vec));
-        const auto& runner =
-            NpuOpRunner("ReduceSumD",
-                        {dout},
-                        {tmp},
-                        {{"axes", reduce_axes}, {"keep_dims", false}});
+        NpuOpRunner runner;
+        runner.SetType("ReduceSum");
+        runner.AddInput(dout);
+        runner.AddInput(dev_ctx, std::move(reduce_axes));
+        runner.AddOutput(tmp);
+        runner.AddAttr("keep_dims", false);
         runner.Run(stream);
       }
     } else {


### PR DESCRIPTION
ReduceSumD will raise error when input's type is double. Here, we use ReduceSum to replace it.