### PR TITLE
append remainder op fail case & fix it

### DIFF
--- a/backends/npu/kernels/elementwise_mod_kernel.cc
+++ b/backends/npu/kernels/elementwise_mod_kernel.cc
@@ -29,12 +29,13 @@ void ModuloRawKernel(const Context& dev_ctx,
   axis = (axis == -1 ? std::abs(x_dims.size() - y_dims.size()) : axis);
 
   bool direct_compute = false;
-  if (x_dims.size() >= y_dims.size()) {
+  if (y_dims.size() == 0 || x_dims.size() == 0) {
+    direct_compute = false;
+  } else if (x_dims.size() >= y_dims.size()) {
     direct_compute = y_dims == phi::slice_ddim(x_dims, axis, x_dims.size());
   } else {
     direct_compute = x_dims == phi::slice_ddim(y_dims, axis, y_dims.size());
   }
-
   phi::DenseTensor transformed_x, transformed_y;
   if (direct_compute) {
     transformed_x = x;

--- a/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
@@ -177,8 +177,7 @@ class TestRemainderOp(unittest.TestCase):
             self.assertEqual(np.allclose(z_expected, z.numpy()), True)
 
 
-# Use to test zero-dim of binary API
-class TestBinaryAPI(unittest.TestCase):
+class TestRemainderZeroDim(unittest.TestCase):
     def test_dygraph_binary(self):
         paddle.set_device("npu:0")
         paddle.disable_static()

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -2,4 +2,3 @@ disable_ut_npu
 test_adam_op_npu
 test_transpose_op_npu
 test_zero_dim_tensor_npu
-test_elementwise_mod_op_npu

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -2,3 +2,4 @@ disable_ut_npu
 test_adam_op_npu
 test_transpose_op_npu
 test_zero_dim_tensor_npu
+test_elementwise_mod_op_npu


### PR DESCRIPTION
**现象：**
remainder算子经过如下步骤：
1. 计算输入为0-dim，0-dim；
2. 计算输入n-dim，0-dim。

计算会出现错误，只正常计算出第一个元素的结果，若不进行第1步计算则计算无误。

**诊断：**
经过调试发现输入数据无误，目前判断是floormod算子问题。

**初步解决方案：**
当输入的元素维度为0维时可以强制指定为1x1维度，简单测试过可以达到要求。