### PR TITLE
[NPU] fix clip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ kernel_meta*/
 
 # ignore Paddle change
 Paddle/
+
+# ignoer CMakeFiles
+backends/npu/tools/CMakeFiles

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ kernel_meta*/
 
 # ignore Paddle change
 Paddle/
-
-# ignoer CMakeFiles
-backends/npu/tools/CMakeFiles

--- a/backends/npu/tests/unittests/test_clip_op_npu.py
+++ b/backends/npu/tests/unittests/test_clip_op_npu.py
@@ -19,14 +19,13 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-import sys
 from tests.op_test import OpTest
 
 
 class TestClipOp(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
@@ -37,23 +36,23 @@ class TestClipOp(OpTest):
 
         self.op_type = "clip"
         self.attrs = {}
-        self.attrs['min'] = self.min
-        self.attrs['max'] = self.max
-        if 'Min' in self.inputs:
-            min_v = self.inputs['Min']
+        self.attrs["min"] = self.min
+        self.attrs["max"] = self.max
+        if "Min" in self.inputs:
+            min_v = self.inputs["Min"]
         else:
-            min_v = self.attrs['min']
+            min_v = self.attrs["min"]
 
-        if 'Max' in self.inputs:
-            max_v = self.inputs['Max']
+        if "Max" in self.inputs:
+            max_v = self.inputs["Max"]
         else:
-            max_v = self.attrs['max']
+            max_v = self.attrs["max"]
 
         input = np.random.random(self.shape).astype("float32")
         input[np.abs(input - min_v) < self.max_relative_error] = 0.5
         input[np.abs(input - max_v) < self.max_relative_error] = 0.5
-        self.inputs['X'] = input
-        self.outputs = {'Out': np.clip(self.inputs['X'], min_v, max_v)}
+        self.inputs["X"] = input
+        self.outputs = {"Out": np.clip(self.inputs["X"], min_v, max_v)}
 
     def test_check_output(self):
         paddle.enable_static()
@@ -62,15 +61,15 @@ class TestClipOp(OpTest):
 
     def test_check_grad_normal(self):
         paddle.enable_static()
-        self.check_grad_with_place(self.place, ['X'], 'Out')
+        self.check_grad_with_place(self.place, ["X"], "Out")
         paddle.disable_static()
 
     def initTestCase(self):
         self.shape = (4, 10, 10)
         self.max = 0.8
         self.min = 0.3
-        self.inputs['Max'] = np.array([0.8]).astype('float32')
-        self.inputs['Min'] = np.array([0.1]).astype('float32')
+        self.inputs["Max"] = np.array([0.8]).astype("float32")
+        self.inputs["Min"] = np.array([0.1]).astype("float32")
 
 
 class TestCase1(TestClipOp):
@@ -99,8 +98,8 @@ class TestCase4(TestClipOp):
         self.shape = (4, 8, 8)
         self.max = 0.7
         self.min = 0.2
-        self.inputs['Max'] = np.array([0.8]).astype('float32')
-        self.inputs['Min'] = np.array([0.3]).astype('float32')
+        self.inputs["Max"] = np.array([0.8]).astype("float32")
+        self.inputs["Min"] = np.array([0.3]).astype("float32")
 
 
 class TestCase5(TestClipOp):
@@ -121,11 +120,6 @@ class TestClipOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_Variable)
 
-            def test_dtype():
-                x2 = fluid.layers.data(name='x2', shape=[1], dtype='int32')
-                fluid.layers.clip(x=x2, min=-1.0, max=1.0)
-
-            self.assertRaises(TypeError, test_dtype)
         paddle.disable_static()
 
 
@@ -136,14 +130,16 @@ class TestClipAPI(unittest.TestCase):
     def test_clip(self):
         paddle.enable_static()
         data_shape = [1, 9, 9, 4]
-        data = np.random.random(data_shape).astype('float32')
-        images = fluid.data(name='image', shape=data_shape, dtype='float32')
-        min = fluid.data(name='min', shape=[1], dtype='float32')
-        max = fluid.data(name='max', shape=[1], dtype='float32')
+        data = np.random.random(data_shape).astype("float32")
+        images = fluid.data(name="image", shape=data_shape, dtype="float32")
+        min = fluid.data(name="min", shape=[1], dtype="float32")
+        max = fluid.data(name="max", shape=[1], dtype="float32")
 
