### PR TITLE
[NPU]fix ci

### DIFF
--- a/backends/npu/kernels/reduce_mean_kernel.cc
+++ b/backends/npu/kernels/reduce_mean_kernel.cc
@@ -99,7 +99,7 @@ void MeanGradKernel(const Context& dev_ctx,
     FillNpuTensorWithConstant<T>(
         &tensor_value,
         dev_ctx,
-        static_cast<T>(1.0f / static_cast<T>(reduce_numel)));
+        static_cast<T>(static_cast<T>(1.0f) / static_cast<T>(reduce_numel)));
 
     NpuOpRunner runner;
     runner.SetType("Fill")
@@ -110,7 +110,9 @@ void MeanGradKernel(const Context& dev_ctx,
   } else {
     // CANN op Fill/FillD would raise error when output's numel is 1.
     FillNpuTensorWithConstant<T>(
-        x_grad, dev_ctx, static_cast<T>(1.0f / static_cast<T>(reduce_numel)));
+        x_grad,
+        dev_ctx,
+        static_cast<T>(static_cast<T>(1.0f) / static_cast<T>(reduce_numel)));
   }
 
   phi::DenseTensor transformed_x_grad, transformed_out_grad;
@@ -134,11 +136,23 @@ void MeanGradKernel(const Context& dev_ctx,
 
 }  // namespace custom_kernel
 
-PD_REGISTER_PLUGIN_KERNEL(
-    mean_raw, npu, ALL_LAYOUT, custom_kernel::MeanRawKernel, float) {}
+PD_REGISTER_PLUGIN_KERNEL(mean_raw,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::MeanRawKernel,
+                          float,
+                          phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(
-    mean, npu, ALL_LAYOUT, custom_kernel::MeanKernel, float) {}
+PD_REGISTER_PLUGIN_KERNEL(mean,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::MeanKernel,
+                          float,
+                          phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(
-    mean_grad, npu, ALL_LAYOUT, custom_kernel::MeanGradKernel, float) {}
+PD_REGISTER_PLUGIN_KERNEL(mean_grad,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::MeanGradKernel,
+                          float,
+                          phi::dtype::float16) {}

--- a/backends/npu/tests/unittests/test_abs_op_npu.py
+++ b/backends/npu/tests/unittests/test_abs_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division
 
 import numpy as np
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_accuracy_op_npu.py
+++ b/backends/npu/tests/unittests/test_accuracy_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 
@@ -35,9 +33,9 @@ class TestAccuracy(OpTest):
         np.random.seed(SEED)
         n = 8192
         infer = np.random.random((n, 1)).astype(self.dtype)
-        indices = np.random.randint(0, 2, (n, 1)).astype('int64')
-        label = np.random.randint(0, 2, (n, 1)).astype('int64')
-        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        indices = np.random.randint(0, 2, (n, 1)).astype("int64")
+        label = np.random.randint(0, 2, (n, 1)).astype("int64")
+        self.inputs = {"Out": infer, "Indices": indices, "Label": label}
         num_correct = 0
         for rowid in range(n):
             for ele in indices[rowid]:
@@ -45,14 +43,14 @@ class TestAccuracy(OpTest):
                     num_correct += 1
                     break
         self.outputs = {
-            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
-            'Correct': np.array([num_correct]).astype("int32"),
-            'Total': np.array([n]).astype("int32")
+            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
+            "Correct": np.array([num_correct]).astype("int32"),
+            "Total": np.array([n]).astype("int32"),
         }
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -69,9 +67,9 @@ class TestAccuracy2(TestAccuracy):
         np.random.seed(SEED)
         n = 8192
         infer = np.random.random((n, 100)).astype(self.dtype)
-        indices = np.random.randint(0, 1000, (n, 100)).astype('int64')
-        label = np.random.randint(0, 1000, (n, 1)).astype('int64')
-        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        indices = np.random.randint(0, 1000, (n, 100)).astype("int64")
+        label = np.random.randint(0, 1000, (n, 1)).astype("int64")
+        self.inputs = {"Out": infer, "Indices": indices, "Label": label}
         num_correct = 0
         for rowid in range(n):
             for ele in indices[rowid]:
@@ -79,9 +77,9 @@ class TestAccuracy2(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
-            'Correct': np.array([num_correct]).astype("int32"),
-            'Total': np.array([n]).astype("int32")
+            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
+            "Correct": np.array([num_correct]).astype("int32"),
+            "Total": np.array([n]).astype("int32"),
         }
 
 
@@ -93,9 +91,9 @@ class TestAccuracyType(TestAccuracy):
         np.random.seed(SEED)
         n = 8192
         infer = np.random.random((n, 100)).astype(self.dtype)
-        indices = np.random.randint(0, 1000, (n, 100)).astype('int64')
-        label = np.random.randint(0, 1000, (n, 1)).astype('int32')
-        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        indices = np.random.randint(0, 1000, (n, 100)).astype("int64")
+        label = np.random.randint(0, 1000, (n, 1)).astype("int32")
+        self.inputs = {"Out": infer, "Indices": indices, "Label": label}
         num_correct = 0
         for rowid in range(n):
             for ele in indices[rowid]:
@@ -103,9 +101,9 @@ class TestAccuracyType(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
-            'Correct': np.array([num_correct]).astype("int32"),
-            'Total': np.array([n]).astype("int32")
+            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
+            "Correct": np.array([num_correct]).astype("int32"),
+            "Total": np.array([n]).astype("int32"),
         }
 
 
@@ -117,9 +115,9 @@ class TestAccuracyType2(TestAccuracy):
         np.random.seed(SEED)
         n = 8192
         infer = np.random.random((n, 100)).astype(self.dtype)
-        indices = np.random.randint(0, 1000, (n, 100)).astype('int32')
-        label = np.random.randint(0, 1000, (n, 1)).astype('int64')
-        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        indices = np.random.randint(0, 1000, (n, 100)).astype("int32")
+        label = np.random.randint(0, 1000, (n, 1)).astype("int64")
+        self.inputs = {"Out": infer, "Indices": indices, "Label": label}
         num_correct = 0
         for rowid in range(n):
             for ele in indices[rowid]:
@@ -127,11 +125,11 @@ class TestAccuracyType2(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
-            'Correct': np.array([num_correct]).astype("int32"),
-            'Total': np.array([n]).astype("int32")
+            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
+            "Correct": np.array([num_correct]).astype("int32"),
+            "Total": np.array([n]).astype("int32"),
         }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_activation_op.py
+++ b/backends/npu/tests/unittests/test_activation_op.py
@@ -22,7 +22,7 @@ from scipy.special import erf
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021
@@ -39,7 +39,7 @@ class TestActivation(OpTest):
         self.init_dtype()
         self.init_shape()
         self.init_kernel_type()
-        self.check_eager = True
+        self.check_dygraph = True
         self.python_api = paddle.exp
 
         np.random.seed(2049)
@@ -50,18 +50,20 @@ class TestActivation(OpTest):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        check_eager = False
-        if hasattr(self, "check_eager"):
-            check_eager = self.check_eager
-        self.check_output_with_place(self.place, check_eager=check_eager)
+        check_dygraph = False
+        if hasattr(self, "check_dygraph"):
+            check_dygraph = self.check_dygraph
+        self.check_output_with_place(self.place, check_dygraph=check_dygraph)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        check_eager = False
-        if hasattr(self, "check_eager"):
-            check_eager = self.check_eager
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=check_eager)
+        check_dygraph = False
+        if hasattr(self, "check_dygraph"):
+            check_dygraph = self.check_dygraph
+        self.check_grad_with_place(
+            self.place, ["X"], "Out", check_dygraph=check_dygraph
+        )
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -370,7 +372,7 @@ class TestCELU(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=True)
+        self.check_grad_with_place(self.place, ["X"], "Out", check_dygraph=True)
 
 
 class TestCELU_ZeroDim(TestCELU):
@@ -427,7 +429,7 @@ class TestLog(TestActivation):
     def setUp(self):
         self.set_npu()
         self.op_type = "log"
-        self.check_eager = True
+        self.check_dygraph = True
         self.python_api = paddle.log
         self.init_dtype()
         self.init_shape()
@@ -442,7 +444,7 @@ class TestLog(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=True)
+        self.check_grad_with_place(self.place, ["X"], "Out", check_dygraph=True)
 
 
 class TestLog_ZeroDim(TestLog):
@@ -455,7 +457,7 @@ class TestPow(TestActivation):
         self.set_npu()
         self.op_type = "pow"
         self.python_api = paddle.pow
-        self.check_eager = True
+        self.check_dygraph = True
         self.init_dtype()
         self.init_shape()
 
@@ -468,13 +470,13 @@ class TestPow(TestActivation):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_eager=self.check_eager)
+        self.check_output_with_place(self.place, check_dygraph=self.check_dygraph)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         self.check_grad_with_place(
-            self.place, ["X"], "Out", check_eager=self.check_eager
+            self.place, ["X"], "Out", check_dygraph=self.check_dygraph
         )
 
 
@@ -487,7 +489,7 @@ class TestPow_factor_tensor(TestActivation):
     def setUp(self):
         self.set_npu()
         self.op_type = "pow"
-        self.check_eager = False
+        self.check_dygraph = False
         self.python_api = paddle.pow
         self.init_dtype()
 
@@ -504,13 +506,13 @@ class TestPow_factor_tensor(TestActivation):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_eager=self.check_eager)
+        self.check_output_with_place(self.place, check_dygraph=self.check_dygraph)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         self.check_grad_with_place(
-            self.place, ["X"], "Out", check_eager=self.check_eager
+            self.place, ["X"], "Out", check_dygraph=self.check_dygraph
         )
 
 
@@ -613,7 +615,7 @@ class TestRelu6(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=True)
+        self.check_grad_with_place(self.place, ["X"], "Out", check_dygraph=True)
 
 
 class TestRelu6_ZeroDim(TestRelu6):
@@ -683,11 +685,11 @@ class TestSquare(TestActivation):
         if self.dtype == np.float16:
             return
         self.check_grad_with_place(
-            self.place, ["X"], "Out", max_relative_error=0.007, check_eager=True
+            self.place, ["X"], "Out", max_relative_error=0.007, check_dygraph=True
         )
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_eager=True)
+        self.check_output_with_place(self.place, check_dygraph=True)
 
 
 class TestSquare_ZeroDim(TestSquare):
@@ -713,10 +715,10 @@ class TestSqrt(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=True)
+        self.check_grad_with_place(self.place, ["X"], "Out", check_dygraph=True)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_eager=True)
+        self.check_output_with_place(self.place, check_dygraph=True)
 
 
 class TestSqrt_ZeroDim(TestSqrt):
@@ -822,7 +824,7 @@ class TestFloor(TestActivation):
     def setUp(self):
         self.set_npu()
         self.op_type = "floor"
-        self.check_eager = True
+        self.check_dygraph = True
         self.python_api = paddle.floor
         self.init_dtype()
         self.init_shape()

--- a/backends/npu/tests/unittests/test_adagrad_op_npu.py
+++ b/backends/npu/tests/unittests/test_adagrad_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_adam_op_npu.py
+++ b/backends/npu/tests/unittests/test_adam_op_npu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_adamw_op_npu.py
+++ b/backends/npu/tests/unittests/test_adamw_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_arg_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_max_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 

--- a/backends/npu/tests/unittests/test_arg_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_min_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_argsort_op_npu.py
+++ b/backends/npu/tests/unittests/test_argsort_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_assign_op_npu.py
+++ b/backends/npu/tests/unittests/test_assign_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_assign_value_op_npu.py
+++ b/backends/npu/tests/unittests/test_assign_value_op_npu.py
@@ -20,7 +20,7 @@ import numpy
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.framework as framework
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 numpy.random.seed(2021)

--- a/backends/npu/tests/unittests/test_batch_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_batch_norm_op_npu.py
@@ -22,7 +22,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
 from paddle.framework import set_flags
-from tests.op_test import _set_use_system_allocator
+from tests.eager_op_test import _set_use_system_allocator
 
 _set_use_system_allocator(False)
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_bce_loss_npu.py
+++ b/backends/npu/tests/unittests/test_bce_loss_npu.py
@@ -18,7 +18,7 @@ import paddle
 import paddle.fluid as fluid
 import numpy as np
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_bilinear_interp_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_bilinear_interp_v2_op_npu.py
@@ -16,27 +16,26 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
-from tests.op_test import OpTest
-import paddle.fluid.core as core
+from tests.eager_op_test import OpTest
 import paddle.fluid as fluid
-from paddle.nn.functional import interpolate
 import paddle
 
 paddle.enable_static()
 
 
-def bilinear_interp_np(input,
-                       out_h,
-                       out_w,
-                       scale_w=0,
-                       scale_h=0,
-                       out_size=None,
-                       actual_shape=None,
-                       align_corners=True,
-                       align_mode=0,
-                       data_layout='NCHW'):
+def bilinear_interp_np(
+    input,
+    out_h,
+    out_w,
+    scale_w=0,
+    scale_h=0,
+    out_size=None,
+    actual_shape=None,
+    align_corners=True,
+    align_mode=0,
+    data_layout="NCHW",
+):
     """bilinear interpolation implement in shape [N, C, H, W]"""
     if data_layout == "NHWC":
         input = np.transpose(input, (0, 3, 1, 2))  # NHWC => NCHW
