### PR TITLE
[NPU]fix arg_max and arg_min

### DIFF
--- a/backends/npu/kernels/arg_min_max_kernel.cc
+++ b/backends/npu/kernels/arg_min_max_kernel.cc
@@ -28,6 +28,10 @@ void ArgMinKernel(const Context& dev_ctx,
   dev_ctx.Alloc(out, out->dtype());
   auto stream = dev_ctx.stream();
 
+  // NOTE: The dtype of output is decided by param dtype, if param dtype is 2,
+  // output's dtype is int, and if param dtype is 3, output's dtype is int64.
+  // See the detail in
+  // https://github.com/PaddlePaddle/Paddle/blob/f9043c78e55b182e05d1d1efa7da930d8abc28d2/paddle/phi/infermeta/unary.cc#L209
   if (dtype == 2) {
     NpuOpRunner runner;
     runner.SetType("ArgMin")

--- a/backends/npu/tests/unittests/test_arg_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_max_op_npu.py
@@ -16,13 +16,10 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 
@@ -30,293 +27,298 @@ paddle.enable_static()
 class BaseTestCase(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
     def setUp(self):
         self.set_npu()
         self.initTestCase()
         self.x = (1000 * np.random.random(self.dims)).astype(self.dtype)
-        self.inputs = {'X': self.x}
-        self.attrs = {'axis': self.axis}
-        self.outputs = {'Out': np.argmax(self.x, axis=self.axis)}
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis}
+        self.outputs = {"Out": np.argmax(self.x, axis=self.axis)}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
 
+# test param dtype is 2(int32)
+class TestArgMaxParamDtypeInt32(BaseTestCase):
+    def setUp(self):
+        self.set_npu()
+        self.initTestCase()
+        self.x = (1000 * np.random.random(self.dims)).astype(self.dtype)
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis, "dtype": 2}
+        self.outputs = {"Out": np.argmax(self.x, axis=self.axis)}
+
+
 # test argmax, dtype: float16
 class TestArgMaxFloat16Case1(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = -1
 
 
 class TestArgMaxFloat16Case2(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMaxFloat16Case3(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 1
 
 
 class TestArgMaxFloat16Case4(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 2
 
 
 class TestArgMaxFloat16Case5(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = -1
 
 
 class TestArgMaxFloat16Case6(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMaxFloat16Case7(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 1
 
 
 class TestArgMaxFloat16Case8(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (1, )
-        self.dtype = 'float16'
+        self.op_type = "arg_max"
+        self.dims = (1,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMaxFloat16Case9(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (2, )
-        self.dtype = 'float16'
+        self.op_type = "arg_max"
+        self.dims = (2,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMaxFloat16Case10(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (3, )
-        self.dtype = 'float16'
+        self.op_type = "arg_max"
+        self.dims = (3,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 # test argmax, dtype: float32
 class TestArgMaxFloat32Case1(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = -1
 
 
 class TestArgMaxFloat32Case2(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMaxFloat32Case3(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 1
 
 
 class TestArgMaxFloat32Case4(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 2
 
 
 class TestArgMaxFloat32Case5(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = -1
 
 
 class TestArgMaxFloat32Case6(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMaxFloat32Case7(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 1
 
 
 class TestArgMaxFloat32Case8(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (1, )
-        self.dtype = 'float32'
+        self.op_type = "arg_max"
+        self.dims = (1,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMaxFloat32Case9(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (2, )
-        self.dtype = 'float32'
+        self.op_type = "arg_max"
+        self.dims = (2,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMaxFloat32Case10(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (3, )
-        self.dtype = 'float32'
+        self.op_type = "arg_max"
+        self.dims = (3,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 # test argmax, dtype: double
 class TestArgMaxDoubleCase1(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = -1
 
 
 class TestArgMaxDoubleCase2(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = 0
 
 
 class TestArgMaxDoubleCase3(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = 1
 
 
 class TestArgMaxDoubleCase4(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4, 5)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = 2
 
 
 class TestArgMaxDoubleCase5(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = -1
 
 
 class TestArgMaxDoubleCase6(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = 0
 
 
 class TestArgMaxDoubleCase7(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (3, 4)
-        self.dtype = 'double'
+        self.dtype = "double"
         self.axis = 1
 
 
 class TestArgMaxDoubleCase8(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (1, )
-        self.dtype = 'double'
+        self.op_type = "arg_max"
+        self.dims = (1,)
+        self.dtype = "double"
         self.axis = 0
 
 
 class TestArgMaxDoubleCase9(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (2, )
-        self.dtype = 'double'
+        self.op_type = "arg_max"
+        self.dims = (2,)
+        self.dtype = "double"
         self.axis = 0
 
 
 class TestArgMaxDoubleCase10(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_max'
-        self.dims = (3, )
-        self.dtype = 'double'
+        self.op_type = "arg_max"
+        self.dims = (3,)
+        self.dtype = "double"
         self.axis = 0
 
 
 class BaseTestComplex1_1(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (4, 5, 6)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 2
 
     def setUp(self):
         self.set_npu()
         self.initTestCase()
         self.x = (np.random.random(self.dims)).astype(self.dtype)
-        self.inputs = {'X': self.x}
-        self.attrs = {
-            'axis': self.axis,
-            'dtype': int(core.VarDesc.VarType.INT32)
-        }
-        self.outputs = {
-            'Out': np.argmax(
-                self.x, axis=self.axis).astype("int32")
-        }
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis, "dtype": int(core.VarDesc.VarType.INT32)}
+        self.outputs = {"Out": np.argmax(self.x, axis=self.axis).astype("int32")}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -325,27 +327,21 @@ class BaseTestComplex1_1(OpTest):
 class BaseTestComplex1_2(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def initTestCase(self):
-        self.op_type = 'arg_max'
+        self.op_type = "arg_max"
         self.dims = (4, 5, 6)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 2
 
     def setUp(self):
         self.set_npu()
         self.initTestCase()
         self.x = (np.random.random(self.dims)).astype(self.dtype)
-        self.inputs = {'X': self.x}
-        self.attrs = {
-            'axis': self.axis,
-            'dtype': int(core.VarDesc.VarType.INT32)
-        }
-        self.outputs = {
-            'Out': np.argmax(
-                self.x, axis=self.axis).astype("int32")
-        }
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis, "dtype": int(core.VarDesc.VarType.INT32)}
+        self.outputs = {"Out": np.argmax(self.x, axis=self.axis).astype("int32")}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -354,13 +350,13 @@ class BaseTestComplex1_2(OpTest):
 class TestArgMaxAPI(unittest.TestCase):
     def initTestCase(self):
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_dygraph_api(self):
         def run(place):
@@ -370,8 +366,8 @@ class TestArgMaxAPI(unittest.TestCase):
             tensor_input = paddle.to_tensor(numpy_input)
             numpy_output = np.argmax(numpy_input, axis=self.axis)
             paddle_output = paddle.argmax(tensor_input, axis=self.axis)
-            self.assertEqual(
-                np.allclose(numpy_output, paddle_output.numpy()), True)
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
+            assert paddle_output.dtype == paddle.int64
             paddle.enable_static()
 
         for place in self.place:
@@ -381,14 +377,14 @@ class TestArgMaxAPI(unittest.TestCase):
 class TestArgMaxAPI_2(unittest.TestCase):
     def initTestCase(self):
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
         self.keep_dims = True
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_dygraph_api(self):
         def run(place):
@@ -396,12 +392,11 @@ class TestArgMaxAPI_2(unittest.TestCase):
             np.random.seed(2021)
             numpy_input = (np.random.random(self.dims)).astype(self.dtype)
             tensor_input = paddle.to_tensor(numpy_input)
-            numpy_output = np.argmax(
-                numpy_input, axis=self.axis).reshape(1, 4, 5)
+            numpy_output = np.argmax(numpy_input, axis=self.axis).reshape(1, 4, 5)
             paddle_output = paddle.argmax(
-                tensor_input, axis=self.axis, keepdim=self.keep_dims)
-            self.assertEqual(
-                np.allclose(numpy_output, paddle_output.numpy()), True)
+                tensor_input, axis=self.axis, keepdim=self.keep_dims
+            )
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
             self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)
             paddle.enable_static()
 
@@ -412,12 +407,12 @@ class TestArgMaxAPI_2(unittest.TestCase):
 class TestArgMaxAPI_3(unittest.TestCase):
     def initTestCase(self):
         self.dims = (1, 9)
-        self.dtype = 'float32'
+        self.dtype = "float32"
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_dygraph_api(self):
         def run(place):
@@ -427,8 +422,7 @@ class TestArgMaxAPI_3(unittest.TestCase):
             tensor_input = paddle.to_tensor(numpy_input)
             numpy_output = np.argmax(numpy_input).reshape([1])
             paddle_output = paddle.argmax(tensor_input)
-            self.assertEqual(
-                np.allclose(numpy_output, paddle_output.numpy()), True)
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
             self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)
             paddle.enable_static()
 
@@ -436,5 +430,33 @@ class TestArgMaxAPI_3(unittest.TestCase):
             run(place)
 
 
-if __name__ == '__main__':
+# test param dtype is int32
+class TestArgMaxDtypeInt32(unittest.TestCase):
+    def initTestCase(self):
+        self.dims = (3, 4, 5)
+        self.dtype = "float32"
+        self.axis = 0
+
+    def setUp(self):
+        self.initTestCase()
+        self.__class__.use_custom_device = True
+        self.place = [paddle.CustomPlace("npu", 0)]
+
+    def test_dygraph_api(self):
+        def run(place):
+            paddle.disable_static(place)
+            np.random.seed(2021)
+            numpy_input = (np.random.random(self.dims)).astype(self.dtype)
+            tensor_input = paddle.to_tensor(numpy_input)
+            numpy_output = np.argmax(numpy_input, axis=self.axis)
+            paddle_output = paddle.argmax(tensor_input, axis=self.axis, dtype="int32")
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
+            assert paddle_output.dtype == paddle.int32
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_arg_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_min_op_npu.py
@@ -16,211 +16,219 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 
 paddle.enable_static()
 
 
 class BaseTestCase(OpTest):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 1
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         np.random.seed(2021)
         self.x = (np.random.random(self.dims)).astype(self.dtype)
-        self.inputs = {'X': self.x}
-        self.attrs = {'axis': self.axis}
-        if self.op_type == "arg_min":
-            self.outputs = {'Out': np.argmin(self.x, axis=self.axis)}
-        else:
-            self.outputs = {'Out': np.argmax(self.x, axis=self.axis)}
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis}
+        self.outputs = {"Out": np.argmin(self.x, axis=self.axis)}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
 
+# test param dtype is 2(int32)
+class TestArgMinParamDtypeInt32(BaseTestCase):
+    def setUp(self):
+        self.initTestCase()
+        self.__class__.use_custom_device = True
+        self.place = paddle.CustomPlace("npu", 0)
+        np.random.seed(2021)
+        self.x = (np.random.random(self.dims)).astype(self.dtype)
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis, "dtype": 2}
+        self.outputs = {"Out": np.argmin(self.x, axis=self.axis)}
+
+
 # test argmin, dtype: float16
 class TestArgMinFloat16Case1(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = -1
 
 
 class TestArgMinFloat16Case2(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMinFloat16Case3(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 1
 
 
 class TestArgMinFloat16Case4(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 2
 
 
 class TestArgMinFloat16Case5(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = -1
 
 
 class TestArgMinFloat16Case6(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMinFloat16Case7(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.axis = 1
 
 
 class TestArgMinFloat16Case8(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (1, )
-        self.dtype = 'float16'
+        self.op_type = "arg_min"
+        self.dims = (1,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMinFloat16Case9(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (2, )
-        self.dtype = 'float16'
+        self.op_type = "arg_min"
+        self.dims = (2,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 class TestArgMinFloat16Case10(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (3, )
-        self.dtype = 'float16'
+        self.op_type = "arg_min"
+        self.dims = (3,)
+        self.dtype = "float16"
         self.axis = 0
 
 
 # test argmin, dtype: float32
 class TestArgMinFloat32Case1(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = -1
 
 
 class TestArgMinFloat32Case2(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMinFloat32Case3(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 1
 
 
 class TestArgMinFloat32Case4(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 2
 
 
 class TestArgMinFloat32Case5(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = -1
 
 
 class TestArgMinFloat32Case6(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMinFloat32Case7(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
+        self.op_type = "arg_min"
         self.dims = (3, 4)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 1
 
 
 class TestArgMinFloat32Case8(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (1, )
-        self.dtype = 'float32'
+        self.op_type = "arg_min"
+        self.dims = (1,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMinFloat32Case9(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (2, )
-        self.dtype = 'float32'
+        self.op_type = "arg_min"
+        self.dims = (2,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMinFloat32Case10(BaseTestCase):
     def initTestCase(self):
-        self.op_type = 'arg_min'
-        self.dims = (3, )
-        self.dtype = 'float32'
+        self.op_type = "arg_min"
+        self.dims = (3,)
+        self.dtype = "float32"
         self.axis = 0
 
 
 class TestArgMinAPI(unittest.TestCase):
     def initTestCase(self):
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_dygraph_api(self):
         def run(place):
@@ -230,8 +238,8 @@ class TestArgMinAPI(unittest.TestCase):
             tensor_input = paddle.to_tensor(numpy_input)
             numpy_output = np.argmin(numpy_input, axis=self.axis)
             paddle_output = paddle.argmin(tensor_input, axis=self.axis)
-            self.assertEqual(
-                np.allclose(numpy_output, paddle_output.numpy()), True)
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
+            assert paddle_output.dtype == paddle.int64
             paddle.enable_static()
 
         for place in self.place:
@@ -241,14 +249,14 @@ class TestArgMinAPI(unittest.TestCase):
 class TestArgMaxAPI_2(unittest.TestCase):
     def initTestCase(self):
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 0
         self.keep_dims = True
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_dygraph_api(self):
         def run(place):
@@ -256,12 +264,11 @@ class TestArgMaxAPI_2(unittest.TestCase):
             np.random.seed(2021)
             numpy_input = (np.random.random(self.dims)).astype(self.dtype)
             tensor_input = paddle.to_tensor(numpy_input)
-            numpy_output = np.argmin(
-                numpy_input, axis=self.axis).reshape(1, 4, 5)
+            numpy_output = np.argmin(numpy_input, axis=self.axis).reshape(1, 4, 5)
             paddle_output = paddle.argmin(
-                tensor_input, axis=self.axis, keepdim=self.keep_dims)
-            self.assertEqual(
-                np.allclose(numpy_output, paddle_output.numpy()), True)
+                tensor_input, axis=self.axis, keepdim=self.keep_dims
+            )
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
             self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)
             paddle.enable_static()
 
@@ -269,5 +276,32 @@ class TestArgMaxAPI_2(unittest.TestCase):
             run(place)
 
 
-if __name__ == '__main__':
+class TestArgMinDtypeInt32(unittest.TestCase):
+    def initTestCase(self):
+        self.dims = (3, 4, 5)
+        self.dtype = "float32"
+        self.axis = 0
+
+    def setUp(self):
+        self.initTestCase()
+        self.__class__.use_custom_device = True
+        self.place = [paddle.CustomPlace("npu", 0)]
+
+    def test_dygraph_api(self):
+        def run(place):
+            paddle.disable_static(place)
+            np.random.seed(2021)
+            numpy_input = (np.random.random(self.dims)).astype(self.dtype)
+            tensor_input = paddle.to_tensor(numpy_input)
+            numpy_output = np.argmin(numpy_input, axis=self.axis)
+            paddle_output = paddle.argmin(tensor_input, axis=self.axis, dtype="int32")
+            self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
+            assert paddle_output.dtype == paddle.int32
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
之前arg_max和arg_min强制将输出的数据类型限制为int32类型，但是phi中输出的数据类型是根据参数dtype来在int32和int64中进行选择的。本PR解决了此问题。