### PR TITLE
[NPU] fallback to CANN 603, test=develop

### DIFF
--- a/backends/npu/kernels/coalesce_tensor_kernel.cc
+++ b/backends/npu/kernels/coalesce_tensor_kernel.cc
@@ -21,43 +21,6 @@
 
 namespace custom_kernel {
 
-#define _PhiForEachDataTypeHelper_(callback, cpp_type, data_type) \
-  callback(cpp_type, data_type);
-
-#define _PhiForEachDataType_(callback)                                   \
-  _PhiForEachDataTypeHelper_(callback, float, phi::DataType::FLOAT32);   \
-  _PhiForEachDataTypeHelper_(                                            \
-      callback, ::phi::dtype::float16, phi::DataType::FLOAT16);          \
-  _PhiForEachDataTypeHelper_(                                            \
-      callback, ::phi::dtype::bfloat16, phi::DataType::BFLOAT16);        \
-  _PhiForEachDataTypeHelper_(callback, double, phi::DataType::FLOAT64);  \
-  _PhiForEachDataTypeHelper_(callback, int, phi::DataType::INT32);       \
-  _PhiForEachDataTypeHelper_(callback, int64_t, phi::DataType::INT64);   \
-  _PhiForEachDataTypeHelper_(callback, bool, phi::DataType::BOOL);       \
-  _PhiForEachDataTypeHelper_(callback, uint8_t, phi::DataType::UINT8);   \
-  _PhiForEachDataTypeHelper_(callback, int16_t, phi::DataType::INT16);   \
-  _PhiForEachDataTypeHelper_(callback, int8_t, phi::DataType::INT8);     \
-  _PhiForEachDataTypeHelper_(                                            \
-      callback, ::phi::dtype::complex<float>, phi::DataType::COMPLEX64); \
-  _PhiForEachDataTypeHelper_(                                            \
-      callback, ::phi::dtype::complex<double>, phi::DataType::COMPLEX128);
-
-template <typename Visitor>
-inline void VisitDataType(phi::DataType type, Visitor visitor) {
-#define PhiVisitDataTypeCallback(cpp_type, data_type) \
-  do {                                                \
-    if (type == data_type) {                          \
-      visitor.template apply<cpp_type>();             \
-      return;                                         \
-    }                                                 \
-  } while (0)
-
-  _PhiForEachDataType_(PhiVisitDataTypeCallback);
-#undef PhiVisitDataTypeCallback
-  PADDLE_THROW(phi::errors::Unimplemented(
-      "Not supported phi::DataType(%d) as data type.", static_cast<int>(type)));
-}
-
 size_t Alignment(size_t size, const phi::Place &place, int align_size) {
   size_t alignment = 0;
   if (align_size > 0) {
@@ -283,7 +246,7 @@ void CoalesceTensorKernel(const Context &dev_ctx,
                     : len;
     }
   } else if (set_constant) {
-    custom_kernel::VisitDataType(
+    phi::VisitDataType(
         dtype,
         FillConstantVisitor<Context>(dev_ctx, fused_output, constant, dtype));
   } else if (persist_output) {

--- a/backends/npu/kernels/funcs/format_utils.cc
+++ b/backends/npu/kernels/funcs/format_utils.cc
@@ -34,6 +34,8 @@
 
 #include "kernels/funcs/format_utils.h"
 
+#include "kernels/funcs/string_helper.h"
+
 static std::map<paddle::experimental::DataType, aclDataType>  //
     DTYPE_2_ACL_DTYPE = {
         {paddle::experimental::DataType::BOOL, ACL_BOOL},
@@ -126,18 +128,6 @@ char* FormatHelper::GetFormatName(const aclFormat& format) {
   return itr->second.formatName;
 }
 
-std::string FormatHelper::GetShapeString(const FormatShape& shape) {
-  std::stringstream ss;
-  int i = 0;
-  ss << "[";
-  for (auto e : shape) {
-    if (i++ > 0) ss << ", ";
-    ss << e;
-  }
-  ss << "]";
-  return ss.str();
-}
-
 FormatShape FormatHelper::GetStorageShape(const aclFormat storage_format,
                                           const FormatShape origin_dims) {
   auto itr = info.find(storage_format);
@@ -146,9 +136,9 @@ FormatShape FormatHelper::GetStorageShape(const aclFormat storage_format,
       return itr->second.func(origin_dims);  // change ori_size to storage_size
     }
   }
-  // LOG(FATAL) << "unsupport InferShape with format " <<
-  // GetFormatName(storage_format) << "with shape" <<
-  // GetShapeString(origin_dims);
+  LOG(FATAL) << "unsupport InferShape with format "
+             << GetFormatName(storage_format) << "with shape"
+             << GetVectorString(origin_dims);
   return {};
 }
 

--- a/backends/npu/kernels/funcs/format_utils.h
+++ b/backends/npu/kernels/funcs/format_utils.h
@@ -51,7 +51,6 @@ class FormatHelper {
 
  private:
   static char* GetFormatName(const aclFormat& format);
-  static std::string GetShapeString(const FormatShape& shape);
 
  private:
   using shapeInfer = std::function<FormatShape(FormatShape dims)>;

--- a/backends/npu/kernels/funcs/npu_op_runner.cc
+++ b/backends/npu/kernels/funcs/npu_op_runner.cc
@@ -17,6 +17,7 @@
 #include "acl/acl_op_compiler.h"
 #include "kernels/funcs/npu_enforce.h"
 #include "kernels/funcs/npu_funcs.h"
+#include "kernels/funcs/string_helper.h"
 #include "pybind11/pybind11.h"
 #include "runtime/flags.h"
 #include "runtime/runtime.h"
@@ -602,12 +603,9 @@ void NpuOpRunner::Run(aclrtStream stream, bool sync) const {
       stream,
       phi::errors::External("Stream should not be null, please check."));
   InitFloatStatus(stream);
-  VLOG(5) << "NpuOpRunner(" << this << ") Run:";
-  VLOG(4) << "op_type: " << op_type_;
-  VLOG(4) << "input_desc.size: " << input_descs_.size();
-  VLOG(4) << "output_desc.size: " << output_descs_.size();
-  VLOG(4) << "attr: " << attr_;
-  VLOG(4) << "stream: " << stream;
+  VLOG(1) << "NpuOpRunner: " << op_type_ << "\n"
+          << GetOpDescString(input_descs_, "Input")
+          << GetOpDescString(output_descs_, "Output");
   aclError ret;
   // Ensure that the Gil has been released before running
   // aclopCompileAndExecute.

--- a/backends/npu/kernels/funcs/string_helper.cc
+++ b/backends/npu/kernels/funcs/string_helper.cc
@@ -1,0 +1,102 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/string_helper.h"
+
+#include "kernels/funcs/npu_enforce.h"
+
+template <typename T>
+std::string GetVectorString(const std::vector<T>& vec) {
+  std::stringstream ss;
+  int i = 0;
+  ss << "[";
+  for (auto e : vec) {
+    if (i++ > 0) ss << ", ";
+    ss << e;
+  }
+  ss << "]";
+  return ss.str();
+}
+
+template std::string GetVectorString(const std::vector<int64_t>& vec);
+template std::string GetVectorString(const std::vector<float>& vec);
+
+std::string GetDataBufferString(const aclDataBuffer* buf) {
+  auto size = aclGetDataBufferSizeV2(buf);
+  auto addr = aclGetDataBufferAddr(buf);
+  auto numel = size / sizeof(float);
+  std::vector<float> cpu_data(numel, 0);
+  PADDLE_ENFORCE_NPU_SUCCESS(aclrtMemcpy(
+      cpu_data.data(), size, addr, size, ACL_MEMCPY_DEVICE_TO_HOST));
+
+  std::stringstream ss;
+  ss << "TensorData: " << GetVectorString(cpu_data);
+  // for (auto value : cpu_data) {
+  //   ss << value << ",";
+  // }
+  // ss << "]";
+  return ss.str();
+}
+
+std::string GetTensorDescString(const aclTensorDesc* desc) {
+  auto data_type = aclGetTensorDescType(desc);
+  auto origin_format = aclGetTensorDescFormat(desc);  // origin format
+
+  std::stringstream ss;
+  ss << "TensorDesc: data_type = " << data_type
+     << ", origin_format = " << origin_format << ", origin_dims = [";
+
+  size_t rank = aclGetTensorDescNumDims(desc);
+  for (auto i = 0; i < rank; ++i) {
+    int64_t dim_size = -1;
+    PADDLE_ENFORCE_NPU_SUCCESS(aclGetTensorDescDimV2(desc, i, &dim_size));
+    ss << dim_size;
+    if (i < rank - 1) {
+      ss << ", ";
+    }
+  }
+  ss << "]";
+  return ss.str();
+}
+
+std::string GetOpDescString(std::vector<aclTensorDesc*> descs,
+                            const std::string msg) {
+  std::stringstream ss;
+  for (auto i = 0; i < descs.size(); ++i) {
+    ss << " - " << msg << "[" << std::to_string(i)
+       << "]: ";  // Input[i] or Output[i]
+    ss << GetTensorDescString(descs[i]) << "\n";
+  }
+  return ss.str();
+}
+
+std::string GetOpInfoString(std::vector<aclTensorDesc*> descs,
+                            std::vector<aclDataBuffer*> buffs,
+                            const std::string msg) {
+  PADDLE_ENFORCE_EQ(buffs.size(),
+                    descs.size(),
+                    phi::errors::InvalidArgument(
+                        "Input size of buffers and descs should be same, but "
+                        "got buff size [%d] and desc size [%d]",
+                        buffs.size(),
+                        descs.size()));
+
+  std::stringstream ss;
+  for (auto i = 0; i < descs.size(); ++i) {
+    ss << msg << "[" << std::to_string(i) << "]: ";  // Input[i] or Output[i]
+    ss << GetTensorDescString(descs[i]) << "\n";
+    ss << GetDataBufferString(buffs[i]) << "\n";
+  }
+  return ss.str();
+}

--- a/backends/npu/kernels/funcs/string_helper.h
+++ b/backends/npu/kernels/funcs/string_helper.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "acl/acl.h"
+#include "glog/logging.h"
+#include "paddle/extension.h"
+#include "paddle/phi/extension.h"
+
+template <typename T>
+std::string GetVectorString(const std::vector<T>& shape);
+
+std::string GetDataBufferString(const aclDataBuffer* buf);
+
+std::string GetTensorDescString(const aclTensorDesc* desc);
+
+std::string GetOpDescString(std::vector<aclTensorDesc*> descs,
+                            const std::string msg);
+
+std::string GetOpInfoString(std::vector<aclTensorDesc*> descs,
+                            std::vector<aclDataBuffer*> buffs,
+                            const std::string msg);

--- a/backends/npu/tools/dockerfile/build-aarch64.sh
+++ b/backends/npu/tools/dockerfile/build-aarch64.sh
@@ -17,10 +17,10 @@
 set -ex
 
 # Usage:
-# export CANN_VERSION=6.0.0.alpha005
+# export CANN_VERSION=6.0.0.alpha003
 # bash build-aarch64.sh ${CANN_VERSION}
 
-CANN_VERSION=${1:-6.0.0.alpha005} # default 6.0.0.alpha005
+CANN_VERSION=${1:-6.0.0.alpha003} # default 6.0.0.alpha003
 CANN_TOOLKIT=Ascend-cann-toolkit_${CANN_VERSION}_linux-aarch64.run
 
 DOCKER_VERSION=${CANN_VERSION//[^0-9]/}

--- a/backends/npu/tools/dockerfile/build-x86_64.sh
+++ b/backends/npu/tools/dockerfile/build-x86_64.sh
@@ -17,10 +17,10 @@
 set -x
 
 # Usage:
-# export CANN_VERSION=6.0.0.alpha005
+# export CANN_VERSION=6.0.0.alpha003
 # bash build-x86_64.sh ${CANN_VERSION}
 
-CANN_VERSION=${1:-6.0.0.alpha005} # default 6.0.0.alpha005
+CANN_VERSION=${1:-6.0.0.alpha003} # default 6.0.0.alpha003
 CANN_TOOLKIT=Ascend-cann-toolkit_${CANN_VERSION}_linux-x86_64.run
 
 DOCKER_VERSION=${CANN_VERSION//[^0-9]/}


### PR DESCRIPTION
CANN 6.0.0.alpha005 会导致以下算子单测失败，为保证单测稳定，先 fallback 到 6.0.0.alpha003 版本

test_batch_norm_op_npu|test_multinomial_op_npu|test_transpose_op_npu

错误为 transpose 算子输入错误，待修复

![image](https://user-images.githubusercontent.com/16605440/210766085-e60ecd89-b493-4a14-87c3-63a63f5ecbbc.png)

彦卉 PR https://github.com/PaddlePaddle/PaddleCustomDevice/pull/337 已经修复 CANN 6.0.0.alpha005 的问题