@@ -50,7 +49,7 @@ def bilinear_interp_np(input,
 
     ratio_h = ratio_w = 0.0
     if out_h > 1:
-        if (align_corners):
+        if align_corners:
             ratio_h = (in_h - 1.0) / (out_h - 1.0)
         else:
             if scale_h > 0:
@@ -58,7 +57,7 @@ def bilinear_interp_np(input,
             else:
                 ratio_h = 1.0 * in_h / out_h
     if out_w > 1:
-        if (align_corners):
+        if align_corners:
             ratio_w = (in_w - 1.0) / (out_w - 1.0)
         else:
             if scale_w > 0:
@@ -69,37 +68,39 @@ def bilinear_interp_np(input,
     out = np.zeros((batch_size, channel, out_h, out_w))
 
     for i in range(out_h):
-        if (align_mode == 0 and not align_corners):
+        if align_mode == 0 and not align_corners:
             h = int(ratio_h * (i + 0.5) - 0.5)
         else:
             h = int(ratio_h * i)
 
         h = max(0, h)
         hid = 1 if h < in_h - 1 else 0
-        if (align_mode == 0 and not align_corners):
+        if align_mode == 0 and not align_corners:
             idx_src_h = max(ratio_h * (i + 0.5) - 0.5, 0)
             h1lambda = idx_src_h - h
         else:
             h1lambda = ratio_h * i - h
         h2lambda = 1.0 - h1lambda
         for j in range(out_w):
-            if (align_mode == 0 and not align_corners):
+            if align_mode == 0 and not align_corners:
                 w = int(ratio_w * (j + 0.5) - 0.5)
             else:
                 w = int(ratio_w * j)
             w = max(0, w)
             wid = 1 if w < in_w - 1 else 0
-            if (align_mode == 0 and not align_corners):
+            if align_mode == 0 and not align_corners:
                 idx_src_w = max(ratio_w * (j + 0.5) - 0.5, 0)
                 w1lambda = idx_src_w - w
             else:
                 w1lambda = ratio_w * j - w
             w2lambda = 1.0 - w1lambda
 
-            out[:, :, i, j] = h2lambda*(w2lambda*input[:, :, h, w] +
-                                        w1lambda*input[:, :, h, w+wid]) + \
-                h1lambda*(w2lambda*input[:, :, h+hid, w] +
-                          w1lambda*input[:, :, h+hid, w+wid])
+            out[:, :, i, j] = h2lambda * (
+                w2lambda * input[:, :, h, w] + w1lambda * input[:, :, h, w + wid]
+            ) + h1lambda * (
+                w2lambda * input[:, :, h + hid, w]
+                + w1lambda * input[:, :, h + hid, w + wid]
+            )
 
     if data_layout == "NHWC":
         out = np.transpose(out, (0, 2, 3, 1))  # NCHW => NHWC
@@ -110,13 +111,13 @@ def bilinear_interp_np(input,
 class TestBilinearInterpOp(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
         self.out_size = None
         self.actual_shape = None
-        self.data_layout = 'NCHW'
+        self.data_layout = "NCHW"
         self.init_test_case()
         self.op_type = "bilinear_interp_v2"
         input_np = np.random.random(self.input_shape).astype(self.dtype)
@@ -131,7 +132,7 @@ class TestBilinearInterpOp(OpTest):
         scale_w = 0
         if self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
-                if self.scale > 0.:
+                if self.scale > 0.0:
                     scale_h = scale_w = float(self.scale)
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 scale_w = scale_h = self.scale[0]
@@ -144,63 +145,77 @@ class TestBilinearInterpOp(OpTest):
             out_h = self.out_h
             out_w = self.out_w
 
-        output_np = bilinear_interp_np(input_np, out_h, out_w, scale_w, scale_h,
-                                       self.out_size, self.actual_shape,
-                                       self.align_corners, self.align_mode,
-                                       self.data_layout)
+        output_np = bilinear_interp_np(
+            input_np,
+            out_h,
+            out_w,
+            scale_w,
+            scale_h,
+            self.out_size,
+            self.actual_shape,
+            self.align_corners,
+            self.align_mode,
+            self.data_layout,
+        )
 
-        self.inputs = {'X': input_np}
+        self.inputs = {"X": input_np}
         if self.out_size is not None:
-            self.inputs['OutSize'] = self.out_size
+            self.inputs["OutSize"] = self.out_size
         if self.actual_shape is not None:
-            self.inputs['OutSize'] = self.actual_shape
+            self.inputs["OutSize"] = self.actual_shape
 
         self.attrs = {
-            'out_h': self.out_h,
-            'out_w': self.out_w,
-            'interp_method': self.interp_method,
-            'align_corners': self.align_corners,
-            'align_mode': self.align_mode,
-            'data_layout': self.data_layout
+            "out_h": self.out_h,
+            "out_w": self.out_w,
+            "interp_method": self.interp_method,
+            "align_corners": self.align_corners,
+            "align_mode": self.align_mode,
+            "data_layout": self.data_layout,
         }
         if self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
-                if self.scale > 0.:
+                if self.scale > 0.0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]
-            self.attrs['scale'] = self.scale
-        self.outputs = {'Out': output_np}
+            self.attrs["scale"] = self.scale
+        self.outputs = {"Out": output_np}
 
     def test_check_output(self):
         self.check_output_with_place(self.place, atol=self.atol)
 
     def test_check_grad(self):
         self.__class__.exist_check_grad = True
-        if self.dtype == 'float16':
+        if self.dtype == "float16":
             return
         self.max_relative_error = 0.005
-        inputs_to_check = ['X']
-        output_names = ['Out']
+        inputs_to_check = ["X"]
+        output_names = ["Out"]
         no_grad_set = set()
         cpu_place = fluid.CPUPlace()
-        cpu_grads = self._get_gradient(inputs_to_check, cpu_place, output_names,
-                                       no_grad_set)
-        npu_grads = self._get_gradient(inputs_to_check, self.place,
-                                       output_names, no_grad_set)
-        self._assert_is_close(cpu_grads, npu_grads, inputs_to_check,
-                              self.max_relative_error,
-                              "Gradient Check between places")
+        cpu_grads = self._get_gradient(
+            inputs_to_check, cpu_place, output_names, no_grad_set
+        )
+        npu_grads = self._get_gradient(
+            inputs_to_check, self.place, output_names, no_grad_set
+        )
+        self._assert_is_close(
+            cpu_grads,
+            npu_grads,
+            inputs_to_check,
+            self.max_relative_error,
+            "Gradient Check between places",
+        )
 
     def init_test_case(self):
-        self.interp_method = 'bilinear'
+        self.interp_method = "bilinear"
         self.input_shape = [2, 3, 5, 7]
         self.out_h = 60
         self.out_w = 25
         self.scale = 1.5
         self.align_corners = False
         self.align_mode = 1
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.atol = 1e-5
 
 
@@ -213,16 +228,17 @@ class TestBilinearInterpOpAlignCornerTrue(TestBilinearInterpOp):
 class TestBilinearInterpCaseFP16(TestBilinearInterpOp):
     def init_test_case(self):
         super(TestBilinearInterpCaseFP16, self).init_test_case()
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.atol = 1e-2
+
 
 class TestBilinearInterpCaseFP16AlignCornerTrue(TestBilinearInterpOp):
     def init_test_case(self):
         super(TestBilinearInterpCaseFP16AlignCornerTrue, self).init_test_case()
-        self.dtype = 'float16'
+        self.dtype = "float16"
         self.atol = 1e-2
         self.align_corners = True
-         
+
 
 class TestBilinearInterpCase1(TestBilinearInterpOp):
     def init_test_case(self):
@@ -230,7 +246,7 @@ class TestBilinearInterpCase1(TestBilinearInterpOp):
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
-        self.scale = 0.
+        self.scale = 0.0
 
 
 class TestBilinearInterpCase1AlignCornerTrue(TestBilinearInterpOp):
@@ -239,7 +255,7 @@ class TestBilinearInterpCase1AlignCornerTrue(TestBilinearInterpOp):
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
-        self.scale = 0.
+        self.scale = 0.0
         self.align_corners = True
 
 
@@ -249,7 +265,7 @@ class TestBilinearInterpCase2(TestBilinearInterpOp):
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
-        self.scale = 0.
+        self.scale = 0.0
 
 
 class TestBilinearInterpCase2AlignCornerTrue(TestBilinearInterpOp):
@@ -258,7 +274,7 @@ class TestBilinearInterpCase2AlignCornerTrue(TestBilinearInterpOp):
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
-        self.scale = 0.
+        self.scale = 0.0
         self.align_corners = True
 
 
@@ -268,7 +284,7 @@ class TestBilinearInterpCase3(TestBilinearInterpOp):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
 
 
 class TestBilinearInterpCase31(TestBilinearInterpOp):
@@ -277,7 +293,7 @@ class TestBilinearInterpCase31(TestBilinearInterpOp):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
         self.align_corners = True
 
 
@@ -287,7 +303,7 @@ class TestBilinearInterpCase4(TestBilinearInterpOp):
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([2, 2]).astype("int32")
 
 
@@ -297,7 +313,7 @@ class TestBilinearInterpCase41(TestBilinearInterpOp):
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([2, 2]).astype("int32")
         self.align_corners = True
 
@@ -308,7 +324,7 @@ class TestBilinearInterpCase5(TestBilinearInterpOp):
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([11, 11]).astype("int32")
 
 
@@ -318,7 +334,7 @@ class TestBilinearInterpCase51(TestBilinearInterpOp):
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([11, 11]).astype("int32")
         self.align_corners = True
 
@@ -329,7 +345,7 @@ class TestBilinearInterpCase6(TestBilinearInterpOp):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([65, 33]).astype("int32")
 
 
@@ -339,7 +355,7 @@ class TestBilinearInterpCase61(TestBilinearInterpOp):
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([65, 33]).astype("int32")
         self.align_corners = True
 
@@ -369,7 +385,7 @@ class TestBilinearInterpSame(TestBilinearInterpOp):
         self.input_shape = [2, 3, 32, 64]
         self.out_h = 32
         self.out_w = 64
-        self.scale = 0.
+        self.scale = 0.0
 
 
 class TestBilinearInterpSame1(TestBilinearInterpOp):
@@ -378,7 +394,7 @@ class TestBilinearInterpSame1(TestBilinearInterpOp):
         self.input_shape = [2, 3, 32, 64]
         self.out_h = 32
         self.out_w = 64
-        self.scale = 0.
+        self.scale = 0.0
         self.align_corners = True
 
 
@@ -388,7 +404,7 @@ class TestBilinearInterpActualShape(TestBilinearInterpOp):
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([66, 40]).astype("int32")
 
 
@@ -398,7 +414,7 @@ class TestBilinearInterpActualShape1(TestBilinearInterpOp):
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 64
         self.out_w = 32
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([66, 40]).astype("int32")
         self.align_corners = True
 
@@ -409,7 +425,7 @@ class TestBilinearInterpDataLayout(TestBilinearInterpOp):
         self.input_shape = [2, 5, 5, 3]
         self.out_h = 2
         self.out_w = 2
-        self.scale = 0.
+        self.scale = 0.0
         self.out_size = np.array([3, 3]).astype("int32")
         self.data_layout = "NHWC"
 
@@ -431,6 +447,7 @@ class TestBilinearInterpOtherMethod3(TestBilinearInterpOp):
         self.align_corners = True
         self.align_mode = 1
 
+
 class TestBilinearInterpWithMethod4(TestBilinearInterpOp):
     def set_align_mode(self):
         self.align_corners = True
@@ -443,7 +460,7 @@ class TestBilinearInterpScale1(TestBilinearInterpOp):
         self.input_shape = [2, 3, 5, 7]
         self.out_h = 60
         self.out_w = 25
-        self.scale = 2.
+        self.scale = 2.0
 
 
 class TestBilinearInterpScale2(TestBilinearInterpOp):
@@ -452,7 +469,7 @@ class TestBilinearInterpScale2(TestBilinearInterpOp):
         self.input_shape = [2, 3, 5, 7]
         self.out_h = 60
         self.out_w = 25
-        self.scale = 1.
+        self.scale = 1.0
 
 
 class TestBilinearInterpScale3(TestBilinearInterpOp):
@@ -461,7 +478,7 @@ class TestBilinearInterpScale3(TestBilinearInterpOp):
         self.input_shape = [2, 3, 5, 7]
         self.out_h = 60
         self.out_w = 25
-        self.scale = 2.
+        self.scale = 2.0
         self.align_corners = True
 
 
@@ -471,7 +488,7 @@ class TestBilinearInterpScale4(TestBilinearInterpOp):
         self.input_shape = [2, 3, 5, 7]
         self.out_h = 60
         self.out_w = 25
-        self.scale = 1.
+        self.scale = 1.0
         self.align_corners = True
 
 
@@ -484,6 +501,7 @@ class TestBilinearInterpZero(TestBilinearInterpOp):
         self.scale = 0.2
         self.align_mode = 0
 
+
 class TestBilinearInterpZero1(TestBilinearInterpOp):
     def init_test_case(self):
         super(TestBilinearInterpZero1, self).init_test_case()
@@ -493,6 +511,7 @@ class TestBilinearInterpZero1(TestBilinearInterpOp):
         self.scale = 0.2
         self.align_mode = 0
         self.align_corners = True
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_bitwise_op_npu.py
+++ b/backends/npu/tests/unittests/test_bitwise_op_npu.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 

--- a/backends/npu/tests/unittests/test_bmm_op_npu.py
+++ b/backends/npu/tests/unittests/test_bmm_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_box_coder_op_npu.py
+++ b/backends/npu/tests/unittests/test_box_coder_op_npu.py
@@ -16,10 +16,8 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
-import math
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -27,8 +25,8 @@ np.random.seed(2021)
 
 
 def box_decoder(t_box, p_box, pb_v, output_box, norm, axis=0):
-    pb_w = p_box[:, 2] - p_box[:, 0] + (norm == False)
-    pb_h = p_box[:, 3] - p_box[:, 1] + (norm == False)
+    pb_w = p_box[:, 2] - p_box[:, 0] + (not norm)
+    pb_h = p_box[:, 3] - p_box[:, 1] + (not norm)
     pb_x = pb_w * 0.5 + p_box[:, 0]
     pb_y = pb_h * 0.5 + p_box[:, 1]
 
@@ -40,8 +38,11 @@ def box_decoder(t_box, p_box, pb_v, output_box, norm, axis=0):
     pb_y = pb_y.reshape(shape)
 
     if pb_v.ndim == 2:
-        var_shape = (1, pb_v.shape[0], pb_v.shape[1]) if axis == 0 else (
-            pb_v.shape[0], 1, pb_v.shape[1])
+        var_shape = (
+            (1, pb_v.shape[0], pb_v.shape[1])
+            if axis == 0
+            else (pb_v.shape[0], 1, pb_v.shape[1])
+        )
         pb_v = pb_v.reshape(var_shape)
     if pb_v.ndim == 1:
         tb_x = pb_v[0] * t_box[:, :, 0] * pb_w + pb_x
@@ -60,8 +61,8 @@ def box_decoder(t_box, p_box, pb_v, output_box, norm, axis=0):
 
 
 def box_encoder(t_box, p_box, pb_v, output_box, norm):
-    pb_w = p_box[:, 2] - p_box[:, 0] + (norm == False)
-    pb_h = p_box[:, 3] - p_box[:, 1] + (norm == False)
+    pb_w = p_box[:, 2] - p_box[:, 0] + (not norm)
+    pb_h = p_box[:, 3] - p_box[:, 1] + (not norm)
     pb_x = pb_w * 0.5 + p_box[:, 0]
     pb_y = pb_h * 0.5 + p_box[:, 1]
     shape = (1, p_box.shape[0])
@@ -98,18 +99,21 @@ def batch_box_coder(p_box, pb_v, t_box, lod, code_type, norm, axis=0):
     cur_offset = 0
 
     for i in range(len(lod)):
-        if (code_type == "encode_center_size"):
-            box_encoder(t_box[cur_offset:(cur_offset + lod[i]), :], p_box, pb_v,
-                        output_box[cur_offset:(cur_offset + lod[i]), :, :],
-                        norm)
-        elif (code_type == "decode_center_size"):
+        if code_type == "encode_center_size":
+            box_encoder(
+                t_box[cur_offset : (cur_offset + lod[i]), :],
+                p_box,
+                pb_v,
+                output_box[cur_offset : (cur_offset + lod[i]), :, :],
+                norm,
+            )
+        elif code_type == "decode_center_size":
             box_decoder(t_box, p_box, pb_v, output_box, norm, axis)
         cur_offset += lod[i]
     return output_box
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+@unittest.skipIf(not paddle.is_compiled_with_npu(), "core is not compiled with NPU")
 class TestBoxCoderOp(OpTest):
     def setUp(self):
         self.op_type = "box_coder"
@@ -123,7 +127,7 @@ class TestBoxCoderOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -131,7 +135,7 @@ class TestBoxCoderOp(OpTest):
     def set_init_config(self):
         self.M = 81
         self.N = 20
-        self.code_type = 'decode_center_size'
+        self.code_type = "decode_center_size"
         self.box_normalized = False
         self.lod = [[1, 1, 1, 1, 1]]
         self.axis = 0
@@ -141,10 +145,10 @@ class TestBoxCoderOp(OpTest):
 
     def set_inputs(self):
         self.inputs = {}
-        assert (self.code_type in ['decode_center_size', 'encode_center_size'])
-        assert (self.axis in [0, 1])
-        if self.code_type == 'decode_center_size':
-            assert (not self.use_variance or not self.without_prior_box_var)
+        assert self.code_type in ["decode_center_size", "encode_center_size"]
+        assert self.axis in [0, 1]
+        if self.code_type == "decode_center_size":
+            assert not self.use_variance or not self.without_prior_box_var
 
             self.prior_box = np.random.random((self.M, 4)).astype(self.dtype)
 
@@ -154,50 +158,57 @@ class TestBoxCoderOp(OpTest):
                 if self.without_prior_box_var:
                     self.prior_box_var = np.ones((self.M, 4)).astype(self.dtype)
                 else:
-                    self.prior_box_var = np.random.random(
-                        (self.M, 4)).astype(self.dtype)
+                    self.prior_box_var = np.random.random((self.M, 4)).astype(
+                        self.dtype
+                    )
 
             if self.axis == 0:
-                self.target_box = np.random.random(
-                    (self.N, self.M, 4)).astype(self.dtype)
+                self.target_box = np.random.random((self.N, self.M, 4)).astype(
+                    self.dtype
+                )
             else:
-                self.target_box = np.random.random(
-                    (self.M, self.N, 4)).astype(self.dtype)
-            self.inputs['PriorBox'] = self.prior_box
-            self.inputs['TargetBox'] = self.target_box
-            if (not self.use_variance and not self.without_prior_box_var):
-                self.inputs['PriorBoxVar'] = self.prior_box_var
+                self.target_box = np.random.random((self.M, self.N, 4)).astype(
+                    self.dtype
+                )
+            self.inputs["PriorBox"] = self.prior_box
+            self.inputs["TargetBox"] = self.target_box
+            if not self.use_variance and not self.without_prior_box_var:
+                self.inputs["PriorBoxVar"] = self.prior_box_var
         else:
-            #encode_center_size
+            # encode_center_size
             self.prior_box = np.random.random((self.M, 4)).astype(self.dtype)
             if self.use_variance:
                 self.prior_box_var = np.random.random(4).astype(self.dtype)
             else:
-                self.prior_box_var = np.random.random(
-                    (self.M, 4)).astype(self.dtype)
+                self.prior_box_var = np.random.random((self.M, 4)).astype(self.dtype)
             self.target_box = np.random.random((self.N, 4)).astype(self.dtype)
-            self.inputs['PriorBox'] = self.prior_box
-            #self.inputs['PriorBoxVar'] = self.prior_box_var
-            self.inputs['TargetBox'] = (self.target_box, self.lod)
-            if (not self.use_variance):
-                self.inputs['PriorBoxVar'] = self.prior_box_var
+            self.inputs["PriorBox"] = self.prior_box
+            # self.inputs['PriorBoxVar'] = self.prior_box_var
+            self.inputs["TargetBox"] = (self.target_box, self.lod)
+            if not self.use_variance:
+                self.inputs["PriorBoxVar"] = self.prior_box_var
 
     def set_attrs(self):
         self.attrs = {
-            'code_type': self.code_type,
-            'box_normalized': self.box_normalized
+            "code_type": self.code_type,
+            "box_normalized": self.box_normalized,
         }
         if self.use_variance:
-            self.attrs['variance'] = self.prior_box_var.astype(
-                np.float64).flatten()
+            self.attrs["variance"] = self.prior_box_var.astype(np.float64).flatten()
         if self.axis != 0:
-            self.attrs['axis'] = self.axis
+            self.attrs["axis"] = self.axis
 
     def set_outputs(self):
         output_box = batch_box_coder(
-            self.prior_box, self.prior_box_var, self.target_box, self.lod[0],
-            self.code_type, self.box_normalized, self.axis)
-        self.outputs = {'OutputBox': output_box.astype(self.dtype)}
+            self.prior_box,
+            self.prior_box_var,
+            self.target_box,
+            self.lod[0],
+            self.code_type,
+            self.box_normalized,
+            self.axis,
+        )
+        self.outputs = {"OutputBox": output_box.astype(self.dtype)}
 
     def test_check_output(self):
         self.check_output_with_place(self.place, atol=self.atol)
@@ -216,7 +227,7 @@ class TestBoxCoderOpWithLoD(TestBoxCoderOp):
         self.M = 20
         self.N = 50
         self.lod = [[10, 20, 20]]
-        self.code_type = 'encode_center_size'
+        self.code_type = "encode_center_size"
         self.box_normalized = True
 
 
@@ -247,5 +258,5 @@ class TestBoxCoderOpFP16(TestBoxCoderOp):
         self.atol = 1e-2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_cast_op_npu.py
+++ b/backends/npu/tests/unittests/test_cast_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 paddle.enable_static()
@@ -32,15 +30,15 @@ class TestCast1(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "cast"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         ipt = np.random.random(size=[10, 10]) + 1
-        self.inputs = {'X': ipt.astype('float32')}
-        self.outputs = {'Out': ipt.astype('float16')}
+        self.inputs = {"X": ipt.astype("float32")}
+        self.outputs = {"Out": ipt.astype("float16")}
 
         self.attrs = {
-            'in_dtype': int(core.VarDesc.VarType.FP32),
-            'out_dtype': int(core.VarDesc.VarType.FP16)
+            "in_dtype": int(core.VarDesc.VarType.FP32),
+            "out_dtype": int(core.VarDesc.VarType.FP16),
         }
 
     def set_npu(self):
@@ -55,15 +53,15 @@ class TestCast2(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "cast"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         ipt = np.random.random(size=[10, 10]) + 1
-        self.inputs = {'X': ipt.astype('float16')}
-        self.outputs = {'Out': ipt.astype('float32')}
+        self.inputs = {"X": ipt.astype("float16")}
+        self.outputs = {"Out": ipt.astype("float32")}
 
         self.attrs = {
-            'in_dtype': int(core.VarDesc.VarType.FP16),
-            'out_dtype': int(core.VarDesc.VarType.FP32)
+            "in_dtype": int(core.VarDesc.VarType.FP16),
+            "out_dtype": int(core.VarDesc.VarType.FP32),
         }
 
     def set_npu(self):
@@ -78,15 +76,15 @@ class TestCast3(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "cast"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         ipt = np.random.random(size=[10, 10]) + 1
-        self.inputs = {'X': ipt.astype('int32')}
-        self.outputs = {'Out': ipt.astype('int32')}
+        self.inputs = {"X": ipt.astype("int32")}
+        self.outputs = {"Out": ipt.astype("int32")}
 
         self.attrs = {
-            'in_dtype': int(core.VarDesc.VarType.INT32),
-            'out_dtype': int(core.VarDesc.VarType.INT32)
+            "in_dtype": int(core.VarDesc.VarType.INT32),
+            "out_dtype": int(core.VarDesc.VarType.INT32),
         }
 
     def set_npu(self):
@@ -96,5 +94,5 @@ class TestCast3(OpTest):
         self.check_output_with_place(self.place, atol=1e-3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_check_nan_inf_op_npu.py
+++ b/backends/npu/tests/unittests/test_check_nan_inf_op_npu.py
@@ -17,10 +17,8 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.static as static
-import paddle.fluid as fluid
 from paddle.static import Program, program_guard
 
 paddle.enable_static()
@@ -32,13 +30,13 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def get_prog(self):
         main_program = Program()
         with program_guard(main_program):
-            a = static.data(name="a", shape=[32, 32], dtype='float32')
-            b = static.data(name="b", shape=[32, 32], dtype='float32')
+            a = static.data(name="a", shape=[32, 32], dtype="float32")
+            b = static.data(name="b", shape=[32, 32], dtype="float32")
             out = a / b
             fp16_a = a.cast(paddle.float16)
             fp16_b = b.cast(paddle.float16)
@@ -47,38 +45,38 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
 
     def run_prog(self, a, b):
         main_program, out = self.get_prog()
-        place = paddle.CustomPlace('npu', 0)
+        place = paddle.CustomPlace("npu", 0)
 
         exe = static.Executor(place)
         out_ = exe.run(main_program, feed={"a": a, "b": b}, fetch_list=[out])
         return out_
 
     def test_contains_nan(self):
-        a = np.zeros((32, 32)).astype('float32')
-        b = np.zeros((32, 32)).astype('float32')
+        a = np.zeros((32, 32)).astype("float32")
+        b = np.zeros((32, 32)).astype("float32")
 
         with self.assertRaisesRegex(RuntimeError, "contains Nan/Inf"):
             out = self.run_prog(a, b)
             print(out)
 
     def test_contains_inf(self):
-        a = np.ones((32, 32)).astype('float32')
-        b = np.zeros((32, 32)).astype('float32')
+        a = np.ones((32, 32)).astype("float32")
+        b = np.zeros((32, 32)).astype("float32")
 
         with self.assertRaisesRegex(RuntimeError, "contains Nan/Inf"):
             out = self.run_prog(a, b)
             print(out)
 
     def test_not_contains_nan_inf(self):
-        a = np.ones((32, 32)).astype('float32')
-        b = np.ones((32, 32)).astype('float32')
+        a = np.ones((32, 32)).astype("float32")
+        b = np.ones((32, 32)).astype("float32")
 
         out = self.run_prog(a, b)
         print(out)
 
     def test_fp16_overflow(self):
-        a = np.ones((32, 32)).astype('float32')
-        b = np.ones((32, 32)).astype('float32')
+        a = np.ones((32, 32)).astype("float32")
+        b = np.ones((32, 32)).astype("float32")
         a[0][0] = 50000
         b[0][0] = 50000
 
@@ -87,5 +85,5 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
             print(out)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_clip_by_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_clip_by_norm_op_npu.py
@@ -17,8 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -32,25 +31,27 @@ class TestClipByNormOp(OpTest):
         input = np.random.random(self.shape).astype(self.dtype)
         input[np.abs(input) < self.max_relative_error] = 0.5
         self.op_type = "clip_by_norm"
-        self.inputs = {'X': input, }
+        self.inputs = {
+            "X": input,
+        }
         self.attrs = {}
-        self.attrs['max_norm'] = self.max_norm
+        self.attrs["max_norm"] = self.max_norm
         norm = np.sqrt(np.sum(np.square(input)))
         if norm > self.max_norm:
             output = self.max_norm * input / norm
         else:
             output = input
-        self.outputs = {'Out': output}
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def initTestCase(self):
-        self.shape = (100, )
+        self.shape = (100,)
         self.max_norm = 1.0
 
     def init_dtype(self):
@@ -59,7 +60,7 @@ class TestClipByNormOp(OpTest):
 
 class TestCase1(TestClipByNormOp):
     def initTestCase(self):
-        self.shape = (100, )
+        self.shape = (100,)
         self.max_norm = 1e20
 
 
@@ -85,7 +86,7 @@ class TestClipByNormOpFp16(TestClipByNormOp):
 
 class TestClipByNormOpFp16Case1(TestClipByNormOpFp16):
     def initTestCase(self):
-        self.shape = (100, )
+        self.shape = (100,)
         self.max_norm = 1e20
 
 
@@ -101,5 +102,5 @@ class TestClipByNormOpFp16Case3(TestClipByNormOpFp16):
         self.max_norm = 1.0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_clip_op_npu.py
+++ b/backends/npu/tests/unittests/test_clip_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 
 class TestClipOp(OpTest):

--- a/backends/npu/tests/unittests/test_coalesce_tensor_op_npu.py
+++ b/backends/npu/tests/unittests/test_coalesce_tensor_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 from paddle.fluid import core
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 
 def create_test_class(op_type, typename, callback):

--- a/backends/npu/tests/unittests/test_concat_op_npu.py
+++ b/backends/npu/tests/unittests/test_concat_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_conv2d_op_depthwise_conv_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_op_depthwise_conv_npu.py
@@ -17,34 +17,29 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-import sys
 
-from tests.op_test import OpTest
-from paddle import ParamAttr
-from paddle.regularizer import L2Decay
-from paddle.nn.initializer import KaimingNormal
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021
 
 
-def conv2d_forward_naive(input,
-                         filter,
-                         group,
-                         conv_param,
-                         padding_algorithm='EXPLICIT',
-                         data_format='NCHW'):
+def conv2d_forward_naive(
+    input, filter, group, conv_param, padding_algorithm="EXPLICIT", data_format="NCHW"
+):
     if padding_algorithm not in ["SAME", "VALID", "EXPLICIT"]:
-        raise ValueError("Unknown Attr(padding_algorithm): '%s'. "
-                         "It can only be 'SAME' or 'VALID'." %
-                         str(padding_algorithm))
+        raise ValueError(
+            "Unknown Attr(padding_algorithm): '%s'. "
+            "It can only be 'SAME' or 'VALID'." % str(padding_algorithm)
+        )
 
     if data_format not in ["NCHW", "NHWC"]:
-        raise ValueError("Unknown Attr(data_format): '%s' ."
-                         "It can only be 'NCHW' or 'NHWC'." % str(data_format))
+        raise ValueError(
+            "Unknown Attr(data_format): '%s' ."
+            "It can only be 'NCHW' or 'NHWC'." % str(data_format)
+        )
 
-    channel_last = (data_format == "NHWC")
+    channel_last = data_format == "NHWC"
     if channel_last:
         input = np.transpose(input, [0, 3, 1, 2])
 
@@ -57,17 +52,22 @@ def conv2d_forward_naive(input,
     sub_out_c = out_c // group
     sub_f_n = f_n // group
 
-    stride, pad, dilation = conv_param['stride'], conv_param['pad'], conv_param[
-        'dilation']
+    stride, pad, dilation = (
+        conv_param["stride"],
+        conv_param["pad"],
+        conv_param["dilation"],
+    )
 
     # update pad and dilation
     def _get_padding_with_SAME(input_shape, pool_size, pool_stride):
         padding = []
-        for input_size, filter_size, stride_size in zip(input_shape, pool_size,
-                                                        pool_stride):
+        for input_size, filter_size, stride_size in zip(
+            input_shape, pool_size, pool_stride
+        ):
             out_size = int((input_size + stride_size - 1) / stride_size)
-            pad_sum = np.max((
-                (out_size - 1) * stride_size + filter_size - input_size, 0))
+            pad_sum = np.max(
+                ((out_size - 1) * stride_size + filter_size - input_size, 0)
+            )
             pad_0 = int(pad_sum / 2)
             pad_1 = int(pad_sum - pad_0)
             padding.append(pad_0)
@@ -87,39 +87,42 @@ def conv2d_forward_naive(input,
     if len(pad) == 4:
         pad_h_0, pad_h_1 = pad[0], pad[1]
         pad_w_0, pad_w_1 = pad[2], pad[3]
-    out_h = 1 + (in_h + pad_h_0 + pad_h_1 - (dilation[0] *
-                                             (f_h - 1) + 1)) // stride[0]
-    out_w = 1 + (in_w + pad_w_0 + pad_w_1 - (dilation[1] *
-                                             (f_w - 1) + 1)) // stride[1]
+    out_h = 1 + (in_h + pad_h_0 + pad_h_1 - (dilation[0] * (f_h - 1) + 1)) // stride[0]
+    out_w = 1 + (in_w + pad_w_0 + pad_w_1 - (dilation[1] * (f_w - 1) + 1)) // stride[1]
     out = np.zeros((out_n, out_c, out_h, out_w))
 
-    d_bolck_h = (dilation[0] * (f_h - 1) + 1)
-    d_bolck_w = (dilation[1] * (f_w - 1) + 1)
+    d_bolck_h = dilation[0] * (f_h - 1) + 1
+    d_bolck_w = dilation[1] * (f_w - 1) + 1
 
-    input_pad = np.pad(input, ((0, 0), (0, 0), (pad_h_0, pad_h_1),
-                               (pad_w_0, pad_w_1)),
-                       mode='constant',
-                       constant_values=0)
+    input_pad = np.pad(
+        input,
+        ((0, 0), (0, 0), (pad_h_0, pad_h_1), (pad_w_0, pad_w_1)),
+        mode="constant",
+        constant_values=0,
+    )
 
     filter_dilation = np.zeros((f_n, f_c, d_bolck_h, d_bolck_w))
-    filter_dilation[:, :, 0:d_bolck_h:dilation[0], 0:d_bolck_w:dilation[
-        1]] = filter
+    filter_dilation[
+        :, :, 0 : d_bolck_h : dilation[0], 0 : d_bolck_w : dilation[1]
+    ] = filter
 
     for i in range(out_h):
         for j in range(out_w):
             for g in range(group):
-                input_pad_masked = \
-                    input_pad[:, g * f_c:(g + 1) * f_c,
-                    i * stride[0]:i * stride[0] + d_bolck_h,
-                    j * stride[1]:j * stride[1] + d_bolck_w]
+                input_pad_masked = input_pad[
+                    :,
+                    g * f_c : (g + 1) * f_c,
+                    i * stride[0] : i * stride[0] + d_bolck_h,
+                    j * stride[1] : j * stride[1] + d_bolck_w,
+                ]
 
-                f_sub = filter_dilation[g * sub_f_n:(g + 1) * sub_f_n, :, :, :]
+                f_sub = filter_dilation[g * sub_f_n : (g + 1) * sub_f_n, :, :, :]
                 # sub_f_n == sub_out_c
                 for k in range(sub_out_c):
                     # Multiplication of Corresponding Elements, then sum all
-                    out[:, g * sub_out_c + k, i, j] = \
-                        np.sum(input_pad_masked * f_sub[k, :, :, :],
-                               axis=(1, 2, 3))
+                    out[:, g * sub_out_c + k, i, j] = np.sum(
+                        input_pad_masked * f_sub[k, :, :, :], axis=(1, 2, 3)
+                    )
 
     if channel_last:
         out = np.transpose(out, [0, 2, 3, 1])
@@ -175,7 +178,8 @@ def create_test_fp16_class(parent):
 
 # TODO(Aganlengzi)
 @unittest.skipIf(
-    True, "CANN5.0.4 Issue: https://gitee.com/Ascend/modelzoo/issues/I4TBLP")
+    True, "CANN5.0.4 Issue: https://gitee.com/Ascend/modelzoo/issues/I4TBLP"
+)
 class TestDepthwiseConvNPU(OpTest):
     def setUp(self):
         self.set_npu()
@@ -186,37 +190,37 @@ class TestDepthwiseConvNPU(OpTest):
         self.init_test_case_2()
 
         conv2d_param = {
-            'stride': self.stride,
-            'pad': self.pad,
-            'dilation': self.dilations
+            "stride": self.stride,
+            "pad": self.pad,
+            "dilation": self.dilations,
         }
 
         input = np.random.random(self.input_size).astype(self.dtype)
         filter = np.random.uniform(-1, 1, self.filter_size).astype(self.dtype)
 
-        output, _, _, _, _ = conv2d_forward_naive(input, filter, self.groups,
-                                                  conv2d_param, "EXPLICIT",
-                                                  self.data_format)
+        output, _, _, _, _ = conv2d_forward_naive(
+            input, filter, self.groups, conv2d_param, "EXPLICIT", self.data_format
+        )
 
         output = output.astype(self.dtype)
 
         self.inputs = {
-            'Input': OpTest.np_dtype_to_fluid_dtype(input),
-            'Filter': OpTest.np_dtype_to_fluid_dtype(filter)
+            "Input": OpTest.np_dtype_to_fluid_dtype(input),
+            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
         }
 
         self.attrs = {
-            'strides': self.stride,
-            'paddings': self.pad,
-            'groups': self.groups,
-            'dilations': self.dilations,
-            'data_format': self.data_format,
+            "strides": self.stride,
+            "paddings": self.pad,
+            "groups": self.groups,
+            "dilations": self.dilations,
+            "data_format": self.data_format,
         }
-        self.outputs = {'Output': output}
+        self.outputs = {"Output": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_test_case(self):
         self.pad = [1, 1]
@@ -235,46 +239,55 @@ class TestDepthwiseConvNPU(OpTest):
         if self.dilations[0] == 1 and self.dilations[1] == 1:
             if self.dtype == np.float16:
                 self.check_grad_with_place(
-                    self.place, {'Input', 'Filter'},
-                    'Output',
-                    max_relative_error=0.9)
+                    self.place, {"Input", "Filter"}, "Output", max_relative_error=0.9
+                )
             else:
                 self.check_grad_with_place(
-                    self.place, {'Input', 'Filter'},
-                    'Output',
+                    self.place,
+                    {"Input", "Filter"},
+                    "Output",
                     max_relative_error=0.03,
-                    numeric_place=paddle.CPUPlace())
+                    numeric_place=paddle.CPUPlace(),
+                )
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, ['Input'],
-                'Output',
-                no_grad_set=set(['Filter']),
-                max_relative_error=0.9)
+                self.place,
+                ["Input"],
+                "Output",
+                no_grad_set=set(["Filter"]),
+                max_relative_error=0.9,
+            )
         else:
             self.check_grad_with_place(
-                self.place, ['Input'],
-                'Output',
-                no_grad_set=set(['Filter']),
+                self.place,
+                ["Input"],
+                "Output",
+                no_grad_set=set(["Filter"]),
                 max_relative_error=0.03,
-                numeric_place=paddle.CPUPlace())
+                numeric_place=paddle.CPUPlace(),
+            )
 
     def test_check_grad_no_input(self):
         if self.dilations[0] == 1 and self.dilations[1] == 1:
             if self.dtype == np.float16:
                 self.check_grad_with_place(
-                    self.place, ['Filter'],
-                    'Output',
-                    no_grad_set=set(['Input']),
-                    max_relative_error=0.9)
+                    self.place,
+                    ["Filter"],
+                    "Output",
+                    no_grad_set=set(["Input"]),
+                    max_relative_error=0.9,
+                )
             else:
                 self.check_grad_with_place(
-                    self.place, ['Filter'],
-                    'Output',
-                    no_grad_set=set(['Input']),
+                    self.place,
+                    ["Filter"],
+                    "Output",
+                    no_grad_set=set(["Input"]),
                     max_relative_error=0.03,
-                    numeric_place=paddle.CPUPlace())
+                    numeric_place=paddle.CPUPlace(),
+                )
 
     def init_data_format(self):
         self.data_format = "NCHW"
@@ -324,7 +337,8 @@ class TestDepthwiseConvNPU4(TestDepthwiseConvNPU):
 
 # TODO(Aganlengzi)
 @unittest.skipIf(
-    True, "CANN5.0.4 Issue: https://gitee.com/Ascend/modelzoo/issues/I4TBLP")
+    True, "CANN5.0.4 Issue: https://gitee.com/Ascend/modelzoo/issues/I4TBLP"
+)
 class TestDepthwiseConvNPU_Padding(OpTest):
     def setUp(self):
         self.op_type = "depthwise_conv2d"
@@ -337,37 +351,42 @@ class TestDepthwiseConvNPU_Padding(OpTest):
         self.init_test_case_2()
 
         conv2d_param = {
-            'stride': self.stride,
-            'pad': self.pad,
-            'dilation': self.dilations
+            "stride": self.stride,
+            "pad": self.pad,
+            "dilation": self.dilations,
         }
 
         input = np.random.random(self.input_size).astype(self.dtype)
         filter = np.random.uniform(-1, 1, self.filter_size).astype(self.dtype)
 
         output, _, _, _, _ = conv2d_forward_naive(
-            input, filter, self.groups, conv2d_param, self.padding_algorithm,
-            self.data_format)
+            input,
+            filter,
+            self.groups,
+            conv2d_param,
+            self.padding_algorithm,
+            self.data_format,
+        )
         output = output.astype(self.dtype)
 
         self.inputs = {
-            'Input': OpTest.np_dtype_to_fluid_dtype(input),
-            'Filter': OpTest.np_dtype_to_fluid_dtype(filter)
+            "Input": OpTest.np_dtype_to_fluid_dtype(input),
+            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
         }
 
         self.attrs = {
-            'strides': self.stride,
-            'paddings': self.pad,
-            'padding_algorithm': self.padding_algorithm,
-            'groups': self.groups,
-            'dilations': self.dilations,
-            'data_format': self.data_format
+            "strides": self.stride,
+            "paddings": self.pad,
+            "padding_algorithm": self.padding_algorithm,
+            "groups": self.groups,
+            "dilations": self.dilations,
+            "data_format": self.data_format,
         }
-        self.outputs = {'Output': output}
+        self.outputs = {"Output": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_test_case(self):
         self.pad = [1, 1, 0, 1]
@@ -385,45 +404,54 @@ class TestDepthwiseConvNPU_Padding(OpTest):
     def test_check_grad(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, {'Input', 'Filter'},
-                'Output',
-                max_relative_error=1.2)
+                self.place, {"Input", "Filter"}, "Output", max_relative_error=1.2
+            )
         else:
             self.check_grad_with_place(
-                self.place, {'Input', 'Filter'},
-                'Output',
+                self.place,
+                {"Input", "Filter"},
+                "Output",
                 max_relative_error=0.03,
-                numeric_place=paddle.CPUPlace())
+                numeric_place=paddle.CPUPlace(),
+            )
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, ['Input'],
-                'Output',
+                self.place,
+                ["Input"],
+                "Output",
                 max_relative_error=0.7,
-                no_grad_set=set(['Filter']))
+                no_grad_set=set(["Filter"]),
+            )
         else:
             self.check_grad_with_place(
-                self.place, ['Input'],
-                'Output',
+                self.place,
+                ["Input"],
+                "Output",
                 max_relative_error=0.03,
-                no_grad_set=set(['Filter']),
-                numeric_place=paddle.CPUPlace())
+                no_grad_set=set(["Filter"]),
+                numeric_place=paddle.CPUPlace(),
+            )
 
     def test_check_grad_no_input(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, ['Filter'],
-                'Output',
+                self.place,
+                ["Filter"],
+                "Output",
                 max_relative_error=0.8,
-                no_grad_set=set(['Input']))
+                no_grad_set=set(["Input"]),
+            )
         else:
             self.check_grad_with_place(
-                self.place, ['Filter'],
-                'Output',
+                self.place,
+                ["Filter"],
+                "Output",
                 max_relative_error=0.03,
-                no_grad_set=set(['Input']),
-                numeric_place=paddle.CPUPlace())
+                no_grad_set=set(["Input"]),
+                numeric_place=paddle.CPUPlace(),
+            )
 
     def init_data_format(self):
         self.data_format = "NCHW"
@@ -493,5 +521,5 @@ create_test_fp16_class(TestDepthwiseConvNPU_Padding)
 create_test_fp16_class(TestDepthwiseConvNPU2_Padding)
 create_test_fp16_class(TestDepthwiseConvNPU3_Padding)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_conv2d_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 from paddle.framework import set_flags
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_conv2d_transpose_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_transpose_op_npu.py
@@ -20,7 +20,7 @@ import paddle.nn as nn
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_conv3d_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv3d_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_cumsum_op_npu.py
+++ b/backends/npu/tests/unittests/test_cumsum_op_npu.py
@@ -17,11 +17,10 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 
@@ -43,7 +42,7 @@ class TestCumsumOp(unittest.TestCase):
         z = np.cumsum(data_np, axis=-1)
         self.assertTrue(np.array_equal(z, y.numpy()))
 
-        y = paddle.cumsum(data, dtype='float32')
+        y = paddle.cumsum(data, dtype="float32")
         self.assertTrue(y.dtype == core.VarDesc.VarType.FP32)
 
         y = paddle.cumsum(data, dtype=np.int32)
@@ -56,23 +55,23 @@ class TestCumsumOp(unittest.TestCase):
     def run_static(self, use_custom_device=False):
         with fluid.program_guard(fluid.Program()):
             data_np = np.random.random((100, 100)).astype(np.float32)
-            x = paddle.static.data('X', [100, 100])
+            x = paddle.static.data("X", [100, 100])
             y = paddle.cumsum(x)
             y2 = paddle.cumsum(x, axis=0)
             y3 = paddle.cumsum(x, axis=-1)
-            y4 = paddle.cumsum(x, dtype='float32')
+            y4 = paddle.cumsum(x, dtype="float32")
             y5 = paddle.cumsum(x, dtype=np.int32)
             y6 = paddle.cumsum(x, axis=-2)
 
-            place = fluid.CustomPlace(
-                'npu', 0) if use_custom_device else fluid.CPUPlace()
+            place = (
+                fluid.CustomPlace("npu", 0) if use_custom_device else fluid.CPUPlace()
+            )
             exe = fluid.Executor(place)
             exe.run(fluid.default_startup_program())
-            out = exe.run(feed={'X': data_np},
-                          fetch_list=[
-                              y.name, y2.name, y3.name, y4.name, y5.name,
-                              y6.name
-                          ])
+            out = exe.run(
+                feed={"X": data_np},
+                fetch_list=[y.name, y2.name, y3.name, y4.name, y5.name, y6.name],
+            )
 
             z = np.cumsum(data_np)
             self.assertTrue(np.allclose(z, out[0]))
@@ -92,9 +91,9 @@ class TestCumsumOp(unittest.TestCase):
 
     def test_name(self):
         with fluid.program_guard(fluid.Program()):
-            x = paddle.static.data('x', [3, 4])
-            y = paddle.cumsum(x, name='out')
-            self.assertTrue('out' in y.name)
+            x = paddle.static.data("x", [3, 4])
+            y = paddle.cumsum(x, name="out")
+            self.assertTrue("out" in y.name)
 
 
 class TestNPUCumSumOp1(OpTest):
