### PR TITLE
[NPU]fix conv output dtype mismatch and optimize topk

### DIFF
--- a/backends/npu/kernels/conv_transpose_kernel.cc
+++ b/backends/npu/kernels/conv_transpose_kernel.cc
@@ -85,16 +85,18 @@ void Conv2dTransposeKernel(const Context& dev_ctx,
   auto output_dim_vec = phi::vectorize(output_tensor.dims());
 
   auto stream = dev_ctx.stream();
-  const auto& runner = NpuOpRunner("Conv2DTransposeD",
-                                   {input_tensor, filter},
-                                   {output_tensor},
-                                   {{"input_size", output_dim_vec},
-                                    {"strides", strides_vec},
-                                    {"dilations", dilations_vec},
-                                    {"output_padding", output_padding},
-                                    {"groups", groups},
-                                    {"pads", paddings},
-                                    {"data_format", data_format}});
+  NpuOpRunner runner;
+  runner.SetType("Conv2DTranspose")
+      .AddInput(dev_ctx, std::move(output_dim_vec))
+      .AddInput(input_tensor)
+      .AddInput(filter)
+      .AddOutput(output_tensor)
+      .AddAttr("strides", strides_vec)
+      .AddAttr("pads", paddings)
+      .AddAttr("dilations", dilations_vec)
+      .AddAttr("groups", groups)
+      .AddAttr("data_format", data_format)
+      .AddAttr("output_padding", output_padding);
   runner.Run(stream);
 }
 
@@ -163,10 +165,19 @@ void Conv2dTransposeGradKernel(const Context& dev_ctx,
   auto stream = dev_ctx.stream();
   if (dfilter) {
     dev_ctx.template Alloc<T>(dfilter);
+    // Conv2DBackpropFilterD only support fp32 output, so we need cast the
+    // output when the out dtype is fp16.
+    phi::DenseTensor dfilter_tmp;
+    if (dfilter->dtype() == phi::DataType::FLOAT16) {
+      dfilter_tmp.Resize(dfilter->dims());
+      dev_ctx.template Alloc<float>(&dfilter_tmp);
+    } else {
+      dfilter_tmp = *dfilter;
+    }
     const auto& runner =
         NpuOpRunner("Conv2DBackpropFilterD",
                     {output_grad_tensor, input_tensor},
-                    {*dfilter},
+                    {dfilter_tmp},
                     {{"filter_size", phi::vectorize<int>(filter_dims)},
                      {"strides", strides_vec},
                      {"pads", paddings},
@@ -174,6 +185,12 @@ void Conv2dTransposeGradKernel(const Context& dev_ctx,
                      {"groups", groups},
                      {"data_format", data_format}});
     runner.Run(stream);
+    dev_ctx.Wait();
+    if (dfilter->dtype() == phi::DataType::FLOAT16) {
+      const auto& cast_runner = NpuOpRunner(
+          "Cast", {dfilter_tmp}, {*dfilter}, {{"dst_type", ACL_FLOAT16}});
+      cast_runner.Run(stream);
+    }
   }
   if (dx) {
     dev_ctx.template Alloc<T>(dx);

--- a/backends/npu/kernels/top_k_kernel.cc
+++ b/backends/npu/kernels/top_k_kernel.cc
@@ -26,6 +26,10 @@ void TopkKernel(const Context& dev_ctx,
                 bool sorted,
                 phi::DenseTensor* out,
                 phi::DenseTensor* indices) {
+  const int64_t kMaxTopkSize = 32768;
+  const int64_t kMaxK = 8;
+  const int64_t kMinK = 0;
+
   if (axis < 0) {
     axis += x.dims().size();
   }
@@ -47,9 +51,13 @@ void TopkKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<int32_t>(&indices_int32);
 
   auto npu_stream = dev_ctx.stream();
+  // TopK have a better performance in this case.
+  std::string op_type =
+      ((x.numel() > kMaxTopkSize) && (k > kMinK) && (k < kMaxK)) ? "TopK"
+                                                                 : "TopKV2";
 
   NpuOpRunner npu_op_runner_topkv2;
-  npu_op_runner_topkv2.SetType("TopKV2")
+  npu_op_runner_topkv2.SetType(op_type)
       .AddInput(x)
       .AddInput(dev_ctx, std::vector<int32_t>{k})
       .AddOutput(*out)


### PR DESCRIPTION
1.CANN op DepthwiseConv2DBackpropFilterD、Conv3DBackpropFilterD and Conv2DBackpropFilterD only support fp32 output, so output of fp16 dtype would lead to error, we cast the output of these ops to fp16 instead.
2.TopK have a better performance than TopKV2 in some cases, so we apply TopK in these situations. [Reference pytorch](https://gitee.com/ascend/pytorch/blob/v1.8.1/torch_npu/csrc/aten/ops/TopKKernelNpu.cpp#L41)