### PR TITLE
[NPU] fix all ops zero-dim issues

### DIFF
--- a/backends/npu/kernels/bitwise_kernel.cc
+++ b/backends/npu/kernels/bitwise_kernel.cc
@@ -25,25 +25,20 @@ void BitwiseAndKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
-  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  phi::DenseTensor x_tensor(x), y_tensor(y);
   if (x.dims().size() == 0 && y.dims().size() == 0) {
     x_tensor.Resize({1});
     y_tensor.Resize({1});
-    out_tensor.Resize({1});
   }
 
   if (x.dtype() == phi::DataType::BOOL) {
     const auto& runner =
-        NpuOpRunner("LogicalAnd", {x_tensor, y_tensor}, {out_tensor});
+        NpuOpRunner("LogicalAnd", {x_tensor, y_tensor}, {*out});
     runner.Run(stream);
   } else {
     const auto& runner =
-        NpuOpRunner("BitwiseAnd", {x_tensor, y_tensor}, {out_tensor});
+        NpuOpRunner("BitwiseAnd", {x_tensor, y_tensor}, {*out});
     runner.Run(stream);
-  }
-
-  if (x.dims().size() == 0 && y.dims().size() == 0) {
-    out->Resize({});
   }
 }
 
@@ -55,25 +50,18 @@ void BitwiseOrKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
-  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  phi::DenseTensor x_tensor(x), y_tensor(y);
   if (x.dims().size() == 0 && y.dims().size() == 0) {
     x_tensor.Resize({1});
     y_tensor.Resize({1});
-    out_tensor.Resize({1});
   }
 
   if (x.dtype() == phi::DataType::BOOL) {
-    const auto& runner =
-        NpuOpRunner("LogicalOr", {x_tensor, y_tensor}, {out_tensor});
+    const auto& runner = NpuOpRunner("LogicalOr", {x_tensor, y_tensor}, {*out});
     runner.Run(stream);
   } else {
-    const auto& runner =
-        NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {out_tensor});
+    const auto& runner = NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {*out});
     runner.Run(stream);
-  }
-
-  if (x.dims().size() == 0 && y.dims().size() == 0) {
-    out->Resize({});
   }
 }
 
@@ -89,7 +77,6 @@ void BitwiseXorKernel(const Context& dev_ctx,
   if (x.dims().size() == 0 && y.dims().size() == 0) {
     x_tensor.Resize({1});
     y_tensor.Resize({1});
-    out_tensor.Resize({1});
   }
 
   if (x.dtype() == phi::DataType::BOOL) {
@@ -121,10 +108,6 @@ void BitwiseXorKernel(const Context& dev_ctx,
         NpuOpRunner("BitwiseXor", {x_tensor, y_tensor}, {out_tensor});
     runner.Run(stream);
   }
-
-  if (x.dims().size() == 0 && y.dims().size() == 0) {
-    out->Resize({});
-  }
 }
 
 template <typename T, typename Context>
@@ -137,7 +120,6 @@ void BitwiseNotKernel(const Context& dev_ctx,
   phi::DenseTensor x_tensor(x), out_tensor(*out);
   if (x.dims().size() == 0) {
     x_tensor.Resize({1});
-    out_tensor.Resize({1});
   }
 
   if (x.dtype() == phi::DataType::BOOL) {
@@ -146,10 +128,6 @@ void BitwiseNotKernel(const Context& dev_ctx,
   } else {
     const auto& runner = NpuOpRunner("Invert", {x_tensor}, {out_tensor});
     runner.Run(stream);
-  }
-
-  if (x.dims().size() == 0) {
-    out->Resize({});
   }
 }
 

--- a/backends/npu/kernels/softmax_kernel.cc
+++ b/backends/npu/kernels/softmax_kernel.cc
@@ -39,6 +39,17 @@ void SoftmaxGradKernel(const Context& dev_ctx,
                        phi::DenseTensor* x_grad) {
   auto dims = x_grad->dims();
   const int rank = dims.size();
+  if (rank == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    T zero = static_cast<T>(0);
+    auto dst_ptr = x_grad->data<T>();
+    AsyncMemCpyH2D(nullptr,
+                   static_cast<C_Stream>(dev_ctx.stream()),
+                   dst_ptr,
+                   &zero,
+                   sizeof(T));
+    return;
+  }
   axis = custom_kernel::CanonicalAxis(axis, rank);
   int64_t first_dim = 1;
   int64_t sec_dim = 1;

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -2,4 +2,4 @@ disable_ut_npu
 test_adam_op_npu
 test_transpose_op_npu
 test_set_value_op_npu
-test_zero_dim_tensor_npu
+test_bitwise_op_npu


### PR DESCRIPTION
bitwise修改前单测可以通过的原因是因为numpy的问题：
```python
import numpy as np
np.allclose(1,[])
# numpy输出为True，实际期望输出为False
```
这个问题同[宋凯](https://github.com/USTCKAY)商量过，得到的结论是CANN算子的问题，相关问题以提交给[华为方面](https://gitee.com/ascend/modelzoo/issues/I6AODW)