### PR TITLE
[NPU] fix HcclAllReduce

### DIFF
--- a/backends/npu/runtime/runtime.cc
+++ b/backends/npu/runtime/runtime.cc
@@ -432,8 +432,6 @@ HcclDataType PDDataTypeToHcclDataType(C_DataType dtype) {
     return HCCL_DATA_TYPE_FP32;
   } else if (dtype == C_DataType::FLOAT16) {
     return HCCL_DATA_TYPE_FP16;
-  } else if (dtype == C_DataType::INT64) {
-    return HCCL_DATA_TYPE_INT64;
   } else if (dtype == C_DataType::INT32) {
     return HCCL_DATA_TYPE_INT32;
   } else if (dtype == C_DataType::INT8) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45005871/210551549-3bc10453-80c3-4971-a305-28b74e23302b.png)
如图所示，目前HcclAllReduce不支持int64的数据类型