### PR TITLE
[NPU] fix async memcpy h2d

### DIFF
--- a/backends/npu/runtime/runtime.cc
+++ b/backends/npu/runtime/runtime.cc
@@ -114,8 +114,7 @@ class AlignnedAllocator {
   void *Alloc(size_t size, size_t align) {
     std::lock_guard<std::mutex> lock(mtx_);
     ProcessEvents();
-    void *p = nullptr;
-    ACL_CHECK(aclrtMallocHost(&p, size + align));
+    void *p = malloc(size + align);
     void *ret =
         reinterpret_cast<void *>(reinterpret_cast<size_t>(p) + align -
                                  (reinterpret_cast<size_t>(p) & (align - 1)));
@@ -135,9 +134,9 @@ class AlignnedAllocator {
       if (!event) continue;
       ACL_CHECK(aclrtSynchronizeEvent(event));
       void *ptr = it->second.first;
-      ACL_CHECK(aclrtDestroyEvent(event));
+      free(ptr);
       it = recorded_events_.erase(it);
-      ACL_CHECK(aclrtFreeHost(ptr));
+      ACL_CHECK(aclrtDestroyEvent(event));
     }
   }
 
@@ -149,9 +148,9 @@ class AlignnedAllocator {
       ACL_CHECK(aclrtQueryEventStatus(event, &status));
       if (status == ACL_EVENT_RECORDED_STATUS_COMPLETE) {
         void *ptr = it->second.first;
+        free(ptr);
         it = recorded_events_.erase(it);
         ACL_CHECK(aclrtDestroyEvent(event));
-        ACL_CHECK(aclrtFreeHost(ptr));
       } else {
         ++it;
       }


### PR DESCRIPTION
fix async memcpy h2d

async memcpy h2d 使用 malloc 分配临时内存，走os机制， aclrtMallocHost 使用完会有 CANN 的额外操作，无法使用 event 机制监测到其完全使用完毕，此时调用 aclrtFreeHost 释放可能会报错。当前只是改变了时序，即在释放前增加了其他的调用，所以可能还是会报错。