@@ -109,160 +108,157 @@ class TestNPUCumSumOp1(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
 
     def init_testcase(self):
-        self.attrs = {'axis': 2}
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum(axis=2)}
+        self.attrs = {"axis": 2}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum(axis=2)}
 
 
 class TestNPUCumSumOp2(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': -1, 'reverse': True}
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"axis": -1, "reverse": True}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
         self.outputs = {
-            'Out': np.flip(
-                np.flip(
-                    self.inputs['X'], axis=2).cumsum(axis=2), axis=2)
+            "Out": np.flip(np.flip(self.inputs["X"], axis=2).cumsum(axis=2), axis=2)
         }
 
 
 class TestNPUCumSumOp3(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 1}
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum(axis=1)}
+        self.attrs = {"axis": 1}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum(axis=1)}
 
 
 class TestNPUCumSumOp4(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 0}
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum(axis=0)}
+        self.attrs = {"axis": 0}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum(axis=0)}
 
 
 class TestNPUCumSumOp5(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.inputs = {'X': np.random.random((5, 20)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum(axis=1)}
+        self.inputs = {"X": np.random.random((5, 20)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum(axis=1)}
 
 
 class TestNPUCumSumOp7(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.inputs = {'X': np.random.random((100)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum(axis=0)}
+        self.inputs = {"X": np.random.random((100)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum(axis=0)}
 
 
 class TestNPUCumSumExclusive1(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, "exclusive": True}
+        self.attrs = {"axis": 2, "exclusive": True}
         a = np.random.random((4, 5, 65)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         self.outputs = {
-            'Out': np.concatenate(
-                (np.zeros(
-                    (4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
-                axis=2)
+            "Out": np.concatenate(
+                (np.zeros((4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumExclusive2(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, "exclusive": True}
+        self.attrs = {"axis": 2, "exclusive": True}
         a = np.random.random((1, 1, 888)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         self.outputs = {
-            'Out': np.concatenate(
-                (np.zeros(
-                    (1, 1, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
-                axis=2)
+            "Out": np.concatenate(
+                (np.zeros((1, 1, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumExclusive3(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, "exclusive": True}
+        self.attrs = {"axis": 2, "exclusive": True}
         a = np.random.random((4, 5, 888)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         self.outputs = {
-            'Out': np.concatenate(
-                (np.zeros(
-                    (4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
-                axis=2)
+            "Out": np.concatenate(
+                (np.zeros((4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumExclusive4(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, "exclusive": True}
+        self.attrs = {"axis": 2, "exclusive": True}
         a = np.random.random((1, 1, 3049)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         self.outputs = {
-            'Out': np.concatenate(
-                (np.zeros(
-                    (1, 1, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
-                axis=2)
+            "Out": np.concatenate(
+                (np.zeros((1, 1, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumExclusive5(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, "exclusive": True}
+        self.attrs = {"axis": 2, "exclusive": True}
         a = np.random.random((4, 5, 3096)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         self.outputs = {
-            'Out': np.concatenate(
-                (np.zeros(
-                    (4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
-                axis=2)
+            "Out": np.concatenate(
+                (np.zeros((4, 5, 1), dtype=self.dtype), a[:, :, :-1].cumsum(axis=2)),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumReverseExclusive(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': 2, 'reverse': True, "exclusive": True}
+        self.attrs = {"axis": 2, "reverse": True, "exclusive": True}
         a = np.random.random((4, 5, 6)).astype(self.dtype)
-        self.inputs = {'X': a}
+        self.inputs = {"X": a}
         a = np.flip(a, axis=2)
         self.outputs = {
-            'Out': np.concatenate(
-                (np.flip(
-                    a[:, :, :-1].cumsum(axis=2), axis=2), np.zeros(
-                        (4, 5, 1), dtype=self.dtype)),
-                axis=2)
+            "Out": np.concatenate(
+                (
+                    np.flip(a[:, :, :-1].cumsum(axis=2), axis=2),
+                    np.zeros((4, 5, 1), dtype=self.dtype),
+                ),
+                axis=2,
+            )
         }
 
 
 class TestNPUCumSumWithFlatten1(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'flatten': True}
-        self.inputs = {'X': np.random.random((5, 6)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum()}
+        self.attrs = {"flatten": True}
+        self.inputs = {"X": np.random.random((5, 6)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum()}
 
 
 class TestNPUCumSumWithFlatten2(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'flatten': True}
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.outputs = {'Out': self.inputs['X'].cumsum()}
+        self.attrs = {"flatten": True}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.outputs = {"Out": self.inputs["X"].cumsum()}
 
 
-#----------------Cumsum Int64----------------
+# ----------------Cumsum Int64----------------
 class TestNPUCumSumOpInt64(TestNPUCumSumOp1):
     def init_testcase(self):
-        self.attrs = {'axis': -1, 'reverse': True}
+        self.attrs = {"axis": -1, "reverse": True}
         self.inputs = {
-            'X': np.random.randint(
-                1, 10000, size=(5, 6, 10)).astype(self.dtype)
+            "X": np.random.randint(1, 10000, size=(5, 6, 10)).astype(self.dtype)
         }
         self.outputs = {
-            'Out': np.flip(
-                np.flip(
-                    self.inputs['X'], axis=2).cumsum(axis=2), axis=2)
+            "Out": np.flip(np.flip(self.inputs["X"], axis=2).cumsum(axis=2), axis=2)
         }
 
 
@@ -291,5 +287,5 @@ create_test_int64(TestNPUCumSumReverseExclusive)
 create_test_int64(TestNPUCumSumWithFlatten1)
 create_test_int64(TestNPUCumSumWithFlatten2)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_diag_op_npu.py
+++ b/backends/npu/tests/unittests/test_diag_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -38,10 +38,10 @@ class TestDiagOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def config(self):
-        self.x_shape = (100)
+        self.x_shape = 100
         self.offset = 0
         self.padding_value = 0.0
 
@@ -58,12 +58,9 @@ class TestDiagOp(OpTest):
         x = -0.1 + 0.2 * x
         result = reference_diag(x, self.offset)
         result = result.astype(self.dtype)
-        self.inputs = {'X': x}
-        self.attrs = {
-            'offset': self.offset,
-            'padding_value': self.padding_value
-        }
-        self.outputs = {'Out': result}
+        self.inputs = {"X": x}
+        self.attrs = {"offset": self.offset, "padding_value": self.padding_value}
+        self.outputs = {"Out": result}
 
     def test_check_output(self):
         self.check_output_with_place(self.place, atol=1e-7)
@@ -75,7 +72,7 @@ class TestDiagOp1(TestDiagOp):
     """
 
     def config(self):
-        self.x_shape = (100)
+        self.x_shape = 100
         self.offset = 1
         self.padding_value = 0.0
 
@@ -92,7 +89,7 @@ class TestDiagOp2(TestDiagOp):
     """
 
     def config(self):
-        self.x_shape = (100)
+        self.x_shape = 100
         self.offset = 0
         self.padding_value = 0.0
 
@@ -109,7 +106,7 @@ class TestDiagOp3(TestDiagOp):
     """
 
     def config(self):
-        self.x_shape = (100)
+        self.x_shape = 100
         self.offset = 0
         self.padding_value = 0.0
 
@@ -121,12 +118,9 @@ class TestDiagOp3(TestDiagOp):
         x = np.random.randint(0, high=5, size=self.x_shape).astype(self.dtype)
         result = reference_diag(x, self.offset)
         result = result.astype(self.dtype)
-        self.inputs = {'X': x}
-        self.attrs = {
-            'offset': self.offset,
-            'padding_value': self.padding_value
-        }
-        self.outputs = {'Out': result}
+        self.inputs = {"X": x}
+        self.attrs = {"offset": self.offset, "padding_value": self.padding_value}
+        self.outputs = {"Out": result}
 
     def init_kernel_type(self):
         self.dtype = np.int32
@@ -135,5 +129,5 @@ class TestDiagOp3(TestDiagOp):
         self.check_output_with_place(self.place, atol=1e-3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -20,10 +20,10 @@ import unittest
 
 import numpy as np
 import paddle.fluid as fluid
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 import paddle
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_elementwise_div_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_div_op_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle import _legacy_C_ops
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_elementwise_floordiv_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_floordiv_op_npu.py
@@ -16,9 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -32,15 +31,15 @@ class TestElementwiseFloorDiv(OpTest):
         self.init_input_output()
 
         self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
-            'Y': OpTest.np_dtype_to_fluid_dtype(self.y)
+            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
+            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
         }
         self.attrs = {}
-        self.outputs = {'Out': self.out}
+        self.outputs = {"Out": self.out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_input_output(self):
         self.x = np.random.uniform(1, 1000, [10, 10]).astype(self.dtype)
@@ -59,5 +58,5 @@ class TestElementwiseFloorDiv2(TestElementwiseFloorDiv):
         self.dtype = "int32"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_elementwise_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_max_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_elementwise_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_min_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
@@ -17,7 +17,7 @@ import numpy as np
 import unittest
 
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 import paddle.fluid as fluid

--- a/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
@@ -16,10 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 
@@ -27,7 +25,7 @@ paddle.enable_static()
 class ElementwiseMulOp(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
@@ -39,25 +37,23 @@ class ElementwiseMulOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
-            'Y': OpTest.np_dtype_to_fluid_dtype(self.y)
+            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
+            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
         }
-        self.outputs = {'Out': self.out}
-        self.attrs = {'axis': self.axis}
+        self.outputs = {"Out": self.out}
+        self.attrs = {"axis": self.axis}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
-        self.check_grad_with_place(self.place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(self.place, ["X", "Y"], "Out")
 
     def test_check_grad_ingore_x(self):
-        self.check_grad_with_place(
-            self.place, ['Y'], 'Out', no_grad_set=set("X"))
+        self.check_grad_with_place(self.place, ["Y"], "Out", no_grad_set=set("X"))
 
     def test_check_grad_ingore_y(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', no_grad_set=set('Y'))
+        self.check_grad_with_place(self.place, ["X"], "Out", no_grad_set=set("Y"))
 
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
@@ -71,17 +67,16 @@ class ElementwiseMulOp(OpTest):
         pass
 
 
-@skip_check_grad_ci(
-    reason="[skip shape check] Use y_shape(1) to test broadcast.")
+@skip_check_grad_ci(reason="[skip shape check] Use y_shape(1) to test broadcast.")
 class TestElementwiseMulOp_scalar(ElementwiseMulOp):
     def setUp(self):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(10, 3, 4).astype(np.float32),
-            'Y': np.random.rand(1).astype(np.float32)
+            "X": np.random.rand(10, 3, 4).astype(np.float32),
+            "Y": np.random.rand(1).astype(np.float32),
         }
-        self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
 class TestElementwiseMulOp_Vector(ElementwiseMulOp):
@@ -89,10 +84,10 @@ class TestElementwiseMulOp_Vector(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.random((100, )).astype("float32"),
-            'Y': np.random.random((100, )).astype("float32")
+            "X": np.random.random((100,)).astype("float32"),
+            "Y": np.random.random((100,)).astype("float32"),
         }
-        self.outputs = {'Out': np.multiply(self.inputs['X'], self.inputs['Y'])}
+        self.outputs = {"Out": np.multiply(self.inputs["X"], self.inputs["Y"])}
 
 
 class TestElementwiseMulOp_broadcast_0(ElementwiseMulOp):
@@ -110,14 +105,12 @@ class TestElementwiseMulOp_broadcast_1(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(2, 100, 3).astype(np.float32),
-            'Y': np.random.rand(100).astype(np.float32)
+            "X": np.random.rand(2, 100, 3).astype(np.float32),
+            "Y": np.random.rand(100).astype(np.float32),
         }
 
-        self.attrs = {'axis': 1}
-        self.outputs = {
-            'Out': self.inputs['X'] * self.inputs['Y'].reshape(1, 100, 1)
-        }
+        self.attrs = {"axis": 1}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"].reshape(1, 100, 1)}
 
 
 class TestElementwiseMulOp_broadcast_2(ElementwiseMulOp):
@@ -125,13 +118,11 @@ class TestElementwiseMulOp_broadcast_2(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(2, 3, 100).astype(np.float32),
-            'Y': np.random.rand(100).astype(np.float32)
+            "X": np.random.rand(2, 3, 100).astype(np.float32),
+            "Y": np.random.rand(100).astype(np.float32),
         }
 
-        self.outputs = {
-            'Out': self.inputs['X'] * self.inputs['Y'].reshape(1, 1, 100)
-        }
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"].reshape(1, 1, 100)}
 
 
 class TestElementwiseMulOp_broadcast_3(ElementwiseMulOp):
@@ -139,13 +130,13 @@ class TestElementwiseMulOp_broadcast_3(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(2, 10, 12, 3).astype(np.float32),
-            'Y': np.random.rand(10, 12).astype(np.float32)
+            "X": np.random.rand(2, 10, 12, 3).astype(np.float32),
+            "Y": np.random.rand(10, 12).astype(np.float32),
         }
 
-        self.attrs = {'axis': 1}
+        self.attrs = {"axis": 1}
         self.outputs = {
-            'Out': self.inputs['X'] * self.inputs['Y'].reshape(1, 10, 12, 1)
+            "Out": self.inputs["X"] * self.inputs["Y"].reshape(1, 10, 12, 1)
         }
 
 
@@ -154,10 +145,10 @@ class TestElementwiseMulOp_broadcast_4(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(10, 2, 11).astype(np.float32),
-            'Y': np.random.rand(10, 1, 11).astype(np.float32)
+            "X": np.random.rand(10, 2, 11).astype(np.float32),
+            "Y": np.random.rand(10, 1, 11).astype(np.float32),
         }
-        self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
 class TestElementwiseMulOp_broadcast_5(ElementwiseMulOp):
@@ -165,10 +156,10 @@ class TestElementwiseMulOp_broadcast_5(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(10, 4, 2, 3).astype(np.float32),
-            'Y': np.random.rand(10, 4, 1, 3).astype(np.float32)
+            "X": np.random.rand(10, 4, 2, 3).astype(np.float32),
+            "Y": np.random.rand(10, 4, 1, 3).astype(np.float32),
         }
-        self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
 # TODO
@@ -183,10 +174,10 @@ class TestElementwiseMulOp_commonuse_1(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(2, 3, 100).astype(np.float32),
-            'Y': np.random.rand(1, 1, 100).astype(np.float32)
+            "X": np.random.rand(2, 3, 100).astype(np.float32),
+            "Y": np.random.rand(1, 1, 100).astype(np.float32),
         }
-        self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
 class TestElementwiseMulOp_commonuse_2(ElementwiseMulOp):
@@ -194,10 +185,10 @@ class TestElementwiseMulOp_commonuse_2(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(30, 3, 1, 5).astype(np.float32),
-            'Y': np.random.rand(30, 1, 4, 1).astype(np.float32)
+            "X": np.random.rand(30, 3, 1, 5).astype(np.float32),
+            "Y": np.random.rand(30, 1, 4, 1).astype(np.float32),
         }
-        self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
 class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
@@ -205,16 +196,16 @@ class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
         self.set_npu()
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(10, 10).astype(np.float32),
-            'Y': np.random.rand(2, 2, 10, 10).astype(np.float32)
+            "X": np.random.rand(10, 10).astype(np.float32),
+            "Y": np.random.rand(2, 2, 10, 10).astype(np.float32),
         }
 
-        self.attrs = {'axis': 2}
+        self.attrs = {"axis": 2}
 
         self.outputs = {
-            'Out': self.inputs['X'].reshape(1, 1, 10, 10) * self.inputs['Y']
+            "Out": self.inputs["X"].reshape(1, 1, 10, 10) * self.inputs["Y"]
         }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_elementwise_pow_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_pow_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_elu_op_npu.py
+++ b/backends/npu/tests/unittests/test_elu_op_npu.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import unittest
 import numpy as np
 import paddle

--- a/backends/npu/tests/unittests/test_expand_as_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_expand_as_v2_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 

--- a/backends/npu/tests/unittests/test_expand_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_expand_v2_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle

--- a/backends/npu/tests/unittests/test_eye_op_npu.py
+++ b/backends/npu/tests/unittests/test_eye_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid.framework as framework
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 np.random.seed(10)

--- a/backends/npu/tests/unittests/test_fill_any_like_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_any_like_op_npu.py
@@ -16,12 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 
@@ -29,7 +26,7 @@ paddle.enable_static()
 class TestFillAnyLikeNPUOp(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_any_like"
         self.dtype = np.float32
         self.shape = [2, 3, 4, 5]
@@ -37,9 +34,9 @@ class TestFillAnyLikeNPUOp(OpTest):
 
         self.init()
 
-        self.inputs = {'X': np.random.random(self.shape).astype(self.dtype)}
-        self.attrs = {'value': self.value}
-        self.outputs = {'Out': np.full(self.shape, self.value, self.dtype)}
+        self.inputs = {"X": np.random.random(self.shape).astype(self.dtype)}
+        self.attrs = {"value": self.value}
+        self.outputs = {"Out": np.full(self.shape, self.value, self.dtype)}
 
     def init(self):
         pass

--- a/backends/npu/tests/unittests/test_fill_constant_batch_size_like_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_constant_batch_size_like_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()
@@ -30,7 +28,7 @@ SEED = 2021
 class TestFillConstantBatchSizeLike(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant_batch_size_like"
         self.init_shape()
         self.init_value()
@@ -38,21 +36,18 @@ class TestFillConstantBatchSizeLike(OpTest):
         self.init_force_cpu()
         self.init_dim_idx()
 
-        self.inputs = {
-            'Input': np.random.random(self.input_shape).astype("float32")
-        }
+        self.inputs = {"Input": np.random.random(self.input_shape).astype("float32")}
         self.attrs = {
-            'shape': self.shape,
-            'value': self.value,
-            'str_value': self.str_value,
-            'dtype': self.dtype,
-            'force_cpu': self.force_cpu,
-            'input_dim_idx': self.input_dim_idx,
-            'output_dim_idx': self.output_dim_idx
+            "shape": self.shape,
+            "value": self.value,
+            "str_value": self.str_value,
+            "dtype": self.dtype,
+            "force_cpu": self.force_cpu,
+            "input_dim_idx": self.input_dim_idx,
+            "output_dim_idx": self.output_dim_idx,
         }
         self.outputs = {
-            'Out': np.full(self.output_shape, self.output_value,
-                           self.output_dtype)
+            "Out": np.full(self.output_shape, self.output_value, self.output_dtype)
         }
 
     def set_npu(self):
@@ -65,7 +60,7 @@ class TestFillConstantBatchSizeLike(OpTest):
 
     def init_value(self):
         self.value = 3.8
-        self.str_value = ''
+        self.str_value = ""
         self.output_value = 3.8
 
     def init_dtype(self):
@@ -95,7 +90,7 @@ class TestFillConstantBatchSizeLike3(TestFillConstantBatchSizeLike):
     def init_value(self):
         # use 'str_value' rather than 'value'
         self.value = 3.8
-        self.str_value = '4.5'
+        self.str_value = "4.5"
         self.output_value = 4.5
 
 
@@ -134,7 +129,7 @@ class TestFillConstantBatchSizeLikeLodTensor(TestFillConstantBatchSizeLike):
     # test LodTensor
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant_batch_size_like"
         self.init_shape()
         self.init_value()
@@ -144,20 +139,19 @@ class TestFillConstantBatchSizeLikeLodTensor(TestFillConstantBatchSizeLike):
 
         lod = [[3, 2, 5]]
         self.inputs = {
-            'Input': (np.random.random(self.input_shape).astype("float32"), lod)
+            "Input": (np.random.random(self.input_shape).astype("float32"), lod)
         }
         self.attrs = {
-            'shape': self.shape,
-            'value': self.value,
-            'str_value': self.str_value,
-            'dtype': self.dtype,
-            'force_cpu': self.force_cpu,
-            'input_dim_idx': self.input_dim_idx,
-            'output_dim_idx': self.output_dim_idx
+            "shape": self.shape,
+            "value": self.value,
+            "str_value": self.str_value,
+            "dtype": self.dtype,
+            "force_cpu": self.force_cpu,
+            "input_dim_idx": self.input_dim_idx,
+            "output_dim_idx": self.output_dim_idx,
         }
         self.outputs = {
-            'Out': np.full(self.output_shape, self.output_value,
-                           self.output_dtype)
+            "Out": np.full(self.output_shape, self.output_value, self.output_dtype)
         }
 
     def init_shape(self):
@@ -166,8 +160,7 @@ class TestFillConstantBatchSizeLikeLodTensor(TestFillConstantBatchSizeLike):
         self.output_shape = (3, 92)
 
 
-class TestFillConstantBatchSizeLikeLodTensor2(
-        TestFillConstantBatchSizeLikeLodTensor):
+class TestFillConstantBatchSizeLikeLodTensor2(TestFillConstantBatchSizeLikeLodTensor):
     # test LodTensor with 'input_dim_idx' != 0
     def init_shape(self):
         self.input_shape = [10, 20]
@@ -179,5 +172,5 @@ class TestFillConstantBatchSizeLikeLodTensor2(
         self.output_dim_idx = 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_fill_constant_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_constant_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()
@@ -30,13 +28,13 @@ SEED = 2021
 class TestFillConstant(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
         self.init_dtype()
 
         self.inputs = {}
-        self.attrs = {'shape': [123, 92], 'value': 3.8}
-        self.outputs = {'Out': np.full((123, 92), 3.8)}
+        self.attrs = {"shape": [123, 92], "value": 3.8}
+        self.outputs = {"Out": np.full((123, 92), 3.8)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -51,16 +49,16 @@ class TestFillConstant(OpTest):
 class TestFillConstantInt(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
 
         self.inputs = {}
         self.attrs = {
-            'shape': [123, 92],
-            'value': 1,
-            'dtype': core.VarDesc.VarType.INT32
+            "shape": [123, 92],
+            "value": 1,
+            "dtype": core.VarDesc.VarType.INT32,
         }
-        self.outputs = {'Out': np.full((123, 92), 1).astype(self.dtype)}
+        self.outputs = {"Out": np.full((123, 92), 1).astype(self.dtype)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -75,16 +73,16 @@ class TestFillConstantInt(OpTest):
 class TestFillConstantInt64(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
 
         self.inputs = {}
         self.attrs = {
-            'shape': [123, 92],
-            'value': 1,
-            'dtype': core.VarDesc.VarType.INT64
+            "shape": [123, 92],
+            "value": 1,
+            "dtype": core.VarDesc.VarType.INT64,
         }
-        self.outputs = {'Out': np.full((123, 92), 1).astype(self.dtype)}
+        self.outputs = {"Out": np.full((123, 92), 1).astype(self.dtype)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -99,16 +97,16 @@ class TestFillConstantInt64(OpTest):
 class TestFillConstantFP16(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
 
         self.inputs = {}
         self.attrs = {
-            'shape': [123, 92],
-            'value': 1.0,
-            'dtype': core.VarDesc.VarType.FP16
+            "shape": [123, 92],
+            "value": 1.0,
+            "dtype": core.VarDesc.VarType.FP16,
         }
-        self.outputs = {'Out': np.full((123, 92), 1.0).astype(self.dtype)}
+        self.outputs = {"Out": np.full((123, 92), 1.0).astype(self.dtype)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -123,16 +121,16 @@ class TestFillConstantFP16(OpTest):
 class TestFillConstantBool(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
 
         self.inputs = {}
         self.attrs = {
-            'shape': [123, 92],
-            'value': True,
-            'dtype': core.VarDesc.VarType.BOOL
+            "shape": [123, 92],
+            "value": True,
+            "dtype": core.VarDesc.VarType.BOOL,
         }
-        self.outputs = {'Out': np.full((123, 92), True).astype(self.dtype)}
+        self.outputs = {"Out": np.full((123, 92), True).astype(self.dtype)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -147,13 +145,13 @@ class TestFillConstantBool(OpTest):
 class TestFillConstantWithPlaceType(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "fill_constant"
         self.init_dtype()
 
         self.inputs = {}
-        self.attrs = {'shape': [123, 92], 'value': 3.8, 'place_type': 0}
-        self.outputs = {'Out': np.full((123, 92), 3.8)}
+        self.attrs = {"shape": [123, 92], "value": 3.8, "place_type": 0}
+        self.outputs = {"Out": np.full((123, 92), 3.8)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -165,5 +163,5 @@ class TestFillConstantWithPlaceType(OpTest):
         self.check_output_with_place(self.place)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_fill_diagonal_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_diagonal_op_npu.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 

--- a/backends/npu/tests/unittests/test_flip_op_npu.py
+++ b/backends/npu/tests/unittests/test_flip_op_npu.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 import paddle.fluid as fluid

--- a/backends/npu/tests/unittests/test_gather_nd_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_nd_op_npu.py
@@ -16,19 +16,18 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle.fluid as fluid
 import paddle
 
 
 def gather_nd_grad(x, index):
-    dout_shape = index.shape[:-1] + x.shape[index.shape[-1]:]
+    dout_shape = index.shape[:-1] + x.shape[index.shape[-1] :]
     numel = 1
     for i in dout_shape:
         numel = numel * i
-    dout = np.full(dout_shape, 1. / numel)
+    dout = np.full(dout_shape, 1.0 / numel)
     dx = np.full_like(x, 0)
 
     index = tuple(index.reshape(-1, index.shape[-1]).T)
@@ -39,20 +38,15 @@ def gather_nd_grad(x, index):
 
 def test_class1(op_type, typename):
     class TestGatherNdOpWithEmptyIndex(OpTest):
-        #Index has empty element, which means copy entire tensor
+        # Index has empty element, which means copy entire tensor
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             xnp = np.random.random((5, 20)).astype(typename)
-            self.inputs = {
-                'X': xnp,
-                'Index': np.array([[], []]).astype("int32")
-            }
-            self.outputs = {
-                'Out': np.vstack((xnp[np.newaxis, :], xnp[np.newaxis, :]))
-            }
+            self.inputs = {"X": xnp, "Index": np.array([[], []]).astype("int32")}
+            self.outputs = {"Out": np.vstack((xnp[np.newaxis, :], xnp[np.newaxis, :]))}
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -64,7 +58,7 @@ def test_class1(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_1".format(op_type, typename)
     TestGatherNdOpWithEmptyIndex.__name__ = cls_name
@@ -75,11 +69,11 @@ def test_class2(op_type, typename):
     class TestGatherNdOpWithIndex1(OpTest):
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             xnp = np.random.random((5, 20)).astype(typename)
-            self.inputs = {'X': xnp, 'Index': np.array([1]).astype("int32")}
-            self.outputs = {'Out': self.inputs["X"][self.inputs["Index"]]}
+            self.inputs = {"X": xnp, "Index": np.array([1]).astype("int32")}
+            self.outputs = {"Out": self.inputs["X"][self.inputs["Index"]]}
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -91,7 +85,7 @@ def test_class2(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_2".format(op_type, typename)
     TestGatherNdOpWithIndex1.__name__ = cls_name
@@ -100,17 +94,17 @@ def test_class2(op_type, typename):
 
 def test_class3(op_type, typename):
     class TestGatherNdOpWithLowIndex(OpTest):
-        #Index has low rank, X has high rank
+        # Index has low rank, X has high rank
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([[1], [2]]).astype("int64")
 
-            self.inputs = {'X': xnp, 'Index': index}
-            self.outputs = {'Out': xnp[tuple(index.T)]}
+            self.inputs = {"X": xnp, "Index": index}
+            self.outputs = {"Out": xnp[tuple(index.T)]}
             self.x_grad = gather_nd_grad(xnp, index)
 
         def set_npu(self):
@@ -124,7 +118,8 @@ def test_class3(op_type, typename):
                 self.__class__.no_need_check_grad = True
             else:
                 self.check_grad_with_place(
-                    self.place, ['X'], 'Out', user_defined_grads=[self.x_grad])
+                    self.place, ["X"], "Out", user_defined_grads=[self.x_grad]
+                )
 
     cls_name = "{0}_{1}_3".format(op_type, typename)
     TestGatherNdOpWithLowIndex.__name__ = cls_name
@@ -133,18 +128,18 @@ def test_class3(op_type, typename):
 
 def test_class4(op_type, typename):
     class TestGatherNdOpIndex1(OpTest):
-        #Index has low rank, X has high rank
+        # Index has low rank, X has high rank
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([1, 2]).astype("int64")
 
-            self.inputs = {'X': xnp, 'Index': index}
+            self.inputs = {"X": xnp, "Index": index}
 
-            self.outputs = {'Out': xnp[tuple(index.T)]}
+            self.outputs = {"Out": xnp[tuple(index.T)]}
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -156,7 +151,7 @@ def test_class4(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_4".format(op_type, typename)
     TestGatherNdOpIndex1.__name__ = cls_name
@@ -165,17 +160,17 @@ def test_class4(op_type, typename):
 
 def test_class5(op_type, typename):
     class TestGatherNdOpWithSameIndexAsX(OpTest):
-        #Index has same rank as X's rank
+        # Index has same rank as X's rank
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([[1, 1], [2, 1]]).astype("int64")
 
-            self.inputs = {'X': xnp, 'Index': index}
-            self.outputs = {'Out': xnp[tuple(index.T)]}  #[25, 22]
+            self.inputs = {"X": xnp, "Index": index}
+            self.outputs = {"Out": xnp[tuple(index.T)]}  # [25, 22]
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -187,7 +182,7 @@ def test_class5(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_5".format(op_type, typename)
     TestGatherNdOpWithSameIndexAsX.__name__ = cls_name
@@ -196,19 +191,18 @@ def test_class5(op_type, typename):
 
 def test_class6(op_type, typename):
     class TestGatherNdOpWithHighRankSame(OpTest):
-        #Both Index and X have high rank, and Rank(Index) = Rank(X)
+        # Both Index and X have high rank, and Rank(Index) = Rank(X)
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             shape = (5, 2, 3, 1, 10)
             xnp = np.random.rand(*shape).astype(typename)
-            index = np.vstack([np.random.randint(
-                0, s, size=2) for s in shape]).T
+            index = np.vstack([np.random.randint(0, s, size=2) for s in shape]).T
 
-            self.inputs = {'X': xnp, 'Index': index.astype("int32")}
-            self.outputs = {'Out': xnp[tuple(index.T)]}
+            self.inputs = {"X": xnp, "Index": index.astype("int32")}
+            self.outputs = {"Out": xnp[tuple(index.T)]}
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -220,7 +214,7 @@ def test_class6(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_6".format(op_type, typename)
     TestGatherNdOpWithHighRankSame.__name__ = cls_name
@@ -229,21 +223,19 @@ def test_class6(op_type, typename):
 
 def test_class7(op_type, typename):
     class TestGatherNdOpWithHighRankDiff(OpTest):
-        #Both Index and X have high rank, Rank(Index) < Rank(X)
+        # Both Index and X have high rank, Rank(Index) < Rank(X)
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace('npu', 0)
+            self.place = paddle.CustomPlace("npu", 0)
             self.op_type = "gather_nd"
             shape = (2, 3, 4, 1, 10)
             xnp = np.random.rand(*shape).astype(typename)
-            index = np.vstack(
-                [np.random.randint(
-                    0, s, size=200) for s in shape]).T
+            index = np.vstack([np.random.randint(0, s, size=200) for s in shape]).T
             index_re = index.reshape([20, 5, 2, 5])
 
-            self.inputs = {'X': xnp, 'Index': index_re.astype("int32")}
-            self.outputs = {'Out': xnp[tuple(index.T)].reshape([20, 5, 2])}
+            self.inputs = {"X": xnp, "Index": index_re.astype("int32")}
+            self.outputs = {"Out": xnp[tuple(index.T)].reshape([20, 5, 2])}
 
         def set_npu(self):
             self.__class__.use_custom_device = True
@@ -255,7 +247,7 @@ def test_class7(op_type, typename):
             if typename == "float16" or typename == "int64":
                 self.__class__.no_need_check_grad = True
             else:
-                self.check_grad_with_place(self.place, ['X'], 'Out')
+                self.check_grad_with_place(self.place, ["X"], "Out")
 
     cls_name = "{0}_{1}_7".format(op_type, typename)
     TestGatherNdOpWithHighRankDiff.__name__ = cls_name
@@ -276,14 +268,14 @@ class TestGatherNdAPI(unittest.TestCase):
         paddle.enable_static()
 
 
-for _typename in {'float16', 'float32', 'int64'}:
-    test_class1('gather_nd', _typename)
-    test_class2('gather_nd', _typename)
-    test_class3('gather_nd', _typename)
-    test_class4('gather_nd', _typename)
-    test_class5('gather_nd', _typename)
-    test_class6('gather_nd', _typename)
-    test_class7('gather_nd', _typename)
+for _typename in {"float16", "float32", "int64"}:
+    test_class1("gather_nd", _typename)
+    test_class2("gather_nd", _typename)
+    test_class3("gather_nd", _typename)
+    test_class4("gather_nd", _typename)
+    test_class5("gather_nd", _typename)
+    test_class6("gather_nd", _typename)
+    test_class7("gather_nd", _typename)
 
 if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_gather_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_gaussian_random_op_npu.py
+++ b/backends/npu/tests/unittests/test_gaussian_random_op_npu.py
@@ -14,13 +14,11 @@
 
 from __future__ import print_function
 
-import sys
 import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -38,19 +36,19 @@ class TestNPUGaussianRandomOp(OpTest):
             "mean": self.mean,
             "std": self.std,
             "seed": 10,
-            "use_mkldnn": self.use_mkldnn
+            "use_mkldnn": self.use_mkldnn,
         }
         paddle.seed(10)
 
-        self.outputs = {'Out': np.zeros((123, 92), dtype='float32')}
+        self.outputs = {"Out": np.zeros((123, 92), dtype="float32")}
 
     def set_attrs(self):
         self.mean = 1.0
-        self.std = 2.
+        self.std = 2.0
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -68,9 +66,9 @@ class TestNPUGaussianRandomOp(OpTest):
         hist2 = hist2.astype("float32")
         hist2 /= float(outs[0].size)
         self.assertTrue(
-            np.allclose(
-                hist, hist2, rtol=0, atol=0.01),
-            "hist: " + str(hist) + " hist2: " + str(hist2))
+            np.allclose(hist, hist2, rtol=0, atol=0.01),
+            "hist: " + str(hist) + " hist2: " + str(hist2),
+        )
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_group_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_group_norm_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_hard_shrink_op_npu.py
+++ b/backends/npu/tests/unittests/test_hard_shrink_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 
 def ref_hard_shrink(x, threshold=0.5):

--- a/backends/npu/tests/unittests/test_hard_sigmoid_op_npu.py
+++ b/backends/npu/tests/unittests/test_hard_sigmoid_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021
@@ -55,18 +55,20 @@ class TestHardSigmoid(OpTest):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        check_eager = False
-        if hasattr(self, "check_eager"):
-            check_eager = self.check_eager
-        self.check_output_with_place(self.place, check_eager=check_eager)
+        check_dygraph = False
+        if hasattr(self, "check_dygraph"):
+            check_dygraph = self.check_dygraph
+        self.check_output_with_place(self.place, check_dygraph=check_dygraph)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        check_eager = False
-        if hasattr(self, "check_eager"):
-            check_eager = self.check_eager
-        self.check_grad_with_place(self.place, ["X"], "Out", check_eager=check_eager)
+        check_dygraph = False
+        if hasattr(self, "check_dygraph"):
+            check_dygraph = self.check_dygraph
+        self.check_grad_with_place(
+            self.place, ["X"], "Out", check_dygraph=check_dygraph
+        )
 
     def init_shape(self):
         self.shape = [10, 12]

--- a/backends/npu/tests/unittests/test_hard_swish_op_npu.py
+++ b/backends/npu/tests/unittests/test_hard_swish_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.nn.functional as F
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 
 def ref_hard_swish_grad(x, threshold=6.0, scale=6.0, offset=3.0):

--- a/backends/npu/tests/unittests/test_huber_loss_op_npu.py
+++ b/backends/npu/tests/unittests/test_huber_loss_op_npu.py
@@ -16,12 +16,9 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 
@@ -37,8 +34,8 @@ def huber_loss_forward(val, delta):
 class TestHuberLossOp(OpTest):
     def setUp(self):
         self.set_npu()
-        self.op_type = 'huber_loss'
-        self.place = paddle.CustomPlace('npu', 0)
+        self.op_type = "huber_loss"
+        self.place = paddle.CustomPlace("npu", 0)
 
         self.init_dtype()
 
@@ -48,23 +45,22 @@ class TestHuberLossOp(OpTest):
 
     def set_inputs(self):
         shape = self.set_shape()
-        x = np.random.uniform(0, 1., shape).astype(self.dtype)
-        y = np.random.uniform(0, 1., shape).astype(self.dtype)
+        x = np.random.uniform(0, 1.0, shape).astype(self.dtype)
+        y = np.random.uniform(0, 1.0, shape).astype(self.dtype)
         self.inputs = {
-            'X': OpTest.np_dtype_to_fluid_dtype(x),
-            'Y': OpTest.np_dtype_to_fluid_dtype(y)
+            "X": OpTest.np_dtype_to_fluid_dtype(x),
+            "Y": OpTest.np_dtype_to_fluid_dtype(y),
         }
 
     def set_attrs(self):
-        self.attrs = {'delta': 0.5}
+        self.attrs = {"delta": 0.5}
 
     def set_outputs(self):
-        delta = self.attrs['delta']
+        delta = self.attrs["delta"]
         shape = self.set_shape()
-        residual = self.inputs['Y'] - self.inputs['X']
-        loss = np.vectorize(huber_loss_forward)(residual,
-                                                delta).astype(self.dtype)
-        self.outputs = {'Residual': residual, 'Out': loss.reshape(shape)}
+        residual = self.inputs["Y"] - self.inputs["X"]
+        loss = np.vectorize(huber_loss_forward)(residual, delta).astype(self.dtype)
+        self.outputs = {"Residual": residual, "Out": loss.reshape(shape)}
 
     def set_shape(self):
         return (100, 1)
@@ -79,26 +75,30 @@ class TestHuberLossOp(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
-        self.check_grad_with_place(self.place, ['X', 'Y'], 'Out')
+        self.check_grad_with_place(self.place, ["X", "Y"], "Out")
 
     def test_check_grad_ingore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'],
-            'Out',
+            self.place,
+            ["Y"],
+            "Out",
             max_relative_error=0.008,
-            no_grad_set=set("residual"))
+            no_grad_set=set("residual"),
+        )
 
     def test_check_grad_ingore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'],
-            'Out',
+            self.place,
+            ["X"],
+            "Out",
             max_relative_error=0.008,
-            no_grad_set=set('residual'))
+            no_grad_set=set("residual"),
+        )
 
 
 def TestHuberLossOp1(TestHuberLossOp):
     def set_shape(self):
-        return (64)
+        return 64
 
 
 def TestHuberLossOp2(TestHuberLossOp):
@@ -116,5 +116,5 @@ def TestHuberLossOpFP16(TestHuberLossOp):
         self.dtype = np.float16
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_increment_op_npu.py
+++ b/backends/npu/tests/unittests/test_increment_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_index_sample_op_npu.py
+++ b/backends/npu/tests/unittests/test_index_sample_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 

--- a/backends/npu/tests/unittests/test_index_select_op_npu.py
+++ b/backends/npu/tests/unittests/test_index_select_op_npu.py
@@ -16,9 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 from paddle.static import Program, program_guard
 
@@ -29,7 +28,7 @@ SEED = 2021
 class TestNPUIndexSelect(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "index_select"
         self.config()
 
@@ -38,12 +37,13 @@ class TestNPUIndexSelect(OpTest):
             low=0,
             high=self.x_shape[self.dim],
             size=self.index_size,
-            dtype=self.index_type)
+            dtype=self.index_type,
+        )
 
         # compute real output as baseline.
-        outer_loop = np.prod(self.x_shape[:self.dim])
+        outer_loop = np.prod(self.x_shape[: self.dim])
         outer_loop = outer_loop.astype(self.index_type)
-        x_reshape = [outer_loop] + list(self.x_shape[self.dim:])
+        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
         x_np_reshape = np.reshape(x_np, tuple(x_reshape))
 
         out_list = []
@@ -55,9 +55,9 @@ class TestNPUIndexSelect(OpTest):
         self.out_shape = tuple(self.out_shape)
         out = np.reshape(out_list, self.out_shape)
 
-        self.inputs = {'X': x_np, 'Index': index_np}
-        self.attrs = {'dim': self.dim}
-        self.outputs = {'Out': out}
+        self.inputs = {"X": x_np, "Index": index_np}
+        self.attrs = {"dim": self.dim}
+        self.outputs = {"Out": out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -66,7 +66,7 @@ class TestNPUIndexSelect(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Out')
+        self.check_grad_with_place(self.place, ["X"], "Out")
 
     def config(self):
         self.x_shape = (100, 4, 5)
@@ -105,9 +105,10 @@ class TestNPUIndexSelectCase4(TestNPUIndexSelect):
 
 class TestNPUIndexSelectAPI(unittest.TestCase):
     def input_data(self):
-        self.data_x = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
-                                [9.0, 10.0, 11.0, 12.0]]).astype('float32')
-        self.data_index = np.array([0, 1, 1]).astype('int32')
+        self.data_x = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]
+        ).astype("float32")
+        self.data_index = np.array([0, 1, 1]).astype("int32")
 
     def test_index_select_api(self):
         paddle.set_device("npu:0")
@@ -116,30 +117,34 @@ class TestNPUIndexSelectAPI(unittest.TestCase):
 
         # case 1:
         with program_guard(Program(), Program()):
-            x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
-            index = paddle.static.data(name='index', shape=[3], dtype='int32')
+            x = paddle.static.data(name="x", shape=[-1, 4], dtype="float32")
+            index = paddle.static.data(name="index", shape=[3], dtype="int32")
             z = paddle.index_select(x, index, axis=1)
-            exe = paddle.static.Executor(paddle.CustomPlace('npu', 0))
-            res, = exe.run(feed={'x': self.data_x,
-                                 'index': self.data_index},
-                           fetch_list=[z.name],
-                           return_numpy=False)
-        expect_out = np.array([[1.0, 2.0, 2.0], [5.0, 6.0, 6.0],
-                               [9.0, 10.0, 10.0]]).astype('float32')
+            exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
+            (res,) = exe.run(
+                feed={"x": self.data_x, "index": self.data_index},
+                fetch_list=[z.name],
+                return_numpy=False,
+            )
+        expect_out = np.array(
+            [[1.0, 2.0, 2.0], [5.0, 6.0, 6.0], [9.0, 10.0, 10.0]]
+        ).astype("float32")
         self.assertTrue(np.allclose(expect_out, np.array(res)))
 
         # case 2:
         with program_guard(Program(), Program()):
-            x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
-            index = paddle.static.data(name='index', shape=[3], dtype='int32')
+            x = paddle.static.data(name="x", shape=[-1, 4], dtype="float32")
+            index = paddle.static.data(name="index", shape=[3], dtype="int32")
             z = paddle.index_select(x, index)
-            exe = paddle.static.Executor(paddle.CustomPlace('npu', 0))
-            res, = exe.run(feed={'x': self.data_x,
-                                 'index': self.data_index},
-                           fetch_list=[z.name],
-                           return_numpy=False)
-        expect_out = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
-                               [5.0, 6.0, 7.0, 8.0]]).astype('float32')
+            exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
+            (res,) = exe.run(
+                feed={"x": self.data_x, "index": self.data_index},
+                fetch_list=[z.name],
+                return_numpy=False,
+            )
+        expect_out = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [5.0, 6.0, 7.0, 8.0]]
+        ).astype("float32")
         self.assertTrue(np.allclose(expect_out, np.array(res)))
 
     def test_dygraph_index_select_api(self):
@@ -152,8 +157,9 @@ class TestNPUIndexSelectAPI(unittest.TestCase):
         index = paddle.to_tensor(self.data_index)
         z = paddle.index_select(x, index)
         np_z = z.numpy()
-        expect_out = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
-                               [5.0, 6.0, 7.0, 8.0]]).astype('float32')
+        expect_out = np.array(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [5.0, 6.0, 7.0, 8.0]]
+        ).astype("float32")
         self.assertTrue(np.allclose(expect_out, np_z))
 
         # case 2:
@@ -161,10 +167,11 @@ class TestNPUIndexSelectAPI(unittest.TestCase):
         index = paddle.to_tensor(self.data_index)
         z = paddle.index_select(x, index, axis=1)
         np_z = z.numpy()
-        expect_out = np.array([[1.0, 2.0, 2.0], [5.0, 6.0, 6.0],
-                               [9.0, 10.0, 10.0]]).astype('float32')
+        expect_out = np.array(
+            [[1.0, 2.0, 2.0], [5.0, 6.0, 6.0], [9.0, 10.0, 10.0]]
+        ).astype("float32")
         self.assertTrue(np.allclose(expect_out, np_z))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_is_empty_op_npu.py
+++ b/backends/npu/tests/unittests/test_is_empty_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -32,14 +32,14 @@ class TestEmpty(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
 
     def set_data(self):
-        self.inputs = {'X': np.array([1, 2, 3]).astype(self.dtype)}
-        self.outputs = {'Out': np.array([False])}
+        self.inputs = {"X": np.array([1, 2, 3]).astype(self.dtype)}
+        self.outputs = {"Out": np.array([False])}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -47,15 +47,16 @@ class TestEmpty(OpTest):
 
 class TestNotEmpty(TestEmpty):
     def set_data(self):
-        self.inputs = {'X': np.array([])}
-        self.outputs = {'Out': np.array([True])}
+        self.inputs = {"X": np.array([])}
+        self.outputs = {"Out": np.array([True])}
 
 
 class TestIsEmptyOpError(unittest.TestCase):
     def test_errors(self):
         paddle.enable_static()
-        with paddle.static.program_guard(paddle.static.Program(),
-                                         paddle.static.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             input_data = np.random.random((3, 2)).astype("float32")
 
             def test_Variable():
@@ -66,16 +67,14 @@ class TestIsEmptyOpError(unittest.TestCase):
 
             def test_type():
                 # dtype must be float32, float16 in NPU
-                x3 = paddle.static.data(
-                    name="x3", shape=[4, 32, 32], dtype="bool")
+                x3 = paddle.static.data(name="x3", shape=[4, 32, 32], dtype="bool")
                 res = paddle.is_empty(x=x3)
 
             self.assertRaises(TypeError, test_type)
 
             def test_name_type():
                 # name type must be string.
-                x4 = paddle.static.data(
-                    name="x4", shape=[3, 2], dtype="float32")
+                x4 = paddle.static.data(name="x4", shape=[3, 2], dtype="float32")
                 res = paddle.is_empty(x=x4, name=1)
 
             self.assertRaises(TypeError, test_name_type)
@@ -83,8 +82,8 @@ class TestIsEmptyOpError(unittest.TestCase):
 
 class TestIsEmptyOpDygraph(unittest.TestCase):
     def test_dygraph(self):
-        paddle.disable_static(paddle.CustomPlace('npu', 0))
-        input = paddle.rand(shape=[4, 32, 32], dtype='float32')
+        paddle.disable_static(paddle.CustomPlace("npu", 0))
+        input = paddle.rand(shape=[4, 32, 32], dtype="float32")
         res = paddle.is_empty(x=input)
 
 

--- a/backends/npu/tests/unittests/test_kldiv_loss_op_npu.py
+++ b/backends/npu/tests/unittests/test_kldiv_loss_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function, division
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_label_smooth_op_npu.py
+++ b/backends/npu/tests/unittests/test_label_smooth_op_npu.py
@@ -17,9 +17,8 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021
@@ -29,7 +28,7 @@ class TestLabelSmoothOp(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "label_smooth"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         self.init_dtype()
         np.random.seed(SEED)
@@ -52,17 +51,16 @@ class TestLabelSmoothOp(OpTest):
         x = np.zeros((batch_size, label_dim)).astype(self.dtype)
         nonzero_index = np.random.randint(label_dim, size=(batch_size))
         x[np.arange(batch_size), nonzero_index] = 1
-        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
 
     def set_attrs(self):
         epsilon = 0.1
         self.attrs = {"epsilon": epsilon}
 
     def set_outputs(self):
-        dist = None if 'PriorDist' not in self.inputs else self.inputs[
-            'PriorDist']
-        out = self.calc_out(self.inputs['X'], self.attrs['epsilon'], dist)
-        self.outputs = {'Out': out}
+        dist = None if "PriorDist" not in self.inputs else self.inputs["PriorDist"]
+        out = self.calc_out(self.inputs["X"], self.attrs["epsilon"], dist)
+        self.outputs = {"Out": out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -75,30 +73,29 @@ class TestLabelSmoothOp(OpTest):
 
     def test_check_grad(self):
         if self.dtype == np.float16:
-            self.check_grad_with_place(
-                self.place, ['X'], 'Out', max_relative_error=0.5)
+            self.check_grad_with_place(self.place, ["X"], "Out", max_relative_error=0.5)
         else:
-            self.check_grad_with_place(self.place, ['X'], 'Out')
+            self.check_grad_with_place(self.place, ["X"], "Out")
 
 
 class TestLabelSmoothOpWithPriorDist(TestLabelSmoothOp):
     def set_inputs(self):
         super(TestLabelSmoothOpWithPriorDist, self).set_inputs()
-        label_dim = self.inputs['X'].shape[-1]
+        label_dim = self.inputs["X"].shape[-1]
         dist = np.random.random((1, label_dim)).astype(self.dtype)
-        self.inputs['PriorDist'] = dist
+        self.inputs["PriorDist"] = dist
 
 
 class TestLabelSmoothOp3D(TestLabelSmoothOp):
     def set_inputs(self):
         super(TestLabelSmoothOp3D, self).set_inputs()
-        self.inputs['X'].reshape([2, -1, self.inputs['X'].shape[-1]])
+        self.inputs["X"].reshape([2, -1, self.inputs["X"].shape[-1]])
 
 
 class TestLabelSmoothOpWithPriorDist3D(TestLabelSmoothOpWithPriorDist):
     def set_inputs(self):
         super(TestLabelSmoothOpWithPriorDist3D, self).set_inputs()
-        self.inputs['X'].reshape([2, -1, self.inputs['X'].shape[-1]])
+        self.inputs["X"].reshape([2, -1, self.inputs["X"].shape[-1]])
 
 
 class TestLabelSmoothOpFP16(TestLabelSmoothOp):
@@ -121,5 +118,5 @@ class TestLabelSmoothOpWithPriorDist3DFP16(TestLabelSmoothOpWithPriorDist3D):
         self.dtype = np.float16
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_layer_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_layer_norm_op_npu.py
@@ -27,7 +27,7 @@ paddle.enable_static()
 
 SEED = 2021
 
-from tests.op_test import _set_use_system_allocator
+from tests.eager_op_test import _set_use_system_allocator
 
 _set_use_system_allocator(False)
 

--- a/backends/npu/tests/unittests/test_linspace_op_npu.py
+++ b/backends/npu/tests/unittests/test_linspace_op_npu.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 import paddle.fluid as fluid

--- a/backends/npu/tests/unittests/test_log_loss_op_npu.py
+++ b/backends/npu/tests/unittests/test_log_loss_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_log_softmax_op_npu.py
+++ b/backends/npu/tests/unittests/test_log_softmax_op_npu.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 import numpy as np
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.nn.functional as F
 

--- a/backends/npu/tests/unittests/test_logical_op_npu.py
+++ b/backends/npu/tests/unittests/test_logical_op_npu.py
@@ -14,90 +14,38 @@
 
 from __future__ import print_function
 
-from tests.op_test import OpTest
 import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from paddle.static import Program, program_guard
 
 SUPPORTED_DTYPES = [bool]
 
-TEST_META_OP_DATA = [{
-    'op_str': 'logical_and',
-    'binary_op': True
-}, {
-    'op_str': 'logical_or',
-    'binary_op': True
-}, {
-    'op_str': 'logical_not',
-    'binary_op': False
-}]
+TEST_META_OP_DATA = [
+    {"op_str": "logical_and", "binary_op": True},
+    {"op_str": "logical_or", "binary_op": True},
+    {"op_str": "logical_not", "binary_op": False},
+]
 
 TEST_META_SHAPE_DATA = {
-    'XDimLargerThanYDim1': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [4, 5]
-    },
-    'XDimLargerThanYDim2': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [4, 1]
-    },
-    'XDimLargerThanYDim3': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [1, 4, 1]
-    },
-    'XDimLargerThanYDim4': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [3, 4, 1]
-    },
-    'XDimLargerThanYDim5': {
-        'x_shape': [2, 3, 1, 5],
-        'y_shape': [3, 1, 1]
-    },
-    'XDimLessThanYDim1': {
-        'x_shape': [4, 1],
-        'y_shape': [2, 3, 4, 5]
-    },
-    'XDimLessThanYDim2': {
-        'x_shape': [1, 4, 1],
-        'y_shape': [2, 3, 4, 5]
-    },
-    'XDimLessThanYDim3': {
-        'x_shape': [3, 4, 1],
-        'y_shape': [2, 3, 4, 5]
-    },
-    'XDimLessThanYDim4': {
-        'x_shape': [3, 1, 1],
-        'y_shape': [2, 3, 1, 5]
-    },
-    'XDimLessThanYDim5': {
-        'x_shape': [4, 5],
-        'y_shape': [2, 3, 4, 5]
-    },
-    'Axis1InLargerDim': {
-        'x_shape': [1, 4, 5],
-        'y_shape': [2, 3, 1, 5]
-    },
-    'EqualDim1': {
-        'x_shape': [10, 7],
-        'y_shape': [10, 7]
-    },
-    'EqualDim2': {
-        'x_shape': [1, 1, 4, 5],
-        'y_shape': [2, 3, 1, 5]
-    }
+    "XDimLargerThanYDim1": {"x_shape": [2, 3, 4, 5], "y_shape": [4, 5]},
+    "XDimLargerThanYDim2": {"x_shape": [2, 3, 4, 5], "y_shape": [4, 1]},
+    "XDimLargerThanYDim3": {"x_shape": [2, 3, 4, 5], "y_shape": [1, 4, 1]},
+    "XDimLargerThanYDim4": {"x_shape": [2, 3, 4, 5], "y_shape": [3, 4, 1]},
+    "XDimLargerThanYDim5": {"x_shape": [2, 3, 1, 5], "y_shape": [3, 1, 1]},
+    "XDimLessThanYDim1": {"x_shape": [4, 1], "y_shape": [2, 3, 4, 5]},
+    "XDimLessThanYDim2": {"x_shape": [1, 4, 1], "y_shape": [2, 3, 4, 5]},
+    "XDimLessThanYDim3": {"x_shape": [3, 4, 1], "y_shape": [2, 3, 4, 5]},
+    "XDimLessThanYDim4": {"x_shape": [3, 1, 1], "y_shape": [2, 3, 1, 5]},
+    "XDimLessThanYDim5": {"x_shape": [4, 5], "y_shape": [2, 3, 4, 5]},
+    "Axis1InLargerDim": {"x_shape": [1, 4, 5], "y_shape": [2, 3, 1, 5]},
+    "EqualDim1": {"x_shape": [10, 7], "y_shape": [10, 7]},
+    "EqualDim2": {"x_shape": [1, 1, 4, 5], "y_shape": [2, 3, 1, 5]},
 }
 
 TEST_META_WRONG_SHAPE_DATA = {
-    'ErrorDim1': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [3, 4]
-    },
-    'ErrorDim2': {
-        'x_shape': [2, 3, 4, 5],
-        'y_shape': [4, 3]
-    }
+    "ErrorDim1": {"x_shape": [2, 3, 4, 5], "y_shape": [3, 4]},
+    "ErrorDim2": {"x_shape": [2, 3, 4, 5], "y_shape": [4, 3]},
 }
 
 
@@ -107,17 +55,17 @@ def run_static(x_np, y_np, op_str, use_custom_device=False, binary_op=True):
     main_program = fluid.Program()
     place = paddle.CPUPlace()
     if use_custom_device:
-        place = paddle.CustomPlace('npu', 0)
+        place = paddle.CustomPlace("npu", 0)
     exe = fluid.Executor(place)
     with fluid.program_guard(main_program, startup_program):
-        x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)
+        x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
         op = getattr(paddle, op_str)
-        feed_list = {'x': x_np}
+        feed_list = {"x": x_np}
         if not binary_op:
             res = op(x)
         else:
-            y = paddle.static.data(name='y', shape=y_np.shape, dtype=y_np.dtype)
-            feed_list['y'] = y_np
+            y = paddle.static.data(name="y", shape=y_np.shape, dtype=y_np.dtype)
+            feed_list["y"] = y_np
             res = op(x, y)
         exe.run(startup_program)
         static_result = exe.run(main_program, feed=feed_list, fetch_list=[res])
@@ -127,7 +75,7 @@ def run_static(x_np, y_np, op_str, use_custom_device=False, binary_op=True):
 def run_dygraph(x_np, y_np, op_str, use_custom_device=False, binary_op=True):
     place = paddle.CPUPlace()
     if use_custom_device:
-        place = paddle.CustomPlace('npu', 0)
+        place = paddle.CustomPlace("npu", 0)
     paddle.disable_static(place)
     op = getattr(paddle, op_str)
     x = paddle.to_tensor(x_np, dtype=x_np.dtype)
@@ -149,33 +97,32 @@ def np_data_generator(np_shape, dtype, *args, **kwargs):
 def test(unit_test, use_custom_device=False, test_error=False):
     for op_data in TEST_META_OP_DATA:
         meta_data = dict(op_data)
-        meta_data['use_custom_device'] = use_custom_device
-        np_op = getattr(np, meta_data['op_str'])
+        meta_data["use_custom_device"] = use_custom_device
+        np_op = getattr(np, meta_data["op_str"])
         META_DATA = dict(TEST_META_SHAPE_DATA)
         if test_error:
             META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
         for shape_data in META_DATA.values():
             for data_type in SUPPORTED_DTYPES:
-                meta_data['x_np'] = np_data_generator(
-                    shape_data['x_shape'], dtype=data_type)
-                meta_data['y_np'] = np_data_generator(
-                    shape_data['y_shape'], dtype=data_type)
-                if meta_data['binary_op'] and test_error:
+                meta_data["x_np"] = np_data_generator(
+                    shape_data["x_shape"], dtype=data_type
+                )
+                meta_data["y_np"] = np_data_generator(
+                    shape_data["y_shape"], dtype=data_type
+                )
+                if meta_data["binary_op"] and test_error:
                     # catch C++ Exception
-                    unit_test.assertRaises(BaseException, run_static,
-                                           **meta_data)
-                    unit_test.assertRaises(BaseException, run_dygraph,
-                                           **meta_data)
+                    unit_test.assertRaises(BaseException, run_static, **meta_data)
+                    unit_test.assertRaises(BaseException, run_dygraph, **meta_data)
                     continue
                 static_result = run_static(**meta_data)
                 dygraph_result = run_dygraph(**meta_data)
-                if meta_data['binary_op']:
-                    np_result = np_op(meta_data['x_np'], meta_data['y_np'])
+                if meta_data["binary_op"]:
+                    np_result = np_op(meta_data["x_np"], meta_data["y_np"])
                 else:
-                    np_result = np_op(meta_data['x_np'])
+                    np_result = np_op(meta_data["x_np"])
                 unit_test.assertTrue((static_result == np_result).all())
-                unit_test.assertTrue((dygraph_result.numpy() == np_result).all(
-                ))
+                unit_test.assertTrue((dygraph_result.numpy() == np_result).all())
 
 
 def test_type_error(unit_test, use_custom_device, type_str_map):
@@ -187,7 +134,7 @@ def test_type_error(unit_test, use_custom_device, type_str_map):
             y = paddle.to_tensor(y)
             error_type = BaseException
         if binary_op:
-            if type_str_map['x'] != type_str_map['y']:
+            if type_str_map["x"] != type_str_map["y"]:
                 unit_test.assertRaises(error_type, op, x=x, y=y)
             if not fluid._non_static_mode():
                 error_type = TypeError
@@ -199,32 +146,31 @@ def test_type_error(unit_test, use_custom_device, type_str_map):
 
     place = paddle.CPUPlace()
     if use_custom_device:
-        place = paddle.CustomPlace('npu', 0)
+        place = paddle.CustomPlace("npu", 0)
     for op_data in TEST_META_OP_DATA:
         meta_data = dict(op_data)
-        binary_op = meta_data['binary_op']
+        binary_op = meta_data["binary_op"]
 
         paddle.disable_static(place)
-        x = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map['x'])
-        y = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map['y'])
-        check_type(meta_data['op_str'], x, y, binary_op)
+        x = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map["x"])
+        y = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map["y"])
+        check_type(meta_data["op_str"], x, y, binary_op)
 
         paddle.enable_static()
         startup_program = paddle.static.Program()
         main_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
-            x = paddle.static.data(
-                name='x', shape=[10], dtype=type_str_map['x'])
-            y = paddle.static.data(
-                name='y', shape=[10], dtype=type_str_map['y'])
-            check_type(meta_data['op_str'], x, y, binary_op)
+            x = paddle.static.data(name="x", shape=[10], dtype=type_str_map["x"])
+            y = paddle.static.data(name="y", shape=[10], dtype=type_str_map["y"])
+            check_type(meta_data["op_str"], x, y, binary_op)
 
 
 def type_map_factory():
-    return [{
-        'x': x_type,
-        'y': y_type
-    } for x_type in SUPPORTED_DTYPES for y_type in SUPPORTED_DTYPES]
+    return [
+        {"x": x_type, "y": y_type}
+        for x_type in SUPPORTED_DTYPES
+        for y_type in SUPPORTED_DTYPES
+    ]
 
 
 class TestCPU(unittest.TestCase):
@@ -253,5 +199,5 @@ class TestNPU(unittest.TestCase):
             test_type_error(self, True, type_map)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_lookup_table_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_lookup_table_v2_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021
@@ -30,30 +28,31 @@ class TestLookupTableV2(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "lookup_table_v2"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         self.init_dtype()
         self.init_dims()
         self.init_padding_idx()
         np.random.seed(SEED)
         w = np.random.random([self.vocab, self.dim]).astype(self.dtype)
-        x = np.random.randint(
-            0, self.vocab, size=(self.bsz, self.seqlen)).astype(self.ids_dtype)
+        x = np.random.randint(0, self.vocab, size=(self.bsz, self.seqlen)).astype(
+            self.ids_dtype
+        )
         out = w[x]
         if self.padding_idx != -1:
             out[np.squeeze(x == self.padding_idx)] = np.zeros(self.dim)
 
         self.inputs = {
-            'W': OpTest.np_dtype_to_fluid_dtype(w),
-            'Ids': OpTest.np_dtype_to_fluid_dtype(x)
+            "W": OpTest.np_dtype_to_fluid_dtype(w),
+            "Ids": OpTest.np_dtype_to_fluid_dtype(x),
         }
         self.attrs = {
-            'is_sparse': False,
-            'is_distributed': False,
-            'remote_prefetch': False,
-            'padding_idx': self.padding_idx
+            "is_sparse": False,
+            "is_distributed": False,
+            "remote_prefetch": False,
+            "padding_idx": self.padding_idx,
         }
-        self.outputs = {'Out': out}
+        self.outputs = {"Out": out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -78,9 +77,10 @@ class TestLookupTableV2(OpTest):
     def test_check_grad(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, ['W'], 'Out', max_relative_error=0.01)
+                self.place, ["W"], "Out", max_relative_error=0.01
+            )
         else:
-            self.check_grad_with_place(self.place, ['W'], 'Out')
+            self.check_grad_with_place(self.place, ["W"], "Out")
 
 
 class TestLookupTableV2FP16(TestLookupTableV2):
@@ -136,5 +136,5 @@ class TestLookupTableV2WithPadding1(TestLookupTableV2):
         self.ids_dtype = np.int64
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_masked_select_op_npu.py
+++ b/backends/npu/tests/unittests/test_masked_select_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_matmulv2_op_npu.py
+++ b/backends/npu/tests/unittests/test_matmulv2_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_mean_op_npu.py
+++ b/backends/npu/tests/unittests/test_mean_op_npu.py
@@ -16,12 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021
@@ -30,16 +27,16 @@ SEED = 2021
 class TestMean(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "mean"
         self.init_dtype()
 
         x = np.random.random([1, 100]).astype(self.dtype)
-        self.inputs = {'X': x}
+        self.inputs = {"X": x}
 
         self.attrs = {}
         np_out = np.mean(x)
-        self.outputs = {'Out': np_out}
+        self.outputs = {"Out": np_out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -51,22 +48,22 @@ class TestMean(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Out')
+        self.check_grad_with_place(self.place, ["X"], "Out")
 
 
 class TestMeanFP16(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "mean"
         self.init_dtype()
 
         x = np.random.random([3, 200]).astype(self.dtype)
-        self.inputs = {'X': x}
+        self.inputs = {"X": x}
 
         self.attrs = {}
         np_out = np.mean(x)
-        self.outputs = {'Out': np_out}
+        self.outputs = {"Out": np_out}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -79,5 +76,5 @@ class TestMeanFP16(OpTest):
         self.check_output_with_place(self.place)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_memcpy_op_npu.py
+++ b/backends/npu/tests/unittests/test_memcpy_op_npu.py
@@ -16,13 +16,10 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 SEED = 2021
@@ -39,15 +36,17 @@ class TestMemcpy_FillConstant(unittest.TestCase):
             cpu_var = main_program.global_block().create_var(
                 name=cpu_var_name,
                 shape=[10, 10],
-                dtype='float32',
+                dtype="float32",
                 persistable=False,
-                stop_gradient=True)
+                stop_gradient=True,
+            )
             npu_var = main_program.global_block().create_var(
                 name=npu_var_name,
                 shape=[10, 10],
-                dtype='float32',
+                dtype="float32",
                 persistable=False,
-                stop_gradient=True)
+                stop_gradient=True,
+            )
             main_program.global_block().append_op(
                 type="fill_constant",
                 outputs={"Out": npu_var_name},
@@ -55,7 +54,8 @@ class TestMemcpy_FillConstant(unittest.TestCase):
                     "shape": [10, 10],
                     "dtype": npu_var.dtype,
                     "value": 1.0,
-                })
+                },
+            )
             main_program.global_block().append_op(
                 type="fill_constant",
                 outputs={"Out": cpu_var_name},
@@ -63,23 +63,25 @@ class TestMemcpy_FillConstant(unittest.TestCase):
                     "shape": [10, 10],
                     "dtype": cpu_var.dtype,
                     "value": 0.0,
-                    "place_type": 0
-                })
+                    "place_type": 0,
+                },
+            )
         return main_program, npu_var, cpu_var
 
     def test_npu_cpoy_to_cpu(self):
         self.__class__.use_custom_device = True
         main_program, npu_var, cpu_var = self.get_prog()
         main_program.global_block().append_op(
-            type='memcpy',
-            inputs={'X': npu_var},
-            outputs={'Out': cpu_var},
-            attrs={'dst_place_type': 0})
-        place = paddle.CustomPlace('npu', 0)
+            type="memcpy",
+            inputs={"X": npu_var},
+            outputs={"Out": cpu_var},
+            attrs={"dst_place_type": 0},
+        )
+        place = paddle.CustomPlace("npu", 0)
         exe = fluid.Executor(place)
-        npu_, cpu_ = exe.run(main_program,
-                             feed={},
-                             fetch_list=[npu_var.name, cpu_var.name])
+        npu_, cpu_ = exe.run(
+            main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
+        )
         np.testing.assert_allclose(npu_, cpu_)
         np.testing.assert_allclose(cpu_, np.ones((10, 10)))
 
@@ -87,18 +89,19 @@ class TestMemcpy_FillConstant(unittest.TestCase):
         self.__class__.use_custom_device = True
         main_program, npu_var, cpu_var = self.get_prog()
         main_program.global_block().append_op(
-            type='memcpy',
-            inputs={'X': cpu_var},
-            outputs={'Out': npu_var},
-            attrs={'dst_place_type': 6})
-        place = paddle.CustomPlace('npu', 0)
+            type="memcpy",
+            inputs={"X": cpu_var},
+            outputs={"Out": npu_var},
+            attrs={"dst_place_type": 6},
+        )
+        place = paddle.CustomPlace("npu", 0)
         exe = fluid.Executor(place)
-        npu_, cpu_ = exe.run(main_program,
-                             feed={},
-                             fetch_list=[npu_var.name, cpu_var.name])
+        npu_, cpu_ = exe.run(
+            main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
+        )
         np.testing.assert_allclose(npu_, cpu_)
         np.testing.assert_allclose(npu_, np.zeros((10, 10)))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
@@ -16,122 +16,121 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 from paddle.fluid.layer_helper import LayerHelper
 from collections import OrderedDict
 
 paddle.enable_static()
 
 
-def run_momentum_op(params,
-                    grads,
-                    velocitys,
-                    master_params,
-                    learning_rate,
-                    place,
-                    multi_precision,
-                    mu=0.9,
-                    rescale_grad=0.01,
-                    use_merged=False):
+def run_momentum_op(
+    params,
+    grads,
+    velocitys,
+    master_params,
+    learning_rate,
+    place,
+    multi_precision,
+    mu=0.9,
+    rescale_grad=0.01,
+    use_merged=False,
+):
     assert len(params) == len(grads)
     assert len(params) == len(velocitys)
     if multi_precision:
         assert len(params) == len(master_params)
-    op_type = 'merged_momentum' if use_merged else 'momentum'
+    op_type = "merged_momentum" if use_merged else "momentum"
     main = paddle.static.Program()
     startup = paddle.static.Program()
     with paddle.static.program_guard(main, startup):
         helper = LayerHelper(op_type, **locals())
         attrs = {
-            'mu': mu,
-            'multi_precision': multi_precision,
-            'rescale_grad': rescale_grad,
+            "mu": mu,
+            "multi_precision": multi_precision,
+            "rescale_grad": rescale_grad,
         }
 
         param_vars = [
-            helper.create_variable(
-                persistable=True, shape=p.shape, dtype=p.dtype) for p in params
+            helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
+            for p in params
         ]
         grad_vars = [
-            helper.create_variable(
-                shape=g.shape, dtype=g.dtype) for g in grads
+            helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
         ]
         velocity_vars = [
-            helper.create_variable(
-                persistable=True, shape=v.shape, dtype=v.dtype)
+            helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
             for v in velocitys
         ]
         lr_var = helper.create_variable(
-            persistable=True,
-            shape=learning_rate.shape,
-            dtype=learning_rate.dtype)
+            persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
+        )
 
         feed_dict = OrderedDict()
 
         feed_dict.update(
-            OrderedDict([(p_var.name, p_val)
-                         for p_var, p_val in zip(param_vars, params)]))
+            OrderedDict(
+                [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
+            )
+        )
         feed_dict.update(
-            OrderedDict([(v_var.name, v_val)
-                         for v_var, v_val in zip(velocity_vars, velocitys)]))
+            OrderedDict(
+                [(v_var.name, v_val) for v_var, v_val in zip(velocity_vars, velocitys)]
+            )
+        )
         fetch_list = list(feed_dict.keys())
 
         feed_dict.update(
-            OrderedDict([(g_var.name, g_val)
-                         for g_var, g_val in zip(grad_vars, grads)]))
+            OrderedDict([(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)])
+        )
         feed_dict.update({lr_var.name: learning_rate})
 
         if multi_precision:
             master_param_vars = [
-                helper.create_variable(
-                    persistable=True, shape=p.shape, dtype=p.dtype)
+                helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
                 for p in master_params
             ]
             feed_dict.update(
-                OrderedDict([(mp_var.name, mp_val)
-                             for mp_var, mp_val in zip(master_param_vars,
-                                                       master_params)]))
+                OrderedDict(
+                    [
+                        (mp_var.name, mp_val)
+                        for mp_var, mp_val in zip(master_param_vars, master_params)
+                    ]
+                )
+            )
             # CPUPlace does not use MasterParam
             if isinstance(place, paddle.CUDAPlace):
-                fetch_list = fetch_list + [
-                    mp_var.name for mp_var in master_param_vars
-                ]
+                fetch_list = fetch_list + [mp_var.name for mp_var in master_param_vars]
         else:
             master_param_vars = None
 
         if not use_merged:
-            for i, (p, g,
-                    v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
+            for i, (p, g, v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
                 inputs = {
-                    'Param': p,
-                    'Grad': g,
-                    'Velocity': v,
-                    'LearningRate': lr_var,
+                    "Param": p,
+                    "Grad": g,
+                    "Velocity": v,
+                    "LearningRate": lr_var,
                 }
-                outputs = {'ParamOut': p, 'VelocityOut': v}
+                outputs = {"ParamOut": p, "VelocityOut": v}
                 if multi_precision:
-                    inputs['MasterParam'] = master_param_vars[i]
-                    outputs['MasterParamOut'] = master_param_vars[i]
+                    inputs["MasterParam"] = master_param_vars[i]
+                    outputs["MasterParamOut"] = master_param_vars[i]
                 helper.append_op(
-                    type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+                    type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
+                )
         else:
             inputs = {
-                'Param': param_vars,
-                'Grad': grad_vars,
-                'Velocity': velocity_vars,
-                'LearningRate': lr_var,
+                "Param": param_vars,
+                "Grad": grad_vars,
+                "Velocity": velocity_vars,
+                "LearningRate": lr_var,
             }
-            outputs = {'ParamOut': param_vars, 'VelocityOut': velocity_vars}
+            outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
             if multi_precision:
-                inputs['MasterParam'] = master_param_vars
-                outputs['MasterParamOut'] = master_param_vars
-            helper.append_op(
-                type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+                inputs["MasterParam"] = master_param_vars
+                outputs["MasterParamOut"] = master_param_vars
+            helper.append_op(type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
 
     exe = paddle.static.Executor(place)
     with paddle.static.scope_guard(paddle.static.Scope()):
@@ -139,123 +138,125 @@ def run_momentum_op(params,
         return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
 
 
-def run_momentum_op2(params,
-                     grads,
-                     velocitys,
-                     master_params,
-                     learning_rate,
-                     place,
-                     multi_precision,
-                     mu=0.9,
-                     rescale_grad=0.01,
-                     use_merged=False,
-                     use_nesterov=True):
+def run_momentum_op2(
+    params,
+    grads,
+    velocitys,
+    master_params,
+    learning_rate,
+    place,
+    multi_precision,
+    mu=0.9,
+    rescale_grad=0.01,
+    use_merged=False,
+    use_nesterov=True,
+):
     assert len(params) == len(grads)
     assert len(params) == len(velocitys)
     if multi_precision:
         assert len(params) == len(master_params)
-    op_type = 'merged_momentum' if use_merged else 'momentum'
+    op_type = "merged_momentum" if use_merged else "momentum"
     main = paddle.static.Program()
     startup = paddle.static.Program()
     with paddle.static.program_guard(main, startup):
         helper = LayerHelper(op_type, **locals())
 
         param_vars = [
-            helper.create_variable(
-                persistable=True, shape=p.shape, dtype=p.dtype) for p in params
+            helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
+            for p in params
         ]
         grad_vars = [
-            helper.create_variable(
-                shape=g.shape, dtype=g.dtype) for g in grads
+            helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
         ]
         velocity_vars = [
-            helper.create_variable(
-                persistable=True, shape=v.shape, dtype=v.dtype)
+            helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
             for v in velocitys
         ]
         lr_var = helper.create_variable(
-            persistable=True,
-            shape=learning_rate.shape,
-            dtype=learning_rate.dtype)
+            persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
+        )
 
         feed_dict = OrderedDict()
 
         feed_dict.update(
-            OrderedDict([(p_var.name, p_val)
-                         for p_var, p_val in zip(param_vars, params)]))
+            OrderedDict(
+                [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
+            )
+        )
         feed_dict.update(
-            OrderedDict([(v_var.name, v_val)
-                         for v_var, v_val in zip(velocity_vars, velocitys)]))
+            OrderedDict(
+                [(v_var.name, v_val) for v_var, v_val in zip(velocity_vars, velocitys)]
+            )
+        )
         fetch_list = list(feed_dict.keys())
 
         feed_dict.update(
-            OrderedDict([(g_var.name, g_val)
-                         for g_var, g_val in zip(grad_vars, grads)]))
+            OrderedDict([(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)])
+        )
         feed_dict.update({lr_var.name: learning_rate})
 
         if multi_precision:
             master_param_vars = [
-                helper.create_variable(
-                    persistable=True, shape=p.shape, dtype=p.dtype)
+                helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
                 for p in master_params
             ]
             feed_dict.update(
-                OrderedDict([(mp_var.name, mp_val)
-                             for mp_var, mp_val in zip(master_param_vars,
-                                                       master_params)]))
+                OrderedDict(
+                    [
+                        (mp_var.name, mp_val)
+                        for mp_var, mp_val in zip(master_param_vars, master_params)
+                    ]
+                )
+            )
             # CPUPlace does not use MasterParam
             if isinstance(place, paddle.CUDAPlace):
-                fetch_list = fetch_list + [
-                    mp_var.name for mp_var in master_param_vars
-                ]
+                fetch_list = fetch_list + [mp_var.name for mp_var in master_param_vars]
         else:
             master_param_vars = None
 
         if not use_merged:
-            for i, (p, g,
-                    v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
+            for i, (p, g, v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
                 inputs = {
-                    'Param': p,
-                    'Grad': g,
-                    'Velocity': v,
-                    'LearningRate': lr_var,
+                    "Param": p,
+                    "Grad": g,
+                    "Velocity": v,
+                    "LearningRate": lr_var,
                 }
-                outputs = {'ParamOut': p, 'VelocityOut': v}
+                outputs = {"ParamOut": p, "VelocityOut": v}
                 if multi_precision:
-                    inputs['MasterParam'] = master_param_vars[i]
-                    outputs['MasterParamOut'] = master_param_vars[i]
+                    inputs["MasterParam"] = master_param_vars[i]
+                    outputs["MasterParamOut"] = master_param_vars[i]
                 attrs = {
-                    'mu': mu,
-                    'multi_precision': multi_precision,
-                    'rescale_grad': rescale_grad,
-                    'use_nesterov': use_nesterov,
-                    'regularization_method': 'l2_decay',
-                    'regularization_coeff': 2.0,
+                    "mu": mu,
+                    "multi_precision": multi_precision,
+                    "rescale_grad": rescale_grad,
+                    "use_nesterov": use_nesterov,
+                    "regularization_method": "l2_decay",
+                    "regularization_coeff": 2.0,
                 }
                 helper.append_op(
-                    type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+                    type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
+                )
         else:
             inputs = {
-                'Param': param_vars,
-                'Grad': grad_vars,
-                'Velocity': velocity_vars,
-                'LearningRate': lr_var,
+                "Param": param_vars,
+                "Grad": grad_vars,
+                "Velocity": velocity_vars,
+                "LearningRate": lr_var,
             }
-            outputs = {'ParamOut': param_vars, 'VelocityOut': velocity_vars}
+            outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
             if multi_precision:
-                inputs['MasterParam'] = master_param_vars
-                outputs['MasterParamOut'] = master_param_vars
+                inputs["MasterParam"] = master_param_vars
+                outputs["MasterParamOut"] = master_param_vars
             attrs = {
-                'mu': mu,
-                'multi_precision': multi_precision,
-                'rescale_grad': rescale_grad,
-                'use_nesterov': use_nesterov,
-                'regularization_method':
-                ['l2_decay' for i in range(len(param_vars))],
-                'regularization_coeff': [2.0 for i in range(len(param_vars))],
+                "mu": mu,
+                "multi_precision": multi_precision,
+                "rescale_grad": rescale_grad,
+                "use_nesterov": use_nesterov,
+                "regularization_method": ["l2_decay" for i in range(len(param_vars))],
+                "regularization_coeff": [2.0 for i in range(len(param_vars))],
             }
-            helper.append_op(
-                type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
+            helper.append_op(type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
 
     exe = paddle.static.Executor(place)
     with paddle.static.scope_guard(paddle.static.Scope()):
@@ -276,8 +277,11 @@ class TestMergedMomentum(unittest.TestCase):
     def prepare_data(self, shapes, multi_precision, seed, place):
         np.random.seed(seed)
         mp_dtype = np.float32
-        dtype = np.float16 if multi_precision and isinstance(
-            place, paddle.CUDAPlace) else np.float32
+        dtype = (
+            np.float16
+            if multi_precision and isinstance(place, paddle.CUDAPlace)
+            else np.float32
+        )
         params = self.gen_rand_data(shapes, dtype)
         grads = self.gen_rand_data(shapes, dtype)
         velocitys = self.gen_rand_data(shapes, mp_dtype)
@@ -290,7 +294,8 @@ class TestMergedMomentum(unittest.TestCase):
 
     def check_with_place(self, place, multi_precision):
         params, grads, velocitys, master_params, learning_rate = self.prepare_data(
-            self.shapes, multi_precision, self.seed, place)
+            self.shapes, multi_precision, self.seed, place
+        )
 
         def run_op(use_merged):
             # FIXME(zengjinle): CPU Momentum Op does not support rescale_grad
@@ -304,7 +309,8 @@ class TestMergedMomentum(unittest.TestCase):
                 place,
                 multi_precision,
                 rescale_grad=rescale_grad,
-                use_merged=use_merged)
+                use_merged=use_merged,
+            )
 
         outs1 = run_op(True)
         outs2 = run_op(False)
@@ -316,7 +322,7 @@ class TestMergedMomentum(unittest.TestCase):
                 self.assertTrue(np.allclose(out1, out2, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places
@@ -339,8 +345,11 @@ class TestMergedMomentum2(unittest.TestCase):
     def prepare_data(self, shapes, multi_precision, seed, place):
         np.random.seed(seed)
         mp_dtype = np.float32
-        dtype = np.float16 if multi_precision and isinstance(
-            place, paddle.CUDAPlace) else np.float32
+        dtype = (
+            np.float16
+            if multi_precision and isinstance(place, paddle.CUDAPlace)
+            else np.float32
+        )
         params = self.gen_rand_data(shapes, dtype)
         grads = self.gen_rand_data(shapes, dtype)
         velocitys = self.gen_rand_data(shapes, mp_dtype)
@@ -353,7 +362,8 @@ class TestMergedMomentum2(unittest.TestCase):
 
     def check_with_place(self, place, multi_precision):
         params, grads, velocitys, master_params, learning_rate = self.prepare_data(
-            self.shapes, multi_precision, self.seed, place)
+            self.shapes, multi_precision, self.seed, place
+        )
 
         def run_op(use_nesterov, use_merged):
             # FIXME(zengjinle): CPU Momentum Op does not support rescale_grad
@@ -368,7 +378,8 @@ class TestMergedMomentum2(unittest.TestCase):
                 multi_precision,
                 rescale_grad=rescale_grad,
                 use_merged=use_merged,
-                use_nesterov=use_nesterov)
+                use_nesterov=use_nesterov,
+            )
 
         outs1 = run_op(use_nesterov=True, use_merged=True)
         outs2 = run_op(use_nesterov=True, use_merged=False)
@@ -389,7 +400,7 @@ class TestMergedMomentum2(unittest.TestCase):
                 self.assertTrue(np.allclose(out3, out4, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places

--- a/backends/npu/tests/unittests/test_meshgrid_op_npu.py
+++ b/backends/npu/tests/unittests/test_meshgrid_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 import paddle
 

--- a/backends/npu/tests/unittests/test_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_momentum_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_multinomial_op_npu.py
+++ b/backends/npu/tests/unittests/test_multinomial_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import numpy as np
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_nearest_interp_op_npu.py
+++ b/backends/npu/tests/unittests/test_nearest_interp_op_npu.py
@@ -16,26 +16,26 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-import paddle.nn as nn
 import paddle
 from paddle.nn.functional import interpolate
 
 paddle.enable_static()
 
 
-def nearest_neighbor_interp_np(X,
-                               out_h,
-                               out_w,
-                               scale_h=0,
-                               scale_w=0,
-                               out_size=None,
-                               actual_shape=None,
-                               align_corners=True,
-                               data_layout='NCHW'):
+def nearest_neighbor_interp_np(
+    X,
+    out_h,
+    out_w,
+    scale_h=0,
+    scale_w=0,
+    out_size=None,
+    actual_shape=None,
+    align_corners=True,
+    data_layout="NCHW",
+):
     """nearest neighbor interpolation implement in shape [N, C, H, W]"""
     if data_layout == "NHWC":
         X = np.transpose(X, (0, 3, 1, 2))  # NHWC => NCHW
@@ -48,16 +48,16 @@ def nearest_neighbor_interp_np(X,
     n, c, in_h, in_w = X.shape
 
     ratio_h = ratio_w = 0.0
-    if (out_h > 1):
-        if (align_corners):
+    if out_h > 1:
+        if align_corners:
             ratio_h = (in_h - 1.0) / (out_h - 1.0)
         else:
             if scale_h > 0:
                 ratio_h = 1.0 / scale_h
             else:
                 ratio_h = 1.0 * in_h / out_h
-    if (out_w > 1):
-        if (align_corners):
+    if out_w > 1:
+        if align_corners:
             ratio_w = (in_w - 1.0) / (out_w - 1.0)
         else:
             if scale_w > 0:
@@ -88,14 +88,14 @@ def nearest_neighbor_interp_np(X,
 class TestNearestInterpOp(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
         self.out_size = None
         self.actual_shape = None
         self.init_dtype()
-        self.data_layout = 'NCHW'
+        self.data_layout = "NCHW"
         self.init_test_case()
         self.op_type = "nearest_interp_v2"
         input_np = np.random.random(self.input_shape).astype(self.dtype)
@@ -124,19 +124,27 @@ class TestNearestInterpOp(OpTest):
             output_w = self.out_w
 
         output_np = nearest_neighbor_interp_np(
-            input_np, output_h, output_w, scale_h, scale_w, self.out_size,
-            self.actual_shape, self.align_corners, self.data_layout)
-        self.inputs = {'X': input_np}
+            input_np,
+            output_h,
+            output_w,
+            scale_h,
+            scale_w,
+            self.out_size,
+            self.actual_shape,
+            self.align_corners,
+            self.data_layout,
+        )
+        self.inputs = {"X": input_np}
         if self.out_size is not None:
-            self.inputs['OutSize'] = self.out_size
+            self.inputs["OutSize"] = self.out_size
         if self.actual_shape is not None:
-            self.inputs['OutSize'] = self.actual_shape
+            self.inputs["OutSize"] = self.actual_shape
         self.attrs = {
-            'out_h': self.out_h,
-            'out_w': self.out_w,
-            'interp_method': self.interp_method,
-            'align_corners': self.align_corners,
-            'data_layout': self.data_layout
+            "out_h": self.out_h,
+            "out_w": self.out_w,
+            "interp_method": self.interp_method,
+            "align_corners": self.align_corners,
+            "data_layout": self.data_layout,
         }
         if self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
@@ -144,8 +152,8 @@ class TestNearestInterpOp(OpTest):
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]
-            self.attrs['scale'] = self.scale
-        self.outputs = {'Out': output_np}
+            self.attrs["scale"] = self.scale
+        self.outputs = {"Out": output_np}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -153,22 +161,18 @@ class TestNearestInterpOp(OpTest):
     def test_check_grad(self):
         if self.dtype == np.float16:
             self.check_grad_with_place(
-                self.place, ['X'],
-                'Out',
-                in_place=True,
-                max_relative_error=0.02)
+                self.place, ["X"], "Out", in_place=True, max_relative_error=0.02
+            )
         else:
             self.check_grad_with_place(
-                self.place, ['X'],
-                'Out',
-                in_place=True,
-                max_relative_error=0.006)
+                self.place, ["X"], "Out", in_place=True, max_relative_error=0.006
+            )
 
     def init_dtype(self):
         self.dtype = np.float32
 
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [2, 3, 4, 5]
         self.out_h = 2
         self.out_w = 2
@@ -184,7 +188,7 @@ class TestNearestNeighborInterpFP16(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase1(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
@@ -194,7 +198,7 @@ class TestNearestNeighborInterpCase1(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase2(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
@@ -204,7 +208,7 @@ class TestNearestNeighborInterpCase2(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase3(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
@@ -214,7 +218,7 @@ class TestNearestNeighborInterpCase3(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase4(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [4, 1, 7, 8]
         self.out_h = 1
         self.out_w = 1
@@ -225,7 +229,7 @@ class TestNearestNeighborInterpCase4(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase5(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
@@ -236,7 +240,7 @@ class TestNearestNeighborInterpCase5(TestNearestInterpOp):
 
 class TestNearestNeighborInterpCase6(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
         self.out_w = 32
@@ -247,7 +251,7 @@ class TestNearestNeighborInterpCase6(TestNearestInterpOp):
 
 class TestNearestNeighborInterpSame(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [2, 3, 32, 64]
         self.out_h = 32
         self.out_w = 64
@@ -257,7 +261,7 @@ class TestNearestNeighborInterpSame(TestNearestInterpOp):
 
 class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 64
         self.out_w = 32
@@ -268,7 +272,7 @@ class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
 
 class TestNearestNeighborInterpScale1(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 7, 5]
         self.out_h = 64
         self.out_w = 32
@@ -279,7 +283,7 @@ class TestNearestNeighborInterpScale1(TestNearestInterpOp):
 
 class TestNearestNeighborInterpScale2(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 5, 7]
         self.out_h = 64
         self.out_w = 32
@@ -290,7 +294,7 @@ class TestNearestNeighborInterpScale2(TestNearestInterpOp):
 
 class TestNearestNeighborInterpScale3(TestNearestInterpOp):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 7, 5]
         self.out_h = 64
         self.out_w = 32
@@ -302,7 +306,7 @@ class TestNearestNeighborInterpScale3(TestNearestInterpOp):
 class TestNearestInterpOp_attr_tensor(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
@@ -313,15 +317,15 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         self.shape_by_1Dtensor = False
         self.scale_by_1Dtensor = False
         self.attrs = {
-            'interp_method': self.interp_method,
-            'align_corners': self.align_corners,
+            "interp_method": self.interp_method,
+            "align_corners": self.align_corners,
         }
 
         input_np = np.random.random(self.input_shape).astype("float32")
-        self.inputs = {'X': input_np}
+        self.inputs = {"X": input_np}
 
         if self.scale_by_1Dtensor:
-            self.inputs['Scale'] = np.array([self.scale]).astype("float32")
+            self.inputs["Scale"] = np.array([self.scale]).astype("float32")
         elif self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
@@ -338,36 +342,44 @@ class TestNearestInterpOp_attr_tensor(OpTest):
             out_w = self.out_w
 
         if self.shape_by_1Dtensor:
-            self.inputs['OutSize'] = self.out_size
+            self.inputs["OutSize"] = self.out_size
         elif self.out_size is not None:
             size_tensor = []
             for index, ele in enumerate(self.out_size):
-                size_tensor.append(("x" + str(index), np.ones(
-                    (1)).astype('int32') * ele))
-            self.inputs['SizeTensor'] = size_tensor
+                size_tensor.append(
+                    ("x" + str(index), np.ones((1)).astype("int32") * ele)
+                )
+            self.inputs["SizeTensor"] = size_tensor
 
-        self.attrs['out_h'] = self.out_h
-        self.attrs['out_w'] = self.out_w
+        self.attrs["out_h"] = self.out_h
+        self.attrs["out_w"] = self.out_w
         if self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0:
                     self.scale = [self.scale]
             if isinstance(self.scale, list) and len(self.scale) == 1:
                 self.scale = [self.scale[0], self.scale[0]]
-            self.attrs['scale'] = self.scale
-        output_np = nearest_neighbor_interp_np(input_np, out_h, out_w, 0, 0,
-                                               self.out_size, self.actual_shape,
-                                               self.align_corners)
-        self.outputs = {'Out': output_np}
+            self.attrs["scale"] = self.scale
+        output_np = nearest_neighbor_interp_np(
+            input_np,
+            out_h,
+            out_w,
+            0,
+            0,
+            self.out_size,
+            self.actual_shape,
+            self.align_corners,
+        )
+        self.outputs = {"Out": output_np}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Out', in_place=True)
+        self.check_grad_with_place(self.place, ["X"], "Out", in_place=True)
 
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [2, 5, 4, 4]
         self.out_h = 3
         self.out_w = 3
@@ -379,7 +391,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
 # out_size is a tensor list
 class TestNearestInterp_attr_tensor_Case1(TestNearestInterpOp_attr_tensor):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 3, 9, 6]
         self.out_h = 12
         self.out_w = 12
@@ -391,7 +403,7 @@ class TestNearestInterp_attr_tensor_Case1(TestNearestInterpOp_attr_tensor):
 # out_size is a 1-D tensor
 class TestNearestInterp_attr_tensor_Case2(TestNearestInterpOp_attr_tensor):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 64
         self.out_w = 32
@@ -404,7 +416,7 @@ class TestNearestInterp_attr_tensor_Case2(TestNearestInterpOp_attr_tensor):
 # scale is a 1-D tensor
 class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
     def init_test_case(self):
-        self.interp_method = 'nearest'
+        self.interp_method = "nearest"
         self.input_shape = [3, 2, 32, 16]
         self.out_h = 64
         self.out_w = 32
@@ -417,8 +429,9 @@ class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
 class TestNearestInterpOpAPI_dy(unittest.TestCase):
     def test_case(self):
         import paddle
-        if ('npu' in paddle.fluid.core.get_all_custom_device_type()):
-            place = paddle.CustomPlace('npu', 0)
+
+        if "npu" in paddle.fluid.core.get_all_custom_device_type():
+            place = paddle.CustomPlace("npu", 0)
         else:
             place = core.CPUPlace()
         with fluid.dygraph.guard(place):
@@ -427,12 +440,11 @@ class TestNearestInterpOpAPI_dy(unittest.TestCase):
             input_x = paddle.to_tensor(input_data)
             scale = paddle.to_tensor(scale_np)
             expect_res = nearest_neighbor_interp_np(
-                input_data, out_h=12, out_w=12, align_corners=False)
+                input_data, out_h=12, out_w=12, align_corners=False
+            )
             out = interpolate(
-                x=input_x,
-                scale_factor=scale,
-                mode="nearest",
-                align_corners=False)
+                x=input_x, scale_factor=scale, mode="nearest", align_corners=False
+            )
             self.assertTrue(np.allclose(out.numpy(), expect_res))
 
 

--- a/backends/npu/tests/unittests/test_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_norm_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 
 def l2_norm(x, axis, epsilon):

--- a/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
@@ -72,7 +72,7 @@ class TestOneHotOp_non_lod(OpTest):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output_with_place(paddle.CustomPlace("npu", 0), check_dygraph=False)
 
 
 class TestOneHotOp_attr(OpTest):

--- a/backends/npu/tests/unittests/test_p_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_p_norm_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -69,28 +69,26 @@ class TestPnormOp(OpTest):
         self.init_test_case()
         x = (np.random.random(self.shape) + 0.5).astype(self.dtype)
         norm = p_norm(x, self.axis, self.porder, self.keepdim)
-        self.inputs = {'X': x}
+        self.inputs = {"X": x}
         self.attrs = {
-            'epsilon': self.epsilon,
-            'axis': self.axis,
-            'keepdim': self.keepdim,
-            'porder': float(self.porder)
+            "epsilon": self.epsilon,
+            "axis": self.axis,
+            "keepdim": self.keepdim,
+            "porder": float(self.porder),
         }
-        self.outputs = {'Out': norm}
+        self.outputs = {"Out": norm}
         self.gradient = self.calc_gradient()
 
     def test_check_output(self):
         if self.dtype == "float16":
-            self.check_output_with_place(
-                paddle.CustomPlace('npu', 0), atol=5e-3)
+            self.check_output_with_place(paddle.CustomPlace("npu", 0), atol=5e-3)
         else:
-            self.check_output_with_place(paddle.CustomPlace('npu', 0))
+            self.check_output_with_place(paddle.CustomPlace("npu", 0))
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            paddle.CustomPlace('npu', 0), ['X'],
-            'Out',
-            user_defined_grads=self.gradient)
+            paddle.CustomPlace("npu", 0), ["X"], "Out", user_defined_grads=self.gradient
+        )
 
     def init_test_case(self):
         self.shape = [2, 3, 4, 5]
@@ -105,10 +103,10 @@ class TestPnormOp(OpTest):
 
     def calc_gradient(self):
         self.attrs = {
-            'epsilon': self.epsilon,
-            'axis': self.axis,
-            'keepdim': self.keepdim,
-            'porder': float(self.porder)
+            "epsilon": self.epsilon,
+            "axis": self.axis,
+            "keepdim": self.keepdim,
+            "porder": float(self.porder),
         }
         x = self.inputs["X"]
         porder = self.attrs["porder"]
@@ -122,8 +120,11 @@ class TestPnormOp(OpTest):
             grad[x_abs != norm] = 0.0
         else:
             norm = p_norm(x, axis=axis, porder=porder, keepdims=True)
-            grad = np.power(norm, 1 - porder) * np.power(
-                np.abs(x), porder - 1) * np.sign(x)
+            grad = (
+                np.power(norm, 1 - porder)
+                * np.power(np.abs(x), porder - 1)
+                * np.sign(x)
+            )
 
         numel = 1
         for s in x.shape:

--- a/backends/npu/tests/unittests/test_pad3d_op_npu.py
+++ b/backends/npu/tests/unittests/test_pad3d_op_npu.py
@@ -15,7 +15,7 @@
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F

--- a/backends/npu/tests/unittests/test_pad_op_npu.py
+++ b/backends/npu/tests/unittests/test_pad_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 from paddle.fluid import Program, program_guard
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_pool2d_op_npu.py
+++ b/backends/npu/tests/unittests/test_pool2d_op_npu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid.core as core
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_prelu_op_npu.py
+++ b/backends/npu/tests/unittests/test_prelu_op_npu.py
@@ -18,8 +18,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
-from paddle.fluid.framework import _test_eager_guard
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 
@@ -75,8 +74,7 @@ class TestFunctionalPReluAPI(unittest.TestCase):
         self.dygraph_check(self.weight_np_1)
 
     def test_dygraph_api_eager(self):
-        with _test_eager_guard():
-            self.test_dygraph_api()
+        self.test_dygraph_api()
 
 
 class TestNNPReluAPI(unittest.TestCase):
@@ -137,9 +135,8 @@ class TestNNPReluAPI(unittest.TestCase):
         paddle.enable_static()
 
 
-def prelu_api_wrapper(x, weight, data_format="NCHW"):
-    weight = weight.reshape([-1])
-    return paddle.nn.functional.prelu(x, weight, data_format, name=None)
+def prelu_api_wrapper(x, alpha, data_format="NCHW", mode="all"):
+    return paddle._C_ops.prelu(x, alpha, data_format, mode)
 
 
 class PReluTest(OpTest):
@@ -148,7 +145,6 @@ class PReluTest(OpTest):
         self.init_dtype()
         self.init_input_shape()
         self.init_place()
-        self.eager_mode = True
         self.init_attr()
         self.op_type = "prelu"
         self.python_api = prelu_api_wrapper
@@ -169,8 +165,6 @@ class PReluTest(OpTest):
             alpha_np = np.random.uniform(-1, -0.5, [1, 1, 1, self.x_shape[-1]])
         else:
             alpha_np = np.random.uniform(-1, -0.5, [1] + self.x_shape[1:])
-            # eager check don't support mode = 'all'
-            self.eager_mode = False
         alpha_np = alpha_np.astype(self.dtype)
 
         self.inputs = {"X": x_np, "Alpha": alpha_np}

--- a/backends/npu/tests/unittests/test_prior_box_op_npu.py
+++ b/backends/npu/tests/unittests/test_prior_box_op_npu.py
@@ -19,17 +19,9 @@ import numpy as np
 import paddle
 import math
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
-
-
-def _set_use_system_allocator(value=None):
-    USE_SYSTEM_ALLOCATOR_FLAG = "FLAGS_use_system_allocator"
-    old_value = core.globals()[USE_SYSTEM_ALLOCATOR_FLAG]
-    value = old_value if value is None else value
-    core.globals()[USE_SYSTEM_ALLOCATOR_FLAG] = value
-    return old_value
 
 
 class TestNPUPriorBox(OpTest):
@@ -44,7 +36,7 @@ class TestNPUPriorBox(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -53,27 +45,27 @@ class TestNPUPriorBox(OpTest):
         self.init_test_params()
         self.init_test_input()
         self.init_test_output()
-        self.inputs = {'Input': self.input, 'Image': self.image}
+        self.inputs = {"Input": self.input, "Image": self.image}
 
         self.attrs = {
-            'min_sizes': self.min_sizes,
-            'aspect_ratios': self.aspect_ratios,
-            'variances': self.variances,
-            'flip': self.flip,
-            'clip': self.clip,
-            'min_max_aspect_ratios_order': self.min_max_aspect_ratios_order,
-            'step_w': self.step_w,
-            'step_h': self.step_h,
-            'offset': self.offset
+            "min_sizes": self.min_sizes,
+            "aspect_ratios": self.aspect_ratios,
+            "variances": self.variances,
+            "flip": self.flip,
+            "clip": self.clip,
+            "min_max_aspect_ratios_order": self.min_max_aspect_ratios_order,
+            "step_w": self.step_w,
+            "step_h": self.step_h,
+            "offset": self.offset,
         }
         if len(self.max_sizes) > 0:
-            self.attrs['max_sizes'] = self.max_sizes
+            self.attrs["max_sizes"] = self.max_sizes
 
-        self.outputs = {'Boxes': self.out_boxes, 'Variances': self.out_var}
+        self.outputs = {"Boxes": self.out_boxes, "Variances": self.out_var}
 
     def set_max_sizes(self):
         max_sizes = [5, 10]
-        self.max_sizes = np.array(max_sizes).astype('float32').tolist()
+        self.max_sizes = np.array(max_sizes).astype("float32").tolist()
 
     def set_min_max_aspect_ratios_order(self):
         self.min_max_aspect_ratios_order = True
@@ -94,14 +86,13 @@ class TestNPUPriorBox(OpTest):
         self.batch_size = 10
 
         self.min_sizes = [2, 4]
-        self.min_sizes = np.array(self.min_sizes).astype('float32').tolist()
+        self.min_sizes = np.array(self.min_sizes).astype("float32").tolist()
         self.set_max_sizes()
         self.aspect_ratios = [2.0, 3.0]
         self.flip = True
         self.set_min_max_aspect_ratios_order()
         self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
-        self.aspect_ratios = np.array(
-            self.aspect_ratios, dtype=np.float64).flatten()
+        self.aspect_ratios = np.array(self.aspect_ratios, dtype=np.float64).flatten()
         self.variances = [0.1, 0.1, 0.2, 0.2]
         self.variances = np.array(self.variances, dtype=np.float64).flatten()
 
@@ -113,17 +104,17 @@ class TestNPUPriorBox(OpTest):
 
     def init_test_input(self):
         self.image = np.random.random(
-            (self.batch_size, self.image_channels, self.image_w,
-             self.image_h)).astype('float32')
+            (self.batch_size, self.image_channels, self.image_w, self.image_h)
+        ).astype("float32")
 
         self.input = np.random.random(
-            (self.batch_size, self.input_channels, self.layer_w,
-             self.layer_h)).astype('float32')
+            (self.batch_size, self.input_channels, self.layer_w, self.layer_h)
+        ).astype("float32")
 
     def init_test_output(self):
         out_dim = (self.layer_h, self.layer_w, self.num_priors, 4)
-        out_boxes = np.zeros(out_dim).astype('float32')
-        out_var = np.zeros(out_dim).astype('float32')
+        out_boxes = np.zeros(out_dim).astype("float32")
+        out_var = np.zeros(out_dim).astype("float32")
 
         idx = 0
         for h in range(self.layer_h):
@@ -140,9 +131,10 @@ class TestNPUPriorBox(OpTest):
                             c_w = min_size * math.sqrt(ar) / 2
                             c_h = (min_size / math.sqrt(ar)) / 2
                             out_boxes[h, w, idx, :] = [
-                                (c_x - c_w) / self.image_w, (c_y - c_h) /
-                                self.image_h, (c_x + c_w) / self.image_w,
-                                (c_y + c_h) / self.image_h
+                                (c_x - c_w) / self.image_w,
+                                (c_y - c_h) / self.image_h,
+                                (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h,
                             ]
                             idx += 1
 
@@ -151,40 +143,45 @@ class TestNPUPriorBox(OpTest):
                             # second prior: aspect_ratio = 1,
                             c_w = c_h = math.sqrt(min_size * max_size) / 2
                             out_boxes[h, w, idx, :] = [
-                                (c_x - c_w) / self.image_w, (c_y - c_h) /
-                                self.image_h, (c_x + c_w) / self.image_w,
-                                (c_y + c_h) / self.image_h
+                                (c_x - c_w) / self.image_w,
+                                (c_y - c_h) / self.image_h,
+                                (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h,
                             ]
                             idx += 1
                     else:
-                        c_w = c_h = min_size / 2.
-                        out_boxes[h, w, idx, :] = [(c_x - c_w) / self.image_w,
-                                                   (c_y - c_h) / self.image_h,
-                                                   (c_x + c_w) / self.image_w,
-                                                   (c_y + c_h) / self.image_h]
+                        c_w = c_h = min_size / 2.0
+                        out_boxes[h, w, idx, :] = [
+                            (c_x - c_w) / self.image_w,
+                            (c_y - c_h) / self.image_h,
+                            (c_x + c_w) / self.image_w,
+                            (c_y + c_h) / self.image_h,
+                        ]
                         idx += 1
                         if len(self.max_sizes) > 0:
                             max_size = self.max_sizes[s]
                             # second prior: aspect_ratio = 1,
                             c_w = c_h = math.sqrt(min_size * max_size) / 2
                             out_boxes[h, w, idx, :] = [
-                                (c_x - c_w) / self.image_w, (c_y - c_h) /
-                                self.image_h, (c_x + c_w) / self.image_w,
-                                (c_y + c_h) / self.image_h
+                                (c_x - c_w) / self.image_w,
+                                (c_y - c_h) / self.image_h,
+                                (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h,
                             ]
                             idx += 1
 
                         # rest of priors
                         for r in range(len(self.real_aspect_ratios)):
                             ar = self.real_aspect_ratios[r]
-                            if abs(ar - 1.) < 1e-6:
+                            if abs(ar - 1.0) < 1e-6:
                                 continue
                             c_w = min_size * math.sqrt(ar) / 2
                             c_h = (min_size / math.sqrt(ar)) / 2
                             out_boxes[h, w, idx, :] = [
-                                (c_x - c_w) / self.image_w, (c_y - c_h) /
-                                self.image_h, (c_x + c_w) / self.image_w,
-                                (c_y + c_h) / self.image_h
+                                (c_x - c_w) / self.image_w,
+                                (c_y - c_h) / self.image_h,
+                                (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h,
                             ]
                             idx += 1
 
@@ -192,10 +189,11 @@ class TestNPUPriorBox(OpTest):
         if self.clip:
             out_boxes = np.clip(out_boxes, 0.0, 1.0)
         # set the variance.
-        out_var = np.tile(self.variances,
-                          (self.layer_h, self.layer_w, self.num_priors, 1))
-        self.out_boxes = out_boxes.astype('float32')
-        self.out_var = out_var.astype('float32')
+        out_var = np.tile(
+            self.variances, (self.layer_h, self.layer_w, self.num_priors, 1)
+        )
+        self.out_boxes = out_boxes.astype("float32")
+        self.out_var = out_var.astype("float32")
 
 
 class TestNPUPriorBoxWithoutMaxSize(TestNPUPriorBox):
@@ -209,5 +207,5 @@ class TestNPUPriorBoxWithoutSpecifiedOutOrder(TestNPUPriorBox):
         self.atol = 1e-1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_randperm_op_npu.py
+++ b/backends/npu/tests/unittests/test_randperm_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 from paddle.static import program_guard, Program
@@ -26,31 +26,34 @@ paddle.enable_static()
 
 
 def check_randperm_out(n, data_np):
-    assert isinstance(data_np, np.ndarray), \
-        "The input data_np should be np.ndarray."
+    assert isinstance(data_np, np.ndarray), "The input data_np should be np.ndarray."
     gt_sorted = np.arange(n)
     out_sorted = np.sort(data_np)
     return list(gt_sorted == out_sorted)
 
 
 def error_msg(data_np):
-    return "The sorted ground truth and sorted out should " + \
- "be equal, out = " + str(data_np)
+    return (
+        "The sorted ground truth and sorted out should "
+        + "be equal, out = "
+        + str(data_np)
+    )
 
 
 def convert_dtype(dtype_str):
     dtype_str_list = ["int32", "int64", "float32", "float64"]
     dtype_num_list = [
-        core.VarDesc.VarType.INT32, core.VarDesc.VarType.INT64,
-        core.VarDesc.VarType.FP32, core.VarDesc.VarType.FP64
+        core.VarDesc.VarType.INT32,
+        core.VarDesc.VarType.INT64,
+        core.VarDesc.VarType.FP32,
+        core.VarDesc.VarType.FP64,
     ]
-    assert dtype_str in dtype_str_list, dtype_str + \
-        " should in " + str(dtype_str_list)
+    assert dtype_str in dtype_str_list, dtype_str + " should in " + str(dtype_str_list)
     return dtype_num_list[dtype_str_list.index(dtype_str)]
 
 
 class TestRandpermOp(OpTest):
-    """ Test randperm op."""
+    """Test randperm op."""
 
     def setUp(self):
         self.set_npu()
@@ -70,7 +73,7 @@ class TestRandpermOp(OpTest):
         self.__class__.use_custom_device = True
 
     def _get_places(self):
-        return [paddle.CustomPlace('npu', 0)]
+        return [paddle.CustomPlace("npu", 0)]
 
     def init_attrs(self):
         pass
@@ -80,8 +83,7 @@ class TestRandpermOp(OpTest):
 
     def verify_output(self, outs):
         out_np = np.array(outs[0])
-        self.assertTrue(
-            check_randperm_out(self.n, out_np), msg=error_msg(out_np))
+        self.assertTrue(check_randperm_out(self.n, out_np), msg=error_msg(out_np))
 
 
 class TestRandpermOpN(TestRandpermOp):
@@ -108,16 +110,16 @@ class TestRandpermOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             self.assertRaises(ValueError, paddle.randperm, -3)
-            self.assertRaises(TypeError, paddle.randperm, 10, 'int8')
+            self.assertRaises(TypeError, paddle.randperm, 10, "int8")
 
 
 class TestRandpermAPI(unittest.TestCase):
     def test_out(self):
         n = 10
-        place = paddle.CustomPlace('npu', 0)
+        place = paddle.CustomPlace("npu", 0)
         with program_guard(Program(), Program()):
             x1 = paddle.randperm(n)
-            x2 = paddle.randperm(n, 'float32')
+            x2 = paddle.randperm(n, "float32")
 
             exe = paddle.static.Executor(place)
             res = exe.run(fetch_list=[x1, x2])
@@ -130,13 +132,12 @@ class TestRandpermAPI(unittest.TestCase):
 
 class TestRandpermImperative(unittest.TestCase):
     def test_out(self):
-        paddle.disable_static(paddle.CustomPlace('npu', 0))
+        paddle.disable_static(paddle.CustomPlace("npu", 0))
         n = 10
-        for dtype in ['int32', np.int64, 'float32', 'float64']:
+        for dtype in ["int32", np.int64, "float32", "float64"]:
             data_p = paddle.randperm(n, dtype)
             data_np = data_p.numpy()
-            self.assertTrue(
-                check_randperm_out(n, data_np), msg=error_msg(data_np))
+            self.assertTrue(check_randperm_out(n, data_np), msg=error_msg(data_np))
         paddle.enable_static()
 
 

--- a/backends/npu/tests/unittests/test_range_npu.py
+++ b/backends/npu/tests/unittests/test_range_npu.py
@@ -16,8 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -26,21 +25,22 @@ paddle.enable_static()
 class TestRangeOp(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         self.set_npu()
         self.op_type = "range"
         self.init_config()
         self.inputs = {
-            'Start': np.array([self.case[0]]).astype(self.dtype),
-            'End': np.array([self.case[1]]).astype(self.dtype),
-            'Step': np.array([self.case[2]]).astype(self.dtype)
+            "Start": np.array([self.case[0]]).astype(self.dtype),
+            "End": np.array([self.case[1]]).astype(self.dtype),
+            "Step": np.array([self.case[2]]).astype(self.dtype),
         }
 
         self.outputs = {
-            'Out': np.arange(self.case[0], self.case[1],
-                             self.case[2]).astype(self.dtype)
+            "Out": np.arange(self.case[0], self.case[1], self.case[2]).astype(
+                self.dtype
+            )
         }
 
     def init_config(self):

--- a/backends/npu/tests/unittests/test_reciprocal_op_npu.py
+++ b/backends/npu/tests/unittests/test_reciprocal_op_npu.py
@@ -16,8 +16,9 @@ from __future__ import print_function, division
 
 import numpy as np
 import unittest
+
 # from op_test import OpTest, skip_check_grad_ci
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
 
 paddle.enable_static()
@@ -33,19 +34,18 @@ class TestReciprocal(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = np.reciprocal(x)
 
-        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.outputs = {'Out': out}
+        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {"Out": out}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', max_relative_error=0.01)
+        self.check_grad_with_place(self.place, ["X"], "Out", max_relative_error=0.01)
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -54,23 +54,24 @@ class TestReciprocal(OpTest):
 class TestReciprocalFp64(TestReciprocal):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float64
 
 
 @skip_check_grad_ci(
-    reason="The backward test is not supported for float16 type on NPU.")
+    reason="The backward test is not supported for float16 type on NPU."
+)
 class TestReciprocalFp16(TestReciprocal):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.__class__.no_need_check_grad = True
 
     def init_dtype(self):
         self.dtype = np.float16
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_reduce_all_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_all_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_reduce_any_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_any_op_npu.py
@@ -17,12 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 
@@ -31,13 +27,12 @@ class TestAny8DOp(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "reduce_any"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.inputs = {
-            'X': np.random.randint(0, 2,
-                                   (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
+            "X": np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'dim': (3, 5, 4)}
-        self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
+        self.attrs = {"dim": (3, 5, 4)}
+        self.outputs = {"Out": self.inputs["X"].any(axis=self.attrs["dim"])}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -50,10 +45,10 @@ class TestAnyOpWithDim(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "reduce_any"
-        self.place = paddle.CustomPlace('npu', 0)
-        self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
-        self.attrs = {'dim': [1]}
-        self.outputs = {'Out': self.inputs['X'].any(axis=1)}
+        self.place = paddle.CustomPlace("npu", 0)
+        self.inputs = {"X": np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
+        self.attrs = {"dim": [1]}
+        self.outputs = {"Out": self.inputs["X"].any(axis=1)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -66,13 +61,12 @@ class TestAny8DOpWithDim(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "reduce_any"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.inputs = {
-            'X': np.random.randint(0, 2,
-                                   (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
+            "X": np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'dim': (3, 6)}
-        self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
+        self.attrs = {"dim": (3, 6)}
+        self.outputs = {"Out": self.inputs["X"].any(axis=self.attrs["dim"])}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -85,12 +79,11 @@ class TestAnyOpWithKeepDim(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "reduce_any"
-        self.place = paddle.CustomPlace('npu', 0)
-        self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
-        self.attrs = {'dim': (1, ), 'keep_dim': True}
+        self.place = paddle.CustomPlace("npu", 0)
+        self.inputs = {"X": np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
+        self.attrs = {"dim": (1,), "keep_dim": True}
         self.outputs = {
-            'Out': np.expand_dims(
-                self.inputs['X'].any(axis=self.attrs['dim']), axis=1)
+            "Out": np.expand_dims(self.inputs["X"].any(axis=self.attrs["dim"]), axis=1)
         }
 
     def set_npu(self):
@@ -104,15 +97,13 @@ class TestAny8DOpWithKeepDim(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "reduce_any"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.inputs = {
-            'X': np.random.randint(0, 2,
-                                   (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
+            "X": np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'dim': (1, ), 'keep_dim': True}
+        self.attrs = {"dim": (1,), "keep_dim": True}
         self.outputs = {
-            'Out': np.expand_dims(
-                self.inputs['X'].any(axis=self.attrs['dim']), axis=1)
+            "Out": np.expand_dims(self.inputs["X"].any(axis=self.attrs["dim"]), axis=1)
         }
 
     def set_npu(self):
@@ -122,5 +113,5 @@ class TestAny8DOpWithKeepDim(OpTest):
         self.check_output_with_place(self.place)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_reduce_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_max_op_npu.py
@@ -16,19 +16,17 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestNPUReduceMaxOp(OpTest):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -37,18 +35,16 @@ class TestNPUReduceMaxOp(OpTest):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'dim': [-1]}
-        self.outputs = {
-            'Out': self.inputs['X'].max(axis=tuple(self.attrs['dim']))
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-1]}
+        self.outputs = {"Out": self.inputs["X"].max(axis=tuple(self.attrs["dim"]))}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -56,7 +52,8 @@ class TestNPUReduceMaxOp(OpTest):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpMultiAxises(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -65,16 +62,15 @@ class TestReduceMaxOpMultiAxises(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'dim': [-2, -1]}
-        self.outputs = {
-            'Out': self.inputs['X'].max(axis=tuple(self.attrs['dim']))
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1]}
+        self.outputs = {"Out": self.inputs["X"].max(axis=tuple(self.attrs["dim"]))}
 
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceAll(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -83,14 +79,15 @@ class TestReduceAll(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'reduce_all': True}
-        self.outputs = {'Out': self.inputs['X'].max()}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"reduce_all": True}
+        self.outputs = {"Out": self.inputs["X"].max()}
 
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_bool(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -99,14 +96,10 @@ class TestReduceMaxOpWithOutDtype_bool(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.BOOL)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.BOOL)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].max(axis=tuple(self.attrs['dim'])).astype(np.bool_)
+            "Out": self.inputs["X"].max(axis=tuple(self.attrs["dim"])).astype(np.bool_)
         }
 
     def init_dtype(self):
@@ -115,7 +108,8 @@ class TestReduceMaxOpWithOutDtype_bool(TestNPUReduceMaxOp):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_int32(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -124,14 +118,10 @@ class TestReduceMaxOpWithOutDtype_int32(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT32)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].max(axis=tuple(self.attrs['dim'])).astype(np.int32)
+            "Out": self.inputs["X"].max(axis=tuple(self.attrs["dim"])).astype(np.int32)
         }
 
     def init_dtype(self):
@@ -140,7 +130,8 @@ class TestReduceMaxOpWithOutDtype_int32(TestNPUReduceMaxOp):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_int64(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -149,14 +140,10 @@ class TestReduceMaxOpWithOutDtype_int64(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT64)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].max(axis=tuple(self.attrs['dim'])).astype(np.int64)
+            "Out": self.inputs["X"].max(axis=tuple(self.attrs["dim"])).astype(np.int64)
         }
 
     def init_dtype(self):
@@ -165,7 +152,8 @@ class TestReduceMaxOpWithOutDtype_int64(TestNPUReduceMaxOp):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_fp16(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -174,14 +162,12 @@ class TestReduceMaxOpWithOutDtype_fp16(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP16)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP16)}
         self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim'])).astype(np.float16)
+            "Out": self.inputs["X"]
+            .max(axis=tuple(self.attrs["dim"]))
+            .astype(np.float16)
         }
 
     def test_check_output(self):
@@ -190,7 +176,8 @@ class TestReduceMaxOpWithOutDtype_fp16(TestNPUReduceMaxOp):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_fp32(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -199,20 +186,19 @@ class TestReduceMaxOpWithOutDtype_fp32(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP32)}
         self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .max(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_fp64(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -221,20 +207,19 @@ class TestReduceMaxOpWithOutDtype_fp64(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP64)}
         self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim'])).astype(np.float64)
+            "Out": self.inputs["X"]
+            .max(axis=tuple(self.attrs["dim"]))
+            .astype(np.float64)
         }
 
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpWithOutDtype_fp32_2(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -243,14 +228,12 @@ class TestReduceMaxOpWithOutDtype_fp32_2(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP32)}
         self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .max(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
     def init_dtype(self):
@@ -259,7 +242,8 @@ class TestReduceMaxOpWithOutDtype_fp32_2(TestNPUReduceMaxOp):
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMaxOpInt64(TestNPUReduceMaxOp):
     """Remove Max with subgradient from gradient check to confirm the success of CI."""
 
@@ -268,19 +252,17 @@ class TestReduceMaxOpInt64(TestNPUReduceMaxOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT64)}
         self.outputs = {
-            'Out': self.inputs['X'].max(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .max(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
     def init_dtype(self):
         self.dtype = np.int64
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_reduce_mean_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_mean_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -31,6 +31,23 @@ class TestMeanOp(OpTest):
         self.set_npu()
         self.op_type = "reduce_mean"
         self.inputs = {"X": np.random.random((5, 6, 10)).astype("float32")}
+        self.outputs = {"Out": self.inputs["X"].mean(axis=0)}
+
+    def test_check_output(self):
+        self.check_output_with_place(paddle.CustomPlace("npu", 0))
+
+    def test_check_grad(self):
+        self.check_grad_with_place(paddle.CustomPlace("npu", 0), ["X"], "Out")
+
+
+class TestMeanOpFP16(OpTest):
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "reduce_mean"
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype("float16")}
         self.outputs = {"Out": self.inputs["X"].mean(axis=0)}
 
     def test_check_output(self):

--- a/backends/npu/tests/unittests/test_reduce_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_min_op_npu.py
@@ -16,19 +16,17 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestNPUReduceMinOp(OpTest):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -37,18 +35,16 @@ class TestNPUReduceMinOp(OpTest):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'dim': [-1]}
-        self.outputs = {
-            'Out': self.inputs['X'].min(axis=tuple(self.attrs['dim']))
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-1]}
+        self.outputs = {"Out": self.inputs["X"].min(axis=tuple(self.attrs["dim"]))}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -56,7 +52,8 @@ class TestNPUReduceMinOp(OpTest):
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpMultiAxises(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -65,16 +62,15 @@ class TestReduceMinOpMultiAxises(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'dim': [-2, -1]}
-        self.outputs = {
-            'Out': self.inputs['X'].min(axis=tuple(self.attrs['dim']))
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1]}
+        self.outputs = {"Out": self.inputs["X"].min(axis=tuple(self.attrs["dim"]))}
 
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceAll(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -83,14 +79,15 @@ class TestReduceAll(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {'reduce_all': True}
-        self.outputs = {'Out': self.inputs['X'].min()}
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"reduce_all": True}
+        self.outputs = {"Out": self.inputs["X"].min()}
 
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_int32(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -99,14 +96,10 @@ class TestReduceMinOpWithOutDtype_int32(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT32)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].min(axis=tuple(self.attrs['dim'])).astype(np.int32)
+            "Out": self.inputs["X"].min(axis=tuple(self.attrs["dim"])).astype(np.int32)
         }
 
     def init_dtype(self):
@@ -115,7 +108,8 @@ class TestReduceMinOpWithOutDtype_int32(TestNPUReduceMinOp):
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_int64(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -124,14 +118,10 @@ class TestReduceMinOpWithOutDtype_int64(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT64)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].min(axis=tuple(self.attrs['dim'])).astype(np.int64)
+            "Out": self.inputs["X"].min(axis=tuple(self.attrs["dim"])).astype(np.int64)
         }
 
     def init_dtype(self):
@@ -140,7 +130,8 @@ class TestReduceMinOpWithOutDtype_int64(TestNPUReduceMinOp):
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_fp16(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -149,14 +140,12 @@ class TestReduceMinOpWithOutDtype_fp16(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP16)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP16)}
         self.outputs = {
-            'Out': self.inputs['X'].min(
-                axis=tuple(self.attrs['dim'])).astype(np.float16)
+            "Out": self.inputs["X"]
+            .min(axis=tuple(self.attrs["dim"]))
+            .astype(np.float16)
         }
 
     def test_check_output(self):
@@ -165,7 +154,8 @@ class TestReduceMinOpWithOutDtype_fp16(TestNPUReduceMinOp):
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_fp32(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -174,20 +164,19 @@ class TestReduceMinOpWithOutDtype_fp32(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP32)}
         self.outputs = {
-            'Out': self.inputs['X'].min(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .min(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_fp64(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -196,20 +185,19 @@ class TestReduceMinOpWithOutDtype_fp64(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP64)}
         self.outputs = {
-            'Out': self.inputs['X'].min(
-                axis=tuple(self.attrs['dim'])).astype(np.float64)
+            "Out": self.inputs["X"]
+            .min(axis=tuple(self.attrs["dim"]))
+            .astype(np.float64)
         }
 
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpWithOutDtype_fp32_2(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -218,14 +206,12 @@ class TestReduceMinOpWithOutDtype_fp32_2(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.FP32)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.FP32)}
         self.outputs = {
-            'Out': self.inputs['X'].min(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .min(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
     def init_dtype(self):
@@ -234,7 +220,8 @@ class TestReduceMinOpWithOutDtype_fp32_2(TestNPUReduceMinOp):
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
-    " its gradient check is not supported by unittest framework.")
+    " its gradient check is not supported by unittest framework."
+)
 class TestReduceMinOpInt64(TestNPUReduceMinOp):
     """Remove Min with subgradient from gradient check to confirm the success of CI."""
 
@@ -243,19 +230,17 @@ class TestReduceMinOpInt64(TestNPUReduceMinOp):
         self.set_npu()
         self.init_dtype()
 
-        self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
-        self.attrs = {
-            'dim': [-2, -1],
-            'out_dtype': int(core.VarDesc.VarType.INT64)
-        }
+        self.inputs = {"X": np.random.random((5, 6, 10)).astype(self.dtype)}
+        self.attrs = {"dim": [-2, -1], "out_dtype": int(core.VarDesc.VarType.INT64)}
         self.outputs = {
-            'Out': self.inputs['X'].min(
-                axis=tuple(self.attrs['dim'])).astype(np.float32)
+            "Out": self.inputs["X"]
+            .min(axis=tuple(self.attrs["dim"]))
+            .astype(np.float32)
         }
 
     def init_dtype(self):
         self.dtype = np.int64
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from tests.op_test import OpTest, skip_check_grad_ci
+from tests.eager_op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
 

--- a/backends/npu/tests/unittests/test_reduce_sum_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_sum_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_rnn_op_npu.py
+++ b/backends/npu/tests/unittests/test_rnn_op_npu.py
@@ -16,7 +16,7 @@ import random
 import unittest
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 from paddle.fluid import core

--- a/backends/npu/tests/unittests/test_roi_align_op_npu.py
+++ b/backends/npu/tests/unittests/test_roi_align_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import math
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -34,20 +34,20 @@ class TestROIAlignNPUOp(OpTest):
         seq_len = self.rois_lod[0]
 
         self.inputs = {
-            'X': self.x,
-            'ROIs': (self.rois[:, 1:5], self.rois_lod),
-            'RoisNum': self.boxes_num
+            "X": self.x,
+            "ROIs": (self.rois[:, 1:5], self.rois_lod),
+            "RoisNum": self.boxes_num,
         }
 
         self.attrs = {
-            'spatial_scale': self.spatial_scale,
-            'pooled_height': self.pooled_height,
-            'pooled_width': self.pooled_width,
-            'sampling_ratio': self.sampling_ratio,
-            'aligned': self.aligned
+            "spatial_scale": self.spatial_scale,
+            "pooled_height": self.pooled_height,
+            "pooled_width": self.pooled_width,
+            "sampling_ratio": self.sampling_ratio,
+            "aligned": self.aligned,
         }
 
-        self.outputs = {'Out': self.out_data}
+        self.outputs = {"Out": self.out_data}
 
     def init_test_case(self):
         self.batch_size = 3
@@ -67,25 +67,39 @@ class TestROIAlignNPUOp(OpTest):
 
         self.x = np.random.random(self.x_dim).astype(self.dtype)
 
-    def pre_calc(self, x_i, roi_xmin, roi_ymin, roi_bin_grid_h, roi_bin_grid_w,
-                 bin_size_h, bin_size_w):
+    def pre_calc(
+        self,
+        x_i,
+        roi_xmin,
+        roi_ymin,
+        roi_bin_grid_h,
+        roi_bin_grid_w,
+        bin_size_h,
+        bin_size_w,
+    ):
         count = roi_bin_grid_h * roi_bin_grid_w
         bilinear_pos = np.zeros(
-            [self.channels, self.pooled_height, self.pooled_width, count, 4],
-            np.float32)
+            [self.channels, self.pooled_height, self.pooled_width, count, 4], np.float32
+        )
         bilinear_w = np.zeros(
-            [self.pooled_height, self.pooled_width, count, 4], np.float32)
+            [self.pooled_height, self.pooled_width, count, 4], np.float32
+        )
         for ph in range(self.pooled_width):
             for pw in range(self.pooled_height):
                 c = 0
                 for iy in range(roi_bin_grid_h):
-                    y = roi_ymin + ph * bin_size_h + (iy + 0.5) * \
-                        bin_size_h / roi_bin_grid_h
+                    y = (
+                        roi_ymin
+                        + ph * bin_size_h
+                        + (iy + 0.5) * bin_size_h / roi_bin_grid_h
+                    )
                     for ix in range(roi_bin_grid_w):
-                        x = roi_xmin + pw * bin_size_w + (ix + 0.5) * \
-                            bin_size_w / roi_bin_grid_w
-                        if y < -1.0 or y > self.height or \
-                               x < -1.0 or x > self.width:
+                        x = (
+                            roi_xmin
+                            + pw * bin_size_w
+                            + (ix + 0.5) * bin_size_w / roi_bin_grid_w
+                        )
+                        if y < -1.0 or y > self.height or x < -1.0 or x > self.width:
                             continue
                         if y <= 0:
                             y = 0
@@ -106,14 +120,10 @@ class TestROIAlignNPUOp(OpTest):
                         hy = 1 - ly
                         hx = 1 - lx
                         for ch in range(self.channels):
-                            bilinear_pos[ch, ph, pw, c, 0] = x_i[ch, y_low,
-                                                                 x_low]
-                            bilinear_pos[ch, ph, pw, c, 1] = x_i[ch, y_low,
-                                                                 x_high]
-                            bilinear_pos[ch, ph, pw, c, 2] = x_i[ch, y_high,
-                                                                 x_low]
-                            bilinear_pos[ch, ph, pw, c, 3] = x_i[ch, y_high,
-                                                                 x_high]
+                            bilinear_pos[ch, ph, pw, c, 0] = x_i[ch, y_low, x_low]
+                            bilinear_pos[ch, ph, pw, c, 1] = x_i[ch, y_low, x_high]
+                            bilinear_pos[ch, ph, pw, c, 2] = x_i[ch, y_high, x_low]
+                            bilinear_pos[ch, ph, pw, c, 3] = x_i[ch, y_high, x_high]
                         bilinear_w[ph, pw, c, 0] = hy * hx
                         bilinear_w[ph, pw, c, 1] = hy * lx
                         bilinear_w[ph, pw, c, 2] = ly * hx
@@ -123,10 +133,10 @@ class TestROIAlignNPUOp(OpTest):
 
     def calc_roi_align(self):
         self.out_data = np.zeros(
-            (self.rois_num, self.channels, self.pooled_height,
-             self.pooled_width)).astype(self.dtype)
+            (self.rois_num, self.channels, self.pooled_height, self.pooled_width)
+        ).astype(self.dtype)
 
-        offset = 0.5 if self.aligned else 0.
+        offset = 0.5 if self.aligned else 0.0
         for i in range(self.rois_num):
             roi = self.rois[i]
             roi_batch_id = int(roi[0])
@@ -144,16 +154,27 @@ class TestROIAlignNPUOp(OpTest):
 
             bin_size_h = float(roi_height) / float(self.pooled_height)
             bin_size_w = float(roi_width) / float(self.pooled_width)
-            roi_bin_grid_h = self.sampling_ratio if self.sampling_ratio > 0 else \
-                                 math.ceil(roi_height / self.pooled_height)
-            roi_bin_grid_w = self.sampling_ratio if self.sampling_ratio > 0 else \
-                                 math.ceil(roi_width / self.pooled_width)
+            roi_bin_grid_h = (
+                self.sampling_ratio
+                if self.sampling_ratio > 0
+                else math.ceil(roi_height / self.pooled_height)
+            )
+            roi_bin_grid_w = (
+                self.sampling_ratio
+                if self.sampling_ratio > 0
+                else math.ceil(roi_width / self.pooled_width)
+            )
             count = max(int(roi_bin_grid_h * roi_bin_grid_w), 1)
             pre_size = count * self.pooled_width * self.pooled_height
-            bilinear_pos, bilinear_w = self.pre_calc(x_i, roi_xmin, roi_ymin,
-                                                     int(roi_bin_grid_h),
-                                                     int(roi_bin_grid_w),
-                                                     bin_size_h, bin_size_w)
+            bilinear_pos, bilinear_w = self.pre_calc(
+                x_i,
+                roi_xmin,
+                roi_ymin,
+                int(roi_bin_grid_h),
+                int(roi_bin_grid_w),
+                bin_size_h,
+                bin_size_w,
+            )
             for ch in range(self.channels):
                 align_per_bin = (bilinear_pos[ch] * bilinear_w).sum(axis=-1)
                 output_val = align_per_bin.mean(axis=-1)
@@ -166,34 +187,39 @@ class TestROIAlignNPUOp(OpTest):
             self.rois_lod[0].append(bno + 1)
             for i in range(bno + 1):
                 x1 = np.random.randint(
-                    0, self.width // self.spatial_scale - self.pooled_width)
+                    0, self.width // self.spatial_scale - self.pooled_width
+                )
                 y1 = np.random.randint(
-                    0, self.height // self.spatial_scale - self.pooled_height)
+                    0, self.height // self.spatial_scale - self.pooled_height
+                )
 
-                x2 = np.random.randint(x1 + self.pooled_width,
-                                       self.width // self.spatial_scale)
-                y2 = np.random.randint(y1 + self.pooled_height,
-                                       self.height // self.spatial_scale)
+                x2 = np.random.randint(
+                    x1 + self.pooled_width, self.width // self.spatial_scale
+                )
+                y2 = np.random.randint(
+                    y1 + self.pooled_height, self.height // self.spatial_scale
+                )
 
                 roi = [bno, x1, y1, x2, y2]
                 rois.append(roi)
 
         self.rois_num = len(rois)
         self.rois = np.array(rois).astype("float32")
-        self.boxes_num = np.array(
-            [bno + 1 for bno in range(self.batch_size)]).astype('int32')
+        self.boxes_num = np.array([bno + 1 for bno in range(self.batch_size)]).astype(
+            "int32"
+        )
 
     def setUp(self):
         self.op_type = "roi_align"
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.set_data()
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Out')
+        self.check_grad_with_place(self.place, ["X"], "Out")
 
 
 class TestROIAlignNPUOpDouble(TestROIAlignNPUOp):
@@ -216,8 +242,7 @@ class TestROIAlignNPUOpDouble(TestROIAlignNPUOp):
         self.x = np.random.random(self.x_dim).astype(self.dtype)
 
     def test_check_grad(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', max_relative_error=0.01)
+        self.check_grad_with_place(self.place, ["X"], "Out", max_relative_error=0.01)
 
 
 class TestROIAlignOpWithMinusSample(TestROIAlignNPUOp):
@@ -239,5 +264,5 @@ class TestROIAlignOpWithMinusSample(TestROIAlignNPUOp):
         self.x = np.random.random(self.x_dim).astype(self.dtype)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_rsqrt_op_npu.py
+++ b/backends/npu/tests/unittests/test_rsqrt_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_scale_op_npu.py
+++ b/backends/npu/tests/unittests/test_scale_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_scatter_op_npu.py
+++ b/backends/npu/tests/unittests/test_scatter_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -51,7 +51,7 @@ class TestCast1_FP32(OpTest):
             self.place,
             ["X", "Updates"],
             "Out",
-            check_eager=False,
+            check_dygraph=False,
             numeric_place=paddle.CPUPlace(),
         )
 
@@ -106,7 +106,7 @@ class TestCast2_FP32(OpTest):
             self.place,
             ["X", "Updates"],
             "Out",
-            check_eager=False,
+            check_dygraph=False,
             numeric_place=paddle.CPUPlace(),
         )
 
@@ -139,7 +139,7 @@ class TestCast3_FP32(OpTest):
             self.place,
             ["X", "Updates"],
             "Out",
-            check_eager=False,
+            check_dygraph=False,
             numeric_place=paddle.CPUPlace(),
         )
 

--- a/backends/npu/tests/unittests/test_selu_op_npu.py
+++ b/backends/npu/tests/unittests/test_selu_op_npu.py
@@ -14,7 +14,7 @@
 
 import unittest
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F

--- a/backends/npu/tests/unittests/test_set_value_op_npu.py
+++ b/backends/npu/tests/unittests/test_set_value_op_npu.py
@@ -16,18 +16,14 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 
 class TestSetValueBase(unittest.TestCase):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def setUp(self):
         paddle.enable_static()
@@ -82,10 +78,12 @@ class TestSetValueApi(TestSetValueBase):
         error_msg = "\nIn {} mode: \nExpected res = \n{}, \n\nbut received : \n{}"
         self.assertTrue(
             (self.data == static_out).all(),
-            msg=error_msg.format("static", self.data, static_out))
+            msg=error_msg.format("static", self.data, static_out),
+        )
         self.assertTrue(
             (self.data == dynamic_out).all(),
-            msg=error_msg.format("dynamic", self.data, dynamic_out))
+            msg=error_msg.format("dynamic", self.data, dynamic_out),
+        )
 
 
 # 1. Test different type of item: int, Python slice, Paddle Tensor
@@ -450,13 +448,11 @@ class TestSetValueItemBool4(TestSetValueApi):
 
 class TestSetValueItemBool5(TestSetValueApi):
     def _call_setitem(self, x):
-        idx = paddle.assign(
-            np.array([[False, True, False], [True, True, False]]))
+        idx = paddle.assign(np.array([[False, True, False], [True, True, False]]))
         x[idx] = self.value
 
     def _get_answer(self):
-        self.data[np.array([[False, True, False], [True, True, False]
-                            ])] = self.value
+        self.data[np.array([[False, True, False], [True, True, False]])] = self.value
 
 
 class TestSetValueItemBool6(TestSetValueApi):
@@ -558,8 +554,9 @@ class TestSetValueValueShape2(TestSetValueApi):
 
 class TestSetValueValueShape3(TestSetValueApi):
     def set_value(self):
-        self.value = np.array([[1, 1, 1, 1], [2, 2, 2, 2],
-                               [3, 3, 3, 3]])  # shape is (3,4)
+        self.value = np.array(
+            [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]
+        )  # shape is (3,4)
 
     def _call_setitem(self, x):
         x[0] = self.value
@@ -570,9 +567,9 @@ class TestSetValueValueShape3(TestSetValueApi):
 
 class TestSetValueValueShape4(TestSetValueApi):
     def set_value(self):
-        self.value = np.array([[1, 1, 1, 1], [2, 2, 2, 2],
-                               [3, 3, 3,
-                                3]]).astype(self.dtype)  # shape is (3,4)
+        self.value = np.array([[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3]]).astype(
+            self.dtype
+        )  # shape is (3,4)
 
     def _call_setitem(self, x):
         x[0] = paddle.assign(self.value)  # x is Paddle.Tensor
@@ -595,5 +592,5 @@ class TestSetValueValueShape5(TestSetValueApi):
         self.data[:, 0] = self.value
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_sgd_op_npu.py
+++ b/backends/npu/tests/unittests/test_sgd_op_npu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_shard_index_op_npu.py
+++ b/backends/npu/tests/unittests/test_shard_index_op_npu.py
@@ -16,12 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import math
-from tests.op_test import OpTest
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-import paddle.fluid.framework as framework
-from paddle.fluid.framework import Program, program_guard
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -32,28 +27,28 @@ def common_setup(self, index_num, nshards, shard_id, ignore_value):
     self.__class__.use_custom_device = True
     self.__class__.op_type = "shard_index"
 
-    self.op_type = 'shard_index'
+    self.op_type = "shard_index"
     x_lod = [[i for i in range(10)]]
     N = sum(x_lod[0])
     x = [np.random.randint(0, index_num - 1) for i in range(N)]
-    x = np.array(x).astype('int32').reshape([N, 1])
+    x = np.array(x).astype("int32").reshape([N, 1])
 
     shard_size = (index_num + nshards - 1) // nshards
-    out = np.zeros(shape=x.shape).astype('int32')
+    out = np.zeros(shape=x.shape).astype("int32")
     for i in range(N):
         if x[i] // shard_size == shard_id:
             out[i] = x[i] % shard_size
         else:
             out[i] = ignore_value
 
-    self.inputs = {'X': (x, x_lod)}
+    self.inputs = {"X": (x, x_lod)}
     self.attrs = {
-        'index_num': index_num,
-        'nshards': nshards,
-        'shard_id': shard_id,
-        'ignore_value': ignore_value
+        "index_num": index_num,
+        "nshards": nshards,
+        "shard_id": shard_id,
+        "ignore_value": ignore_value,
     }
-    self.outputs = {'Out': (out, x_lod)}
+    self.outputs = {"Out": (out, x_lod)}
 
 
 class TestShardIndexShardId0Op(OpTest):
@@ -61,7 +56,7 @@ class TestShardIndexShardId0Op(OpTest):
         common_setup(self, 20, 2, 0, -1)
 
     def test_check_output(self):
-        return self.check_output_with_place(place=paddle.CustomPlace('npu', 0))
+        return self.check_output_with_place(place=paddle.CustomPlace("npu", 0))
 
 
 class TestShardIndexShardId1Op(TestShardIndexShardId0Op):
@@ -79,5 +74,5 @@ class TestShardIndexNotEvenlyDividedOp(TestShardIndexShardId0Op):
         common_setup(self, 15, 2, 1, -1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_sigmoid_cross_entropy_with_logits_op_npu.py
+++ b/backends/npu/tests/unittests/test_sigmoid_cross_entropy_with_logits_op_npu.py
@@ -15,21 +15,17 @@
 from __future__ import print_function
 
 import numpy as np
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 from scipy.special import logit
 from scipy.special import expit
-import paddle.fluid.core as core
 import unittest
-from paddle.fluid import compiler, Program, program_guard
-import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()
 
 
 class TestSigmoidCrossEntropyWithLogitsOp1(OpTest):
-    """Test sigmoid_cross_entropy_with_logit_op with binary label
-    """
+    """Test sigmoid_cross_entropy_with_logit_op with binary label"""
 
     def setUp(self):
         self.op_type = "sigmoid_cross_entropy_with_logits"
@@ -39,39 +35,38 @@ class TestSigmoidCrossEntropyWithLogitsOp1(OpTest):
         batch_size = 64
         num_classes = 20
         self.inputs = {
-            'X': logit(
-                np.random.uniform(0, 1, (batch_size, num_classes))
-                .astype(self.dtype)),
-            'Label': np.random.randint(0, 2, (batch_size, num_classes))
-            .astype(self.dtype)
+            "X": logit(
+                np.random.uniform(0, 1, (batch_size, num_classes)).astype(self.dtype)
+            ),
+            "Label": np.random.randint(0, 2, (batch_size, num_classes)).astype(
+                self.dtype
+            ),
         }
 
         # Fw Pass is implemented as elementwise sigmoid followed by
         # elementwise logistic loss
         # Label * -log(sigmoid(X)) + (1 - label) * -log(1 - sigmoid(X))
-        sigmoid_X = expit(self.inputs['X'])
-        term1 = self.inputs['Label'] * np.log(sigmoid_X)
-        term2 = (1 - self.inputs['Label']) * np.log(1 - sigmoid_X)
-        self.outputs = {'Out': -term1 - term2}
+        sigmoid_X = expit(self.inputs["X"])
+        term1 = self.inputs["Label"] * np.log(sigmoid_X)
+        term2 = (1 - self.inputs["Label"]) * np.log(1 - sigmoid_X)
+        self.outputs = {"Out": -term1 - term2}
 
     def test_check_output(self):
         self.check_output_with_place(self.place, atol=1e-5)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], 'Out')
+        self.check_grad_with_place(self.place, ["X"], "Out")
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
 
 
-class TestSigmoidCrossEntropyWithLogitsOp3(
-        TestSigmoidCrossEntropyWithLogitsOp1):
-    """Test sigmoid_cross_entropy_with_logit_op with probabalistic label
-    """
+class TestSigmoidCrossEntropyWithLogitsOp3(TestSigmoidCrossEntropyWithLogitsOp1):
+    """Test sigmoid_cross_entropy_with_logit_op with probabalistic label"""
 
     def setUp(self):
         self.op_type = "sigmoid_cross_entropy_with_logits"
@@ -81,26 +76,25 @@ class TestSigmoidCrossEntropyWithLogitsOp3(
         batch_size = 64
         num_classes = 20
         self.inputs = {
-            'X': logit(
-                np.random.uniform(0, 1, (batch_size, num_classes))
-                .astype(self.dtype)),
-            'Label': np.random.uniform(0, 1, (batch_size, num_classes))
-            .astype(self.dtype)
+            "X": logit(
+                np.random.uniform(0, 1, (batch_size, num_classes)).astype(self.dtype)
+            ),
+            "Label": np.random.uniform(0, 1, (batch_size, num_classes)).astype(
+                self.dtype
+            ),
         }
 
         # Fw Pass is implemented as elementwise sigmoid followed by
         # elementwise logistic loss
         # Label * -log(sigmoid(X)) + (1 - label) * -log(1 - sigmoid(X))
-        sigmoid_X = expit(self.inputs['X'])
-        term1 = self.inputs['Label'] * np.log(sigmoid_X)
-        term2 = (1 - self.inputs['Label']) * np.log(1 - sigmoid_X)
-        self.outputs = {'Out': -term1 - term2}
+        sigmoid_X = expit(self.inputs["X"])
+        term1 = self.inputs["Label"] * np.log(sigmoid_X)
+        term2 = (1 - self.inputs["Label"]) * np.log(1 - sigmoid_X)
+        self.outputs = {"Out": -term1 - term2}
 
 
-class TestSigmoidCrossEntropyWithLogitsOp5(
-        TestSigmoidCrossEntropyWithLogitsOp1):
-    """Test sigmoid_cross_entropy_with_logit_op with probabalistic label
-    """
+class TestSigmoidCrossEntropyWithLogitsOp5(TestSigmoidCrossEntropyWithLogitsOp1):
+    """Test sigmoid_cross_entropy_with_logit_op with probabalistic label"""
 
     def setUp(self):
         self.op_type = "sigmoid_cross_entropy_with_logits"
@@ -110,26 +104,27 @@ class TestSigmoidCrossEntropyWithLogitsOp5(
         batch_size = [10, 10]
         num_classes = 20
         self.inputs = {
-            'X': logit(
-                np.random.uniform(0, 1, tuple(batch_size + [num_classes]))
-                .astype(self.dtype)),
-            'Label': np.random.uniform(0, 1, tuple(batch_size + [num_classes]))
-            .astype(self.dtype)
+            "X": logit(
+                np.random.uniform(0, 1, tuple(batch_size + [num_classes])).astype(
+                    self.dtype
+                )
+            ),
+            "Label": np.random.uniform(0, 1, tuple(batch_size + [num_classes])).astype(
+                self.dtype
+            ),
         }
 
         # Fw Pass is implemented as elementwise sigmoid followed by
         # elementwise logistic loss
         # Label * -log(sigmoid(X)) + (1 - label) * -log(1 - sigmoid(X))
-        sigmoid_X = expit(self.inputs['X'])
-        term1 = self.inputs['Label'] * np.log(sigmoid_X)
-        term2 = (1 - self.inputs['Label']) * np.log(1 - sigmoid_X)
-        self.outputs = {'Out': -term1 - term2}
+        sigmoid_X = expit(self.inputs["X"])
+        term1 = self.inputs["Label"] * np.log(sigmoid_X)
+        term2 = (1 - self.inputs["Label"]) * np.log(1 - sigmoid_X)
+        self.outputs = {"Out": -term1 - term2}
 
 
-class TestSigmoidCrossEntropyWithLogitsOp6(
-        TestSigmoidCrossEntropyWithLogitsOp1):
-    """Test sigmoid_cross_entropy_with_logit_op with binary label
-    """
+class TestSigmoidCrossEntropyWithLogitsOp6(TestSigmoidCrossEntropyWithLogitsOp1):
+    """Test sigmoid_cross_entropy_with_logit_op with binary label"""
 
     def setUp(self):
         self.op_type = "sigmoid_cross_entropy_with_logits"
@@ -139,21 +134,24 @@ class TestSigmoidCrossEntropyWithLogitsOp6(
         batch_size = [10, 10]
         num_classes = 20
         self.inputs = {
-            'X': logit(
-                np.random.uniform(0, 1, tuple(batch_size + [num_classes]))
-                .astype(self.dtype)),
-            'Label': np.random.randint(0, 2, tuple(batch_size + [num_classes]))
-            .astype(self.dtype)
+            "X": logit(
+                np.random.uniform(0, 1, tuple(batch_size + [num_classes])).astype(
+                    self.dtype
+                )
+            ),
+            "Label": np.random.randint(0, 2, tuple(batch_size + [num_classes])).astype(
+                self.dtype
+            ),
         }
 
         # Fw Pass is implemented as elementwise sigmoid followed by
         # elementwise logistic loss
         # Label * -log(sigmoid(X)) + (1 - label) * -log(1 - sigmoid(X))
-        sigmoid_X = expit(self.inputs['X'])
-        term1 = self.inputs['Label'] * np.log(sigmoid_X)
-        term2 = (1 - self.inputs['Label']) * np.log(1 - sigmoid_X)
-        self.outputs = {'Out': -term1 - term2}
+        sigmoid_X = expit(self.inputs["X"])
+        term1 = self.inputs["Label"] * np.log(sigmoid_X)
+        term2 = (1 - self.inputs["Label"]) * np.log(1 - sigmoid_X)
+        self.outputs = {"Out": -term1 - term2}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_softmax_op_npu.py
+++ b/backends/npu/tests/unittests/test_softmax_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_softmax_with_cross_entropy_op_npu.py
+++ b/backends/npu/tests/unittests/test_softmax_with_cross_entropy_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import paddle
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -452,12 +452,12 @@ class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):
 
     def test_check_output(self):
         if self.python_api is not None:
-            self.check_output_with_place(self.place, check_eager=False)
+            self.check_output_with_place(self.place, check_dygraph=False)
         self.check_output_with_place(self.place)
 
     # def test_check_grad(self):
     #     if self.python_api is not None:
-    #         self.check_grad(["Logits"], "Loss", check_eager=False)
+    #         self.check_grad(["Logits"], "Loss", check_dygraph=False)
     #     self.check_grad(["Logits"], "Loss")
 
 

--- a/backends/npu/tests/unittests/test_split_op_npu.py
+++ b/backends/npu/tests/unittests/test_split_op_npu.py
@@ -16,10 +16,8 @@ from __future__ import print_function, division
 
 import numpy as np
 import unittest
-import sys
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 
@@ -28,7 +26,7 @@ class NPUOpTest(OpTest):
     def set_plugin(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
 
 class TestNPUSplitOp(NPUOpTest):
@@ -39,9 +37,9 @@ class TestNPUSplitOp(NPUOpTest):
         axis = 1
         x = np.random.random((4, 5, 6)).astype(self.dtype)
         out = np.split(x, [2, 3], axis)
-        self.inputs = {'X': x}
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
-        self.attrs = {'axis': axis, 'sections': [2, 1, 2]}
+        self.inputs = {"X": x}
+        self.outputs = {"Out": [("out%d" % i, out[i]) for i in range(len(out))]}
+        self.attrs = {"axis": axis, "sections": [2, 1, 2]}
 
     def get_dtype(self):
         return "float32"
@@ -62,15 +60,11 @@ class TestNPUSplitOp_2(NPUOpTest):
         self._set_op_type()
         self.dtype = self.get_dtype()
         self.init_data()
-        self.inputs = {'X': self.x}
-        self.attrs = {
-            'axis': self.axis,
-            'sections': self.sections,
-            'num': self.num
-        }
+        self.inputs = {"X": self.x}
+        self.attrs = {"axis": self.axis, "sections": self.sections, "num": self.num}
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {"Out": [("out%d" % i, out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)
@@ -99,14 +93,11 @@ class TestSplitOp_AxisTensor(NPUOpTest):
         self._set_op_type()
         self.dtype = self.get_dtype()
         self.init_data()
-        self.inputs = {
-            'X': self.x,
-            'AxisTensor': np.array([self.axis]).astype("int32")
-        }
-        self.attrs = {'sections': self.sections, 'num': self.num}
+        self.inputs = {"X": self.x, "AxisTensor": np.array([self.axis]).astype("int32")}
+        self.attrs = {"sections": self.sections, "num": self.num}
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {"Out": [("out%d" % i, out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)
@@ -135,23 +126,24 @@ class TestSplitOp_SectionsTensor(NPUOpTest):
         self._set_op_type()
         self.dtype = self.get_dtype()
         self.init_data()
-        self.inputs = {'X': self.x}
+        self.inputs = {"X": self.x}
 
         sections_tensor = []
         for index, ele in enumerate(self.sections):
-            sections_tensor.append(("x" + str(index), np.ones(
-                (1)).astype('int32') * ele))
+            sections_tensor.append(
+                ("x" + str(index), np.ones((1)).astype("int32") * ele)
+            )
 
-        self.inputs['SectionsTensorList'] = sections_tensor
+        self.inputs["SectionsTensorList"] = sections_tensor
 
         self.attrs = {
-            'axis': self.axis,
-            'sections': self.sections_infer,
-            'num': self.num
+            "axis": self.axis,
+            "sections": self.sections_infer,
+            "num": self.num,
         }
 
         out = np.split(self.x, self.indices_or_sections, self.axis)
-        self.outputs = {'Out': [('out%d' % i, out[i]) for i in range(len(out))]}
+        self.outputs = {"Out": [("out%d" % i, out[i]) for i in range(len(out))]}
 
     def init_data(self):
         self.x = np.random.random((4, 5, 6)).astype(self.dtype)
@@ -174,19 +166,19 @@ class TestSplitOp_SectionsTensor(NPUOpTest):
         pass
 
 
-# split_with_num op cannot be called by set op type because it has not been registered in fluid OpProto, 
+# split_with_num op cannot be called by set op type because it has not been registered in fluid OpProto,
 # we call paddle.split() in dygraph mode to test it.
 class TestNPUSplitWithNumOp(unittest.TestCase):
     def initTestCase(self):
         self.dim = (4, 5, 6)
-        self.dtype = 'float32'
+        self.dtype = "float32"
         self.axis = 2
         self.num = 3
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_split_with_num(self):
         def run(place):
@@ -198,8 +190,8 @@ class TestNPUSplitWithNumOp(unittest.TestCase):
             paddle_output = paddle.split(tensor_input, self.num, self.axis)
             for i in range(self.num):
                 self.assertEqual(
-                    np.allclose(numpy_output[i], paddle_output[i].numpy()),
-                    True)
+                    np.allclose(numpy_output[i], paddle_output[i].numpy()), True
+                )
             paddle.enable_static()
 
         for place in self.place:
@@ -209,14 +201,14 @@ class TestNPUSplitWithNumOp(unittest.TestCase):
 class TestNPUSplitWithNumOp_AxisTensor(TestNPUSplitWithNumOp):
     def initTestCase(self):
         self.dim = (4, 5, 6)
-        self.dtype = 'float32'
-        self.axis = np.array([2]).astype('int32')
+        self.dtype = "float32"
+        self.axis = np.array([2]).astype("int32")
         self.num = 3
 
     def setUp(self):
         self.initTestCase()
         self.__class__.use_custom_device = True
-        self.place = [paddle.CustomPlace('npu', 0)]
+        self.place = [paddle.CustomPlace("npu", 0)]
 
     def test_split_with_num(self):
         def run(place):
@@ -225,17 +217,18 @@ class TestNPUSplitWithNumOp_AxisTensor(TestNPUSplitWithNumOp):
             numpy_input = (np.random.random(self.dim)).astype(self.dtype)
             tensor_input = paddle.to_tensor(numpy_input)
             numpy_output = np.split(numpy_input, self.num, self.axis[0])
-            paddle_output = paddle.split(tensor_input, self.num,
-                                         paddle.to_tensor(self.axis))
+            paddle_output = paddle.split(
+                tensor_input, self.num, paddle.to_tensor(self.axis)
+            )
             for i in range(self.num):
                 self.assertEqual(
-                    np.allclose(numpy_output[i], paddle_output[i].numpy()),
-                    True)
+                    np.allclose(numpy_output[i], paddle_output[i].numpy()), True
+                )
             paddle.enable_static()
 
         for place in self.place:
             run(place)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_squared_l2_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_squared_l2_norm_op_npu.py
@@ -17,26 +17,25 @@ from __future__ import print_function
 import numpy as np
 import unittest
 from numpy import linalg as LA
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
 
 
 class TestL2LossOp(OpTest):
-    """Test npu squared_l2_norm
-    """
+    """Test npu squared_l2_norm"""
 
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "squared_l2_norm"
         self.max_relative_error = 0.05
 
         X = np.random.uniform(-1, 1, (13, 19)).astype("float32")
         X[np.abs(X) < self.max_relative_error] = 0.1
-        self.inputs = {'X': X}
-        self.outputs = {'Out': np.square(LA.norm(X))}
+        self.inputs = {"X": X}
+        self.outputs = {"Out": np.square(LA.norm(X))}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -46,9 +45,8 @@ class TestL2LossOp(OpTest):
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ['X'],
-            'Out',
-            max_relative_error=self.max_relative_error)
+            self.place, ["X"], "Out", max_relative_error=self.max_relative_error
+        )
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_squeeze_op_npu.py
+++ b/backends/npu/tests/unittests/test_squeeze_op_npu.py
@@ -16,12 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 
@@ -36,7 +32,7 @@ class TestSqueeze2Op(OpTest):
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float32")
+            "XShape": np.random.random(self.ori_shape).astype("float32"),
         }
 
     def set_npu(self):
@@ -44,10 +40,11 @@ class TestSqueeze2Op(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            paddle.CustomPlace('npu', 0), no_check_set=['XShape'])
+            paddle.CustomPlace("npu", 0), no_check_set=["XShape"]
+        )
 
     def test_check_grad(self):
-        self.check_grad_with_place(paddle.CustomPlace('npu', 0), ["X"], "Out")
+        self.check_grad_with_place(paddle.CustomPlace("npu", 0), ["X"], "Out")
 
     def init_test_case(self):
         self.ori_shape = (1, 3, 1, 40)

--- a/backends/npu/tests/unittests/test_stack_op_npu.py
+++ b/backends/npu/tests/unittests/test_stack_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_strided_slice_op_npu.py
+++ b/backends/npu/tests/unittests/test_strided_slice_op_npu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_sum_op_npu.py
+++ b/backends/npu/tests/unittests/test_sum_op_npu.py
@@ -16,11 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021
@@ -31,16 +28,16 @@ class TestSum1(OpTest):
         self.set_npu()
         self.init_dtype()
         self.op_type = "sum"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         x0 = np.random.random((3, 40)).astype(self.dtype)
         x1 = np.random.random((3, 40)).astype(self.dtype)
         x2 = np.random.random((3, 40)).astype(self.dtype)
-        self.inputs = {'X': [("x0", x0), ("x1", x1), ("x2", x2)]}
+        self.inputs = {"X": [("x0", x0), ("x1", x1), ("x2", x2)]}
         y = x0 + x1 + x2
-        self.outputs = {'Out': y}
+        self.outputs = {"Out": y}
 
-        self.attrs = {'use_mkldnn': False}
+        self.attrs = {"use_mkldnn": False}
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -57,24 +54,28 @@ class TestSum2(OpTest):
         self.set_npu()
         self.init_dtype()
         self.op_type = "sum"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         x0 = np.random.random((3, 3)).astype(self.dtype)
         x1 = np.random.random((3, 3)).astype(self.dtype)
         x2 = np.random.random((3, 3)).astype(self.dtype)
         x3 = np.random.random((3, 3)).astype(self.dtype)
-        self.inputs = {'X': [("x0", x0), ("x1", x1), ("x2", x2), ("x3", x3)]}
+        self.inputs = {"X": [("x0", x0), ("x1", x1), ("x2", x2), ("x3", x3)]}
         # There will be a problem if just using `y=x0+x1+x2+x3` to calculate the
-        # summation result as the reference standard result. The reason is that 
+        # summation result as the reference standard result. The reason is that
         # numpy's fp16 data has precision loss when doing `add` operation.
         # For example, the results of `x0+x1+x2+x3` is different from that of
         # `x3+x2+x1+x0` if the dtype is fp16.
         # Therefore, converting the input to fp32 for calculation.
-        y = (x0.astype(np.float32) + x1.astype(np.float32) +
-             x2.astype(np.float32) + x3.astype(np.float32)).astype(self.dtype)
-        self.outputs = {'Out': y}
+        y = (
+            x0.astype(np.float32)
+            + x1.astype(np.float32)
+            + x2.astype(np.float32)
+            + x3.astype(np.float32)
+        ).astype(self.dtype)
+        self.outputs = {"Out": y}
 
-        self.attrs = {'use_mkldnn': False}
+        self.attrs = {"use_mkldnn": False}
 
     def init_dtype(self):
         self.dtype = np.float16
@@ -91,15 +92,15 @@ class TestSum3(OpTest):
         self.set_npu()
         self.init_dtype()
         self.op_type = "sum"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         x0 = np.random.random((3, 3)).astype(self.dtype)
 
-        self.inputs = {'X': [("x0", x0)]}
+        self.inputs = {"X": [("x0", x0)]}
         y = x0
-        self.outputs = {'Out': y}
+        self.outputs = {"Out": y}
 
-        self.attrs = {'use_mkldnn': False}
+        self.attrs = {"use_mkldnn": False}
 
     def init_dtype(self):
         self.dtype = np.float16
@@ -116,16 +117,16 @@ class TestSum4(OpTest):
         self.set_npu()
         self.init_dtype()
         self.op_type = "sum"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
         x0 = np.random.random((3, 40)).astype(self.dtype)
         x1 = np.random.random((0, 0)).astype(self.dtype)
         x2 = np.random.random((3, 40)).astype(self.dtype)
-        self.inputs = {'X': [("x0", x0), ("x1", x1), ("x2", x2)]}
+        self.inputs = {"X": [("x0", x0), ("x1", x1), ("x2", x2)]}
         y = x0 + x2
-        self.outputs = {'Out': y}
+        self.outputs = {"Out": y}
 
-        self.attrs = {'use_mkldnn': False}
+        self.attrs = {"use_mkldnn": False}
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -137,5 +138,5 @@ class TestSum4(OpTest):
         self.check_output_with_place(self.place)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_swish_op_npu.py
+++ b/backends/npu/tests/unittests/test_swish_op_npu.py
@@ -16,11 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from scipy.special import expit
 
 paddle.enable_static()
@@ -40,29 +38,27 @@ class TestSwishOp(OpTest):
         np.random.seed(2048)
         x = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
         out = ref_swish(x)
-        self.inputs = {'X': x}
-        self.attrs = {'beta': 1.0}
-        self.outputs = {'Out': out}
+        self.inputs = {"X": x}
+        self.attrs = {"beta": 1.0}
+        self.outputs = {"Out": out}
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        beta = self.attrs['beta']
-        out = self.outputs['Out']
-        x = self.inputs['X']
+        beta = self.attrs["beta"]
+        out = self.outputs["Out"]
+        x = self.inputs["X"]
         dx = beta * out + expit(x) * (1 - beta * out)
         dx = dx / x.size
 
         self.check_grad_with_place(
-            self.place, ['X'],
-            'Out',
-            max_relative_error=0.01,
-            user_defined_grads=[dx])
+            self.place, ["X"], "Out", max_relative_error=0.01, user_defined_grads=[dx]
+        )
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -76,5 +72,5 @@ class TestSwishOpFp16(TestSwishOp):
         self.dtype = np.float16
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_take_along_axis_op_npu.py
+++ b/backends/npu/tests/unittests/test_take_along_axis_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_tile_op_npu.py
+++ b/backends/npu/tests/unittests/test_tile_op_npu.py
@@ -16,30 +16,27 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid import core
 
 paddle.enable_static()
 np.random.seed(10)
 
 
-#Situation 1: repeat_times is a list (without tensor)
+# Situation 1: repeat_times is a list (without tensor)
 class TestTileOpRank1(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
         self.init_data()
 
-        self.inputs = {'X': np.random.random(self.ori_shape).astype("float32")}
-        self.attrs = {'repeat_times': self.repeat_times}
-        output = np.tile(self.inputs['X'], self.repeat_times)
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.attrs = {"repeat_times": self.repeat_times}
+        output = np.tile(self.inputs["X"], self.repeat_times)
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -52,10 +49,10 @@ class TestTileOpRank1(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], ['Out'])
+        self.check_grad_with_place(self.place, ["X"], ["Out"])
 
 
-#with dimension expanding
+# with dimension expanding
 class TestTileOpRank2Expanding(TestTileOpRank1):
     def init_data(self):
         self.ori_shape = [120]
@@ -96,21 +93,22 @@ class TestTileOpRank4(TestTileOpRank1):
 class TestTileOpRank1_tensor_attr(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
         self.init_data()
         repeat_times_tensor = []
         for index, ele in enumerate(self.repeat_times):
-            repeat_times_tensor.append(("x" + str(index), np.ones(
-                (1)).astype('int32') * ele))
+            repeat_times_tensor.append(
+                ("x" + str(index), np.ones((1)).astype("int32") * ele)
+            )
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float32"),
-            'repeat_times_tensor': repeat_times_tensor,
+            "X": np.random.random(self.ori_shape).astype("float32"),
+            "repeat_times_tensor": repeat_times_tensor,
         }
         self.attrs = {"repeat_times": self.infer_repeat_times}
-        output = np.tile(self.inputs['X'], self.repeat_times)
-        self.outputs = {'Out': output}
+        output = np.tile(self.inputs["X"], self.repeat_times)
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -124,7 +122,7 @@ class TestTileOpRank1_tensor_attr(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], ['Out'])
+        self.check_grad_with_place(self.place, ["X"], ["Out"])
 
 
 class TestTileOpRank2_Corner_tensor_attr(TestTileOpRank1_tensor_attr):
@@ -145,17 +143,17 @@ class TestTileOpRank2_attr_tensor(TestTileOpRank1_tensor_attr):
 class TestTileOpRank1_tensor(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
         self.init_data()
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float32"),
-            'RepeatTimes': np.array(self.repeat_times).astype("int32"),
+            "X": np.random.random(self.ori_shape).astype("float32"),
+            "RepeatTimes": np.array(self.repeat_times).astype("int32"),
         }
         self.attrs = {}
-        output = np.tile(self.inputs['X'], self.repeat_times)
-        self.outputs = {'Out': output}
+        output = np.tile(self.inputs["X"], self.repeat_times)
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -168,7 +166,7 @@ class TestTileOpRank1_tensor(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], ['Out'])
+        self.check_grad_with_place(self.place, ["X"], ["Out"])
 
 
 class TestTileOpRank2_tensor(TestTileOpRank1_tensor):
@@ -181,15 +179,12 @@ class TestTileOpRank2_tensor(TestTileOpRank1_tensor):
 class TestTileOpInteger(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
-        self.inputs = {
-            'X': np.random.randint(
-                10, size=(4, 4, 5)).astype("int32")
-        }
-        self.attrs = {'repeat_times': [2, 1, 4]}
-        output = np.tile(self.inputs['X'], (2, 1, 4))
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.randint(10, size=(4, 4, 5)).astype("int32")}
+        self.attrs = {"repeat_times": [2, 1, 4]}
+        output = np.tile(self.inputs["X"], (2, 1, 4))
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -202,15 +197,12 @@ class TestTileOpInteger(OpTest):
 class TestTileOpInt64_t(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
-        self.inputs = {
-            'X': np.random.randint(
-                10, size=(2, 4, 5)).astype("int64")
-        }
-        self.attrs = {'repeat_times': [2, 1, 4]}
-        output = np.tile(self.inputs['X'], (2, 1, 4))
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.randint(10, size=(2, 4, 5)).astype("int64")}
+        self.attrs = {"repeat_times": [2, 1, 4]}
+        output = np.tile(self.inputs["X"], (2, 1, 4))
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -223,12 +215,12 @@ class TestTileOpInt64_t(OpTest):
 class TestTileOpBool(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
-        self.inputs = {'X': np.random.randint(1, size=(2, 4, 5)).astype("bool")}
-        self.attrs = {'repeat_times': [2, 1, 4]}
-        output = np.tile(self.inputs['X'], (2, 1, 4))
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.randint(1, size=(2, 4, 5)).astype("bool")}
+        self.attrs = {"repeat_times": [2, 1, 4]}
+        output = np.tile(self.inputs["X"], (2, 1, 4))
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -241,15 +233,12 @@ class TestTileOpBool(OpTest):
 class TestTileOpDouble(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
-        self.inputs = {
-            'X': np.random.randint(
-                10, size=(2, 10, 5)).astype("double")
-        }
-        self.attrs = {'repeat_times': [2, 1, 4]}
-        output = np.tile(self.inputs['X'], (2, 1, 4))
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.randint(10, size=(2, 10, 5)).astype("double")}
+        self.attrs = {"repeat_times": [2, 1, 4]}
+        output = np.tile(self.inputs["X"], (2, 1, 4))
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -258,22 +247,19 @@ class TestTileOpDouble(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], ['Out'])
+        self.check_grad_with_place(self.place, ["X"], ["Out"])
 
 
 # Situation 8: input x is FP16
 class TestTileOpFloat16(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.op_type = "tile"
-        self.inputs = {
-            'X': np.random.randint(
-                10, size=(2, 10, 5)).astype("float16")
-        }
-        self.attrs = {'repeat_times': [2, 1, 4]}
-        output = np.tile(self.inputs['X'], (2, 1, 4))
-        self.outputs = {'Out': output}
+        self.inputs = {"X": np.random.randint(10, size=(2, 10, 5)).astype("float16")}
+        self.attrs = {"repeat_times": [2, 1, 4]}
+        output = np.tile(self.inputs["X"], (2, 1, 4))
+        self.outputs = {"Out": output}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
@@ -282,16 +268,15 @@ class TestTileOpFloat16(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        numel = self.inputs['X'].size
-        dx = np.full_like(self.inputs['X'], 1.0 / numel, dtype=np.float16)
-        self.check_grad_with_place(
-            self.place, ['X'], ['Out'], user_defined_grads=[dx])
+        numel = self.inputs["X"].size
+        dx = np.full_like(self.inputs["X"], 1.0 / numel, dtype=np.float16)
+        self.check_grad_with_place(self.place, ["X"], ["Out"], user_defined_grads=[dx])
 
 
 # Test python API
 class TestTileAPI(unittest.TestCase):
     def test_api(self):
-        with fluid.dygraph.guard(paddle.CustomPlace('npu', 0)):
+        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.random.random([12, 14]).astype("float32")
             x = paddle.to_tensor(np_x)
 

--- a/backends/npu/tests/unittests/test_top_k_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_top_k_v2_op_npu.py
@@ -16,9 +16,8 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 
@@ -49,11 +48,12 @@ class TestTopkV2NPUOp(OpTest):
         self.set_input_data()
         self.set_attrs()
         output, indices = numpy_topk(
-            self.input_data, axis=self.axis, k=self.k, largest=self.largest)
+            self.input_data, axis=self.axis, k=self.k, largest=self.largest
+        )
 
-        self.inputs = {'X': self.input_data}
-        self.attrs = {'k': self.k, 'axis': self.axis, 'largest': self.largest}
-        self.outputs = {'Out': output, 'Indices': indices}
+        self.inputs = {"X": self.input_data}
+        self.attrs = {"k": self.k, "axis": self.axis, "largest": self.largest}
+        self.outputs = {"Out": output, "Indices": indices}
 
     def set_dtype(self):
         self.dtype = np.int32
@@ -64,8 +64,9 @@ class TestTopkV2NPUOp(OpTest):
         self.largest = True
 
     def set_input_data(self):
-        self.input_data = np.random.choice(
-            10000, size=(10, 20), replace=False).astype(self.dtype)
+        self.input_data = np.random.choice(10000, size=(10, 20), replace=False).astype(
+            self.dtype
+        )
 
     def test_check_output(self):
         self.__class__.no_need_check_grad = True
@@ -76,7 +77,7 @@ class TestTopkV2NPUOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
 
 class TestTopkV2OpFloat16(TestTopkV2NPUOp):
@@ -207,7 +208,7 @@ class TestTopkV2Op4Float64(TestTopkV2OP4Int32):
 class TestTopKAPI(unittest.TestCase):
     def setUp(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         np.random.seed(123)
         self.input_data = np.random.rand(6, 7, 8)
         self.large_input_data = np.random.rand(2, 1030)
@@ -255,19 +256,21 @@ class TestTopKAPI(unittest.TestCase):
         self.assertTrue(np.allclose(paddle_result[1].numpy(), numpy_result[1]))
         # test case for basic test case 7 for the unsorted
         paddle_result = paddle.topk(input_tensor, k=2, axis=1, sorted=False)
-        sort_paddle = numpy_topk(
-            np.array(paddle_result[0].numpy()), axis=1, k=2)
+        sort_paddle = numpy_topk(np.array(paddle_result[0].numpy()), axis=1, k=2)
         numpy_result = numpy_topk(self.input_data, k=2, axis=1)
         self.assertTrue(np.allclose(sort_paddle[0], numpy_result[0]))
 
     def run_static(self, place):
         paddle.enable_static()
-        with paddle.static.program_guard(paddle.static.Program(),
-                                         paddle.static.Program()):
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             input_tensor = paddle.static.data(
-                name="x", shape=[6, 7, 8], dtype="float64")
+                name="x", shape=[6, 7, 8], dtype="float64"
+            )
             large_input_tensor = paddle.static.data(
-                name="large_x", shape=[2, 1030], dtype="float64")
+                name="large_x", shape=[2, 1030], dtype="float64"
+            )
             k_tensor = paddle.static.data(name="k", shape=[1], dtype="int32")
             result1 = paddle.topk(input_tensor, k=2)
             result2 = paddle.topk(input_tensor, k=2, axis=-1)
@@ -285,13 +288,25 @@ class TestTopKAPI(unittest.TestCase):
                 feed={
                     "x": self.input_data,
                     "large_x": self.large_input_data,
-                    "k": np.array([2]).astype("int32")
+                    "k": np.array([2]).astype("int32"),
                 },
                 fetch_list=[
-                    result1[0], result1[1], result2[0], result2[1], result3[0],
-                    result3[1], result4[0], result4[1], result5[0], result5[1],
-                    result6[0], result6[1], result7[0], result7[1]
-                ])
+                    result1[0],
+                    result1[1],
+                    result2[0],
+                    result2[1],
+                    result3[0],
+                    result3[1],
+                    result4[0],
+                    result4[1],
+                    result5[0],
+                    result5[1],
+                    result6[0],
+                    result6[1],
+                    result7[0],
+                    result7[1],
+                ],
+            )
             numpy_result = numpy_topk(self.input_data, k=2)
             self.assertTrue(np.allclose(paddle_result[0], numpy_result[0]))
             self.assertTrue(np.allclose(paddle_result[1], numpy_result[1]))
@@ -304,13 +319,11 @@ class TestTopKAPI(unittest.TestCase):
             self.assertTrue(np.allclose(paddle_result[4], numpy_result[0]))
             self.assertTrue(np.allclose(paddle_result[5], numpy_result[1]))
 
-            numpy_result = numpy_topk(
-                self.input_data, k=2, axis=1, largest=False)
+            numpy_result = numpy_topk(self.input_data, k=2, axis=1, largest=False)
             self.assertTrue(np.allclose(paddle_result[6], numpy_result[0]))
             self.assertTrue(np.allclose(paddle_result[7], numpy_result[1]))
 
-            numpy_result = numpy_topk(
-                self.input_data, k=2, axis=-1, largest=False)
+            numpy_result = numpy_topk(self.input_data, k=2, axis=-1, largest=False)
             self.assertTrue(np.allclose(paddle_result[8], numpy_result[0]))
             self.assertTrue(np.allclose(paddle_result[9], numpy_result[1]))
 
@@ -322,14 +335,14 @@ class TestTopKAPI(unittest.TestCase):
             self.assertTrue(np.allclose(sort_paddle[0], numpy_result[0]))
 
     def test_cases(self):
-        places = [core.CustomPlace('npu', 0)]
+        places = [core.CustomPlace("npu", 0)]
         for place in places:
             self.run_dygraph(place)
             self.run_static(place)
 
     def test_errors(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         paddle.disable_static()
         x = paddle.to_tensor([1, 2, 3])
         with self.assertRaises(BaseException):

--- a/backends/npu/tests/unittests/test_transpose_op_npu.py
+++ b/backends/npu/tests/unittests/test_transpose_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_tril_triu_op_npu.py
+++ b/backends/npu/tests/unittests/test_tril_triu_op_npu.py
@@ -20,7 +20,7 @@ import paddle
 import paddle.fluid as fluid
 import paddle.tensor as tensor
 from paddle.fluid.framework import Program, program_guard
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 
@@ -55,7 +55,7 @@ class TestNPUTrilTriu(OpTest):
             self.place,
             ["X"],
             "Out",
-            check_eager=False,
+            check_dygraph=False,
             max_relative_error=0.009,
             numeric_place=paddle.CPUPlace(),
         )

--- a/backends/npu/tests/unittests/test_truncated_gaussian_random_op_npu.py
+++ b/backends/npu/tests/unittests/test_truncated_gaussian_random_op_npu.py
@@ -16,14 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
 
 paddle.enable_static()
 SEED = 2021
@@ -45,17 +40,20 @@ class TestTruncatedNormal(unittest.TestCase):
                 weight_attr = paddle.framework.ParamAttr(
                     name="linear_weight",
                     initializer=paddle.nn.initializer.TruncatedNormal(
-                        mean=0.0, std=2.0))
+                        mean=0.0, std=2.0
+                    ),
+                )
                 linear = paddle.nn.Linear(
-                    2, 2, weight_attr=weight_attr, bias_attr=False)
+                    2, 2, weight_attr=weight_attr, bias_attr=False
+                )
 
             if run_npu:
-                place = paddle.CustomPlace('npu', 0)
+                place = paddle.CustomPlace("npu", 0)
             else:
                 place = paddle.CPUPlace()
 
             exe = paddle.static.Executor(place)
-            w = exe.run(startup_prog, fetch_list=['linear_weight'])
+            w = exe.run(startup_prog, fetch_list=["linear_weight"])
             return w
 
     def test_npu(self):
@@ -65,5 +63,5 @@ class TestTruncatedNormal(unittest.TestCase):
         self.assertTrue(np.allclose(npu_w, cpu_w))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_uniform_random_op_npu.py
+++ b/backends/npu/tests/unittests/test_uniform_random_op_npu.py
@@ -14,19 +14,15 @@
 
 from __future__ import print_function
 
-import sys
-import subprocess
 import unittest
 import numpy as np
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle
-from paddle.fluid.op import Operator
+from tests.op import Operator
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 
@@ -40,12 +36,7 @@ class TestUniformRandomOp(OpTest):
         self.outputs = {"Out": np.zeros((1000, 784)).astype("float32")}
 
     def init_attrs(self):
-        self.attrs = {
-            "shape": [1000, 784],
-            "min": -5.0,
-            "max": 10.0,
-            "seed": 10
-        }
+        self.attrs = {"shape": [1000, 784], "min": -5.0, "max": 10.0, "seed": 10}
         self.output_hist = output_hist
 
     def test_check_output(self):
@@ -54,20 +45,23 @@ class TestUniformRandomOp(OpTest):
     def verify_output(self, outs):
         hist, prob = self.output_hist(np.array(outs[0]))
         self.assertTrue(
-            np.allclose(
-                hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
+            np.allclose(hist, prob, rtol=0, atol=0.01), "hist: " + str(hist)
+        )
 
     def test_check_api(self):
         places = self._get_places()
         for place in places:
             with fluid.dygraph.base.guard(place=place):
-                out = self.python_api(self.attrs['shape'], 'float32',
-                                      self.attrs['min'], self.attrs['max'],
-                                      self.attrs['seed'])
+                out = self.python_api(
+                    self.attrs["shape"],
+                    "float32",
+                    self.attrs["min"],
+                    self.attrs["max"],
+                    self.attrs["seed"],
+                )
 
     def test_check_api_eager(self):
-        with _test_eager_guard():
-            self.test_check_api()
+        self.test_check_api()
 
 
 class TestUniformRandomOpSelectedRows(unittest.TestCase):
@@ -84,18 +78,14 @@ class TestUniformRandomOpSelectedRows(unittest.TestCase):
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
         op = Operator(
-            "uniform_random",
-            Out="X",
-            shape=[1000, 784],
-            min=-5.0,
-            max=10.0,
-            seed=10)
+            "uniform_random", Out="X", shape=[1000, 784], min=-5.0, max=10.0, seed=10
+        )
         op.run(scope, place)
         self.assertEqual(out.get_tensor().shape(), [1000, 784])
         hist, prob = output_hist(np.array(out.get_tensor()))
         self.assertTrue(
-            np.allclose(
-                hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
+            np.allclose(hist, prob, rtol=0, atol=0.01), "hist: " + str(hist)
+        )
 
 
 def output_hist(out):
@@ -116,17 +106,12 @@ class TestNPUUniformRandomOp(OpTest):
         self.outputs = {"Out": np.zeros((1000, 784)).astype(self.dtype)}
 
     def init_attrs(self):
-        self.attrs = {
-            "shape": [1000, 784],
-            "min": -5.0,
-            "max": 10.0,
-            "seed": 10
-        }
+        self.attrs = {"shape": [1000, 784], "min": -5.0, "max": 10.0, "seed": 10}
         self.output_hist = output_hist
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -137,14 +122,14 @@ class TestNPUUniformRandomOp(OpTest):
     def verify_output(self, outs):
         hist, prob = self.output_hist(np.array(outs[0]))
         self.assertTrue(
-            np.allclose(
-                hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
+            np.allclose(hist, prob, rtol=0, atol=0.01), "hist: " + str(hist)
+        )
 
 
 class TestNPUUniformRandomOpSelectedRows(unittest.TestCase):
     def get_places(self):
         places = [core.CPUPlace()]
-        places.append(core.CustomPlace('npu', 0))
+        places.append(core.CustomPlace("npu", 0))
         return places
 
     def test_check_output(self):
@@ -156,18 +141,14 @@ class TestNPUUniformRandomOpSelectedRows(unittest.TestCase):
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
         op = Operator(
-            "uniform_random",
-            Out="X",
-            shape=[1000, 784],
-            min=-5.0,
-            max=10.0,
-            seed=10)
+            "uniform_random", Out="X", shape=[1000, 784], min=-5.0, max=10.0, seed=10
+        )
         op.run(scope, place)
         self.assertEqual(out.get_tensor().shape(), [1000, 784])
         hist, prob = output_hist(np.array(out.get_tensor()))
         self.assertTrue(
-            np.allclose(
-                hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
+            np.allclose(hist, prob, rtol=0, atol=0.01), "hist: " + str(hist)
+        )
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
+++ b/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
@@ -16,13 +16,9 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-import sys
 
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 
@@ -31,21 +27,21 @@ class TestUnsqueeze2Op(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "unsqueeze2"
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
         self.init_test_case()
         self.x = np.random.random(self.ori_shape).astype("float32")
         self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(self.x)}
         self.init_attrs()
         self.outputs = {
             "Out": self.x.reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float32")
+            "XShape": np.random.random(self.ori_shape).astype("float32"),
         }
 
     def set_npu(self):
         self.__class__.use_custom_device = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, no_check_set=['XShape'])
+        self.check_output_with_place(self.place, no_check_set=["XShape"])
 
     @unittest.skip("skip check_grad because unstable.")
     def test_check_grad(self):

--- a/backends/npu/tests/unittests/test_unstack_op_npu.py
+++ b/backends/npu/tests/unittests/test_unstack_op_npu.py
@@ -15,9 +15,8 @@
 from __future__ import print_function
 
 import numpy as np
-import sys
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 import paddle
 
 paddle.enable_static()
@@ -34,13 +33,13 @@ class TestUnStackOpBase(OpTest):
     def get_y_names(self):
         y_names = []
         for i in range(self.input_dim[self.axis]):
-            y_names.append('y{}'.format(i))
+            y_names.append("y{}".format(i))
         return y_names
 
     def setUp(self):
         self.initDefaultParameters()
         self.initParameters()
-        self.op_type = 'unstack'
+        self.op_type = "unstack"
         self.set_npu()
         self.init_dtype()
 
@@ -54,14 +53,14 @@ class TestUnStackOpBase(OpTest):
         for i in range(self.input_dim[self.axis]):
             tmp.append((y_names[i], np.reshape(outs[i], new_shape)))
 
-        self.inputs = {'X': self.x}
-        self.outputs = {'Y': tmp}
-        self.attrs = {'axis': self.axis, 'num': self.input_dim[self.axis]}
+        self.inputs = {"X": self.x}
+        self.outputs = {"Y": tmp}
+        self.attrs = {"axis": self.axis, "num": self.input_dim[self.axis]}
         # self.attrs = {'axis': self.axis}
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace('npu', 0)
+        self.place = paddle.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -70,7 +69,7 @@ class TestUnStackOpBase(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(self.place, ['X'], self.get_y_names())
+        self.check_grad_with_place(self.place, ["X"], self.get_y_names())
 
 
 class TestStackOp3(TestUnStackOpBase):
@@ -93,5 +92,5 @@ class TestStackOp6(TestUnStackOpBase):
         self.axis = 2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_update_loss_scaling_op_npu.py
+++ b/backends/npu/tests/unittests/test_update_loss_scaling_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 import paddle
 

--- a/backends/npu/tests/unittests/test_where_index_npu.py
+++ b/backends/npu/tests/unittests/test_where_index_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_where_op_npu.py
+++ b/backends/npu/tests/unittests/test_where_op_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
-from tests.op_test import OpTest
+from tests.eager_op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/tests/eager_op_test.py
+++ b/python/tests/eager_op_test.py
@@ -1,0 +1,1 @@
+../../Paddle/python/paddle/fluid/tests/unittests/eager_op_test.py

--- a/python/tests/op.py
+++ b/python/tests/op.py
@@ -1,0 +1,1 @@
+../../Paddle/python/paddle/fluid/tests/unittests/op.py

--- a/python/tests/op_test.py
+++ b/python/tests/op_test.py
@@ -1,1 +1,0 @@
-../../Paddle/python/paddle/fluid/tests/unittests/op_test.py


### PR DESCRIPTION
1.移除单测对op_test.py的依赖，新增对eager_op_test.py的依赖
2.新增mean/mean_raw/mean_grad对fp16的支持，以解决test_prelu_op_npu失败的问题
3.将paddle.fluid.op.Operator升级至op.Operator
4.修复部分失败单测