-        place = paddle.CustomPlace('npu', 0) if (
-            'npu' in paddle.fluid.core.get_all_custom_device_type()
-        ) else fluid.CPUPlace()
+        place = (
+            paddle.CustomPlace("npu", 0)
+            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            else fluid.CPUPlace()
+        )
         exe = fluid.Executor(place)
 
         out_1 = self._executed_api(images, min=min, max=max)
@@ -152,19 +148,18 @@ class TestClipAPI(unittest.TestCase):
         out_4 = self._executed_api(images, max=0.7)
         out_5 = self._executed_api(images, min=min)
         out_6 = self._executed_api(images, max=max)
-        out_7 = self._executed_api(images, max=-1.)
+        out_7 = self._executed_api(images, max=-1.0)
         out_8 = self._executed_api(images)
 
         res1, res2, res3, res4, res5, res6, res7, res8 = exe.run(
             fluid.default_main_program(),
             feed={
                 "image": data,
-                "min": np.array([0.2]).astype('float32'),
-                "max": np.array([0.8]).astype('float32')
+                "min": np.array([0.2]).astype("float32"),
+                "max": np.array([0.8]).astype("float32"),
             },
-            fetch_list=[
-                out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8
-            ])
+            fetch_list=[out_1, out_2, out_3, out_4, out_5, out_6, out_7, out_8],
+        )
 
         self.assertTrue(np.allclose(res1, data.clip(0.2, 0.8)))
         self.assertTrue(np.allclose(res2, data.clip(0.2, 0.9)))
@@ -178,20 +173,22 @@ class TestClipAPI(unittest.TestCase):
 
     def test_clip_dygraph(self):
         paddle.disable_static()
-        place = paddle.CustomPlace('npu', 0) if (
-            'npu' in paddle.fluid.core.get_all_custom_device_type()
-        ) else fluid.CPUPlace()
+        place = (
+            paddle.CustomPlace("npu", 0)
+            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            else fluid.CPUPlace()
+        )
         paddle.disable_static(place)
         data_shape = [1, 9, 9, 4]
-        data = np.random.random(data_shape).astype('float32')
-        images = paddle.to_tensor(data, dtype='float32')
+        data = np.random.random(data_shape).astype("float32")
+        images = paddle.to_tensor(data, dtype="float32")
         v_min = paddle.to_tensor(np.array([0.2], dtype=np.float32))
         v_max = paddle.to_tensor(np.array([0.8], dtype=np.float32))
 
         out_1 = self._executed_api(images, min=0.2, max=0.8)
-        images = paddle.to_tensor(data, dtype='float32')
+        images = paddle.to_tensor(data, dtype="float32")
         out_2 = self._executed_api(images, min=0.2, max=0.9)
-        images = paddle.to_tensor(data, dtype='float32')
+        images = paddle.to_tensor(data, dtype="float32")
         out_3 = self._executed_api(images, min=v_min, max=v_max)
 
         self.assertTrue(np.allclose(out_1.numpy(), data.clip(0.2, 0.8)))
@@ -200,8 +197,8 @@ class TestClipAPI(unittest.TestCase):
 
     def test_errors(self):
         paddle.enable_static()
-        x1 = fluid.data(name='x1', shape=[1], dtype="int16")
-        x2 = fluid.data(name='x2', shape=[1], dtype="int8")
+        x1 = fluid.data(name="x1", shape=[1], dtype="int16")
+        x2 = fluid.data(name="x2", shape=[1], dtype="int8")
         self.assertRaises(TypeError, paddle.clip, x=x1, min=0.2, max=0.8)
         self.assertRaises(TypeError, paddle.clip, x=x2, min=0.2, max=0.8)
         paddle.disable_static()
@@ -212,5 +209,5 @@ class TestInplaceClipAPI(TestClipAPI):
         return x.clip_(min, max)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
paddle.clip算子进行了升级，支持float32, float64, int32, int64，不需要再进行类型检查，因此把该单测删除