### PR TITLE
[NPU]fix transpose ut core dump

### DIFF
--- a/backends/npu/tests/unittests/CMakeLists.txt
+++ b/backends/npu/tests/unittests/CMakeLists.txt
@@ -64,4 +64,4 @@ set_tests_properties(test_softmax_with_cross_entropy_op_npu
                      PROPERTIES ENVIRONMENT FLAGS_USE_STANDALONE_EXECUTOR=0)
 set_tests_properties(
   test_transpose_op_npu PROPERTIES ENVIRONMENT
-                                   FLAGS_allocator_strategy="auto_growth")
+                                   FLAGS_allocator_strategy=auto_growth)

--- a/backends/npu/tests/unittests/CMakeLists.txt
+++ b/backends/npu/tests/unittests/CMakeLists.txt
@@ -62,3 +62,6 @@ set_tests_properties(test_softmax_op_npu
                      PROPERTIES ENVIRONMENT FLAGS_USE_STANDALONE_EXECUTOR=0)
 set_tests_properties(test_softmax_with_cross_entropy_op_npu
                      PROPERTIES ENVIRONMENT FLAGS_USE_STANDALONE_EXECUTOR=0)
+set_tests_properties(
+  test_transpose_op_npu PROPERTIES ENVIRONMENT
+                                   FLAGS_allocator_strategy="auto_growth")

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -1,4 +1,3 @@
 disable_ut_npu
 test_adam_op_npu
-test_transpose_op_npu
 test_set_value_op_npu


### PR DESCRIPTION
allocator_strategy of naive_best_fit would occupy too much memory, which result in the core dump.