### PR TITLE
[Zero-Dim] support input 0D Tensor for maximum and minimum on custom_cpu

### DIFF
--- a/backends/custom_cpu/tests/unittests/test_zero_dim_tensor.py
+++ b/backends/custom_cpu/tests/unittests/test_zero_dim_tensor.py
@@ -79,6 +79,7 @@ class TestReduceAPI(unittest.TestCase):
 binary_api_list = [
     {"func": paddle.add, "cls_method": "__add__"},
     {"func": paddle.multiply, "cls_method": "__mul__"},
+    paddle.maximum,
 ]
 
 binary_api_list_without_grad = [


### PR DESCRIPTION
NPU：
- 已有maximum和minimum在NPU/MLU上的单测
- allclose在CustomDevice中无kernel实现，不添加NPU/MLU上的单测

CustomCPU：
maximum的单测运行结果：

![image](https://user-images.githubusercontent.com/22235422/211745451-83c958a6-39c5-4e86-a754-10f351638001.png)


主repo pr: https://github.com/PaddlePaddle/Paddle/pull/49616

