### PR TITLE
fix reduce series ops zero-dim fail issues

### DIFF
--- a/backends/npu/kernels/reduce_all_kernel.cc
+++ b/backends/npu/kernels/reduce_all_kernel.cc
@@ -28,6 +28,11 @@ void AllRawKernel(const Context& dev_ctx,
                       static_cast<int>(dims.size()) == x.dims().size() ||
                       reduce_all;
   std::vector<int64_t> dims_vec = dims;
+  dev_ctx.template Alloc<T>(out);
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, x, true, out);
+    return;
+  }
   if (reduce_all_f) {
     dims_vec.clear();
     for (size_t i = 0; i < x.dims().size(); ++i) {
@@ -35,7 +40,6 @@ void AllRawKernel(const Context& dev_ctx,
     }
   }
   auto stream = dev_ctx.stream();
-  dev_ctx.template Alloc<T>(out);
   NpuOpRunner runner;
   runner.SetType("ReduceAll")
       .AddInput(x)

--- a/backends/npu/kernels/reduce_any_kernel.cc
+++ b/backends/npu/kernels/reduce_any_kernel.cc
@@ -24,7 +24,10 @@ void AnyKernel(const Context& dev_ctx,
                bool keep_dim,
                phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
-
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, x, true, out);
+    return;
+  }
   bool reduce_all = false;
   if (dims.size() == 0) {
     reduce_all = true;

--- a/backends/npu/kernels/reduce_max_kernel.cc
+++ b/backends/npu/kernels/reduce_max_kernel.cc
@@ -84,9 +84,12 @@ void MaxGradKernel(const Context& dev_ctx,
                    bool reduce_all,
                    phi::DenseTensor* x_grad) {
   auto reduce_dims = reduce_dims_in.GetData();
-  dev_ctx.template Alloc<T>(x_grad);
   auto stream = dev_ctx.stream();
-
+  dev_ctx.template Alloc<T>(x_grad);
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, out_grad, true, x_grad);
+    return;
+  }
   // broadcast
   auto x_dims_vec = phi::vectorize(x.dims());
   if (reduce_all) {

--- a/backends/npu/kernels/reduce_mean_kernel.cc
+++ b/backends/npu/kernels/reduce_mean_kernel.cc
@@ -26,7 +26,10 @@ void MeanRawKernel(const Context& dev_ctx,
                    phi::DenseTensor* out) {
   auto dims = axes.GetData();
   dev_ctx.template Alloc<T>(out);
-
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, x, true, out);
+    return;
+  }
   aclrtStream stream = static_cast<aclrtStream>(dev_ctx.stream());
 
   auto input_dims = x.dims();
@@ -66,6 +69,10 @@ void MeanGradKernel(const Context& dev_ctx,
   aclrtStream stream = static_cast<aclrtStream>(dev_ctx.stream());
   auto reduce_dims = axes.GetData();
   dev_ctx.template Alloc<T>(x_grad);
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, out_grad, true, x_grad);
+    return;
+  }
 
   int reduce_numel = 1;
 


### PR DESCRIPTION
在修复zero-dim-tensor时发现部分reduce相关ops缺乏对0-dim处理。
**修复ops：**
1. reduce_all
2. reduce_any
3. reduce_max
4. reduce_mean