### PR TITLE
[NPU]fix bug when transpose's input format is NC1HWC0

### DIFF
--- a/backends/npu/kernels/transpose_kernel.cc
+++ b/backends/npu/kernels/transpose_kernel.cc
@@ -29,17 +29,14 @@ void TransposeKernel(const Context& dev_ctx,
                      const std::vector<int>& axis,
                      phi::DenseTensor* out) {
   phi::DenseTensor x_tmp;
+  // TODO(songkai05): CANN does not support trans from NC1HWC0 to ND between
+  // Transpose_in_0 and Transpose, so we trans NC1HWC0 to its original format
+  // first temporarily.
   if (x.storage_properties_initialized()) {
-    auto npu_properties = x.storage_properties<phi::NPUStorageProperties>();
-    int64_t storage_format = npu_properties.storage_format;
-    if (storage_format == ACL_FORMAT_NC1HWC0) {
-      phi::DenseTensorMeta meta = {x.dtype(), x.dims()};
-      x_tmp.set_meta(meta);
-      custom_kernel::NPUIdentityKernel<T, Context>(
-          dev_ctx, x, ConvertToNpuFormat(x.layout()), &x_tmp);
-    } else {
-      x_tmp = x;
-    }
+    phi::DenseTensorMeta meta = {x.dtype(), x.dims()};
+    x_tmp.set_meta(meta);
+    custom_kernel::NPUIdentityKernel<T, Context>(
+        dev_ctx, x, ConvertToNpuFormat(x.layout()), &x_tmp);
   } else {
     x_tmp = x;
   }


### PR DESCRIPTION
修复当Transpose kernel的输入的format是NC1HWC0时出现的bug。bug信息如下：
`"[GraphOpt][Trans][InsertTransByConcec] We do not support trans from NC1HWC0 to ND between Transpose_in_0 and Transpose."`
本地单测结果如下图
![截屏2023-02-01 16 25 58](https://user-images.githubusercontent.com/50285351/215990775-0e4a21fb-063e-45ad-9c21-82d20f01bb0d.png)
失败的单测是之前就有问题的，本次添加的单测都已通过。

已向model_zoo提交了需求支持的issue，https://gitee.com/ascend/modelzoo/issues/I6CC8O?from=project-issue