### PR TITLE
[NPU]add GRU mode support for rnn kernel

### DIFF
--- a/backends/npu/tests/unittests/test_rnn_op_npu.py
+++ b/backends/npu/tests/unittests/test_rnn_op_npu.py
@@ -19,10 +19,9 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle.fluid import core
 
 from tests.convert import get_params_for_net
-from tests.rnn_numpy import LSTM
+from tests.rnn_numpy import LSTM, GRU
 
 random.seed(2)
 np.set_printoptions(threshold=np.inf)
@@ -79,11 +78,7 @@ class TestRNNOp(OpTest):
         self.python_out_sig = ["Out", "DropoutState", "State"]
         self.python_out_sig_sub_name = {"State": ["last_hidden", "last_cell"]}
         self.dtype = np.float32
-        self.sequence_length = (
-            None
-            if core.is_compiled_with_rocm()
-            else np.array([12, 11, 10, 9, 8], dtype=np.int32)
-        )
+        self.sequence_length = np.array([12, 11, 10, 9, 8], dtype=np.int32)
         self.num_layers = 1
         self.is_bidirec = False
         self.mode = "LSTM"
@@ -261,6 +256,147 @@ class TestRNNOp8(TestRNNOp):
 class TestRNNOp9(TestRNNOp):
     def set_attrs(self):
         self.num_layers = 3
+
+
+class TestGRUOp(OpTest):
+    def get_weight_names(self):
+        weight_names = []
+        for i in range(self.num_layers):
+            for j in range(0, 2 * self.direction_num):
+                weight_names.append("{}.weight_{}".format(i, j))
+        for i in range(self.num_layers):
+            for j in range(0, 2 * self.direction_num):
+                weight_names.append("{}.bias_{}".format(i, j))
+        return weight_names
+
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "rnn"
+        self.dtype = "float32"
+        self.sequence_length = (
+            None
+            # np.array([12, 11, 10, 9, 8, 7, 6, 5], dtype=np.int32)
+        )
+        self.num_layers = 1
+        self.is_bidirec = False
+        self.is_test = False
+        self.mode = "GRU"
+        self.dropout = 0.0
+        seq_length = 12
+        batch_size = 8
+        input_size = 4
+        self.hidden_size = 2
+        self.set_attrs()
+
+        self.direction_num = 2 if self.is_bidirec else 1
+        direction = "bidirectional" if self.is_bidirec else "forward"
+
+        input = np.random.uniform(
+            low=-0.1, high=0.1, size=(seq_length, batch_size, input_size)
+        ).astype(self.dtype)
+
+        if self.sequence_length is not None:
+            input[3][1:][:] = 0
+            input[4][2:][:] = 0
+            input[2][3:][:] = 0
+            input[1][4:][:] = 0
+
+        rnn1 = GRU(
+            input_size,
+            self.hidden_size,
+            num_layers=self.num_layers,
+            time_major=True,
+            direction=direction,
+            dropout=self.dropout,
+            dtype=self.dtype,
+        )
+
+        flat_w = get_params_for_net(rnn1)
+
+        output, last_hidden = rnn1(input, sequence_length=self.sequence_length)
+
+        init_h = np.zeros(
+            (self.num_layers * self.direction_num, batch_size, self.hidden_size)
+        ).astype(self.dtype)
+
+        state_out = np.ndarray((300)).astype("uint8")
+
+        self.inputs = {
+            "Input": input,
+            "WeightList": flat_w,
+            "PreState": [("init_h", init_h)],
+            "SequenceLength": self.sequence_length,
+        }
+        if self.sequence_length is None:
+            self.inputs = {
+                "Input": input,
+                "WeightList": flat_w,
+                "PreState": [("init_h", init_h)],
+            }
+        self.attrs = {
+            "dropout_prob": self.dropout,
+            "is_bidirec": self.is_bidirec,
+            "input_size": input_size,
+            "hidden_size": self.hidden_size,
+            "num_layers": self.num_layers,
+            "is_test": self.is_test,
+            "mode": self.mode,
+        }
+        self.outputs = {
+            "Out": output,
+            "State": [("last_hidden", last_hidden)],
+            "Reserve": np.ndarray((400)).astype("uint8"),
+            "DropoutState": state_out,
+        }
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+        self.place = paddle.CustomPlace("npu", 0)
+
+    def set_attrs(self):
+        pass
+
+    def test_output(self):
+        self.check_output_with_place(
+            self.place, no_check_set=["Reserve", "DropoutState"], atol=1e-3
+        )
+
+    # def test_grad(self):
+    #     if not self.is_test:
+    #         var_name_list = self.get_weight_names()
+    #         grad_check_list = ['Input', 'init_h']
+    #         grad_check_list.extend(var_name_list)
+    #         self.check_grad_with_place(self.place, set(grad_check_list), ['Out', 'last_hidden'])
+
+
+class TestGRUOp1(TestGRUOp):
+    def set_attrs(self):
+        self.sequence_length = None
+
+
+class TestGRUOp2(TestGRUOp):
+    def set_attrs(self):
+        self.sequence_length = None
+        self.is_bidirec = True
+
+
+class TestGRUOp3(TestGRUOp):
+    def set_attrs(self):
+        self.sequence_length = None
+        self.is_test = True
+
+
+class TestGRUOp4(TestGRUOp):
+    def set_attrs(self):
+        self.sequence_length = None
+        self.is_bidirec = True
+        self.is_test = True
+
+
+class TestGRUOpAvx(TestGRUOp):
+    def set_attrs(self):
+        self.dtype = "float32"
+        self.hidden_size = 8
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1.为RNN kernel增加GRU模式的支持。与pytotch-npu RNN kernel对齐，支持双向，不支持多层。
2.CANN op DynamicGRUV2传入seq_length并不生效，目前向model zoo进行了反馈（[issue链接](https://gitee.com/ascend/modelzoo/issues/I6S1QK?from=project-issue)），暂时强制参数sequence_length中的值与输入序列的长度相同。
3.优化了LSTM模式实现逻辑