### PR TITLE
[MPS] Add MPS backend plugin for GPU computing on Macbook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         description: Format files with ClangFormat.
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|xpu|kps)$
+        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|xpu|kps|mm|m)$
 -   repo: local
     hooks:
     -   id: cpplint-cpp-source

--- a/backends/mps/.clang-format
+++ b/backends/mps/.clang-format
@@ -1,0 +1,12 @@
+---
+Language:        ObjC
+BasedOnStyle:  Google
+IndentWidth:     2
+TabWidth:        2
+ContinuationIndentWidth: 4
+AccessModifierOffset: -1  # The private/protected/public has no indent in class
+Standard:  Cpp11 
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackParameters: false
+BinPackArguments: false
+...

--- a/backends/mps/CMakeLists.txt
+++ b/backends/mps/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright(c) 2022 PaddlePaddle Authors.All Rights Reserved.
+# Copyright(c) 2023 PaddlePaddle Authors.All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0(the "License"); you may not use
 # this file except in compliance with the License.You may obtain a copy of the

--- a/backends/mps/CMakeLists.txt
+++ b/backends/mps/CMakeLists.txt
@@ -1,0 +1,112 @@
+# Copyright(c) 2022 PaddlePaddle Authors.All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0(the "License"); you may not use
+# this file except in compliance with the License.You may obtain a copy of the
+# License at
+#
+# http:  // www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.See the
+# License for the specific language governing permissions and limitations under
+# the License
+
+cmake_minimum_required(VERSION 3.10)
+
+project(paddle-mps CXX C)
+
+set(SIGN_IDENTITY
+    ""
+    CACHE STRING "Code signing identity for the dylib")
+
+if(SIGN_IDENTITY STREQUAL "")
+  message(FATAL_ERROR "SIGN_IDENTITY must be set")
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ${SIGN_IDENTITY})
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "YES")
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+
+option(WITH_TESTING "compile with unit testing" OFF)
+option(ON_INFER "compile with inference c++ lib" OFF)
+
+set(PLUGIN_NAME "paddle-mps")
+set(PLUGIN_VERSION "0.0.1")
+
+include(paddle)
+
+include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}
+                    ${CMAKE_SOURCE_DIR}/kernels ${CMAKE_SOURCE_DIR}/runtime)
+link_directories(${PADDLE_LIB_DIR})
+
+file(
+  GLOB_RECURSE PLUGIN_SRCS
+  RELATIVE ${CMAKE_SOURCE_DIR}
+  kernels/*.mm ${CMAKE_SOURCE_DIR} kernels/*.cc
+  ${CMAKE_SOURCE_DIR}/runtime/*.mm)
+list(APPEND PLUGIN_SRCS runtime/runtime.cc)
+
+# build shared library
+add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SRCS})
+if(ON_INFER)
+  target_link_directories(${PLUGIN_NAME} PRIVATE ${PADDLE_INFERENCE_LIB_DIR})
+  target_link_libraries(${PLUGIN_NAME} PRIVATE paddle_inference)
+else()
+  target_link_libraries(${PLUGIN_NAME} PRIVATE ${PADDLE_CORE_LIB})
+endif()
+
+find_library(FOUNDATION_LIBRARY Foundation)
+find_library(METAL_LIBRARY Metal REQUIRED)
+find_library(MPS_LIBRARY MetalPerformanceShaders REQUIRED)
+find_library(MPS_GRAPH_LIBRARY MetalPerformanceShadersGraph REQUIRED)
+target_link_libraries(
+  ${PLUGIN_NAME} PRIVATE ${METAL_LIBRARY} ${MPS_LIBRARY} ${FOUNDATION_LIBRARY}
+                         ${MPS_GRAPH_LIBRARY})
+
+# packing wheel package
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+               ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+
+add_custom_command(
+  TARGET ${PLUGIN_NAME}
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.dylib
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+  COMMAND
+    install_name_tool -change @loader_path/../libs/ ${PADDLE_CORE_LIB}
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/lib${PLUGIN_NAME}.dylib
+  COMMENT "Creating plugin dirrectories------>>>")
+
+find_package(
+  Python
+  COMPONENTS Interpreter
+  REQUIRED)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py bdist_wheel
+  DEPENDS ${PLUGIN_NAME}
+  COMMENT "Packing whl packages------>>>")
+
+add_custom_target(python_package ALL
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp)
+
+if(WITH_TESTING)
+  set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../Paddle")
+  enable_testing()
+  add_subdirectory(tests)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp
+    COMMAND cp -r ${CMAKE_SOURCE_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR})
+  add_custom_target(python_tests ALL
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp)
+endif()

--- a/backends/mps/README.md
+++ b/backends/mps/README.md
@@ -1,0 +1,53 @@
+#PaddlePaddle Custom Device Implementaion for Custom CPU
+
+
+Please refer to the following steps to compile, install and verify the custom device implementaion for MPS backend.
+
+## Prepare environment and source code
+
+```bash
+# 1. clone the source code recursively along with Paddle source code
+git clone --recursive https://github.com/PaddlePaddle/PaddleCustomDevice
+cd PaddleCustomDevice
+
+# 2. execute the following commands to update submodule
+git submodule sync
+git submodule update --remote --init --recursive
+```
+
+## Compile and Install
+
+```bash
+#navigate to implementaion for MPS backend.
+cd backends/mps
+
+#before compiling, ensure that Paddle is installed, you can run the following command
+pip install paddlepaddle
+#create the build directory and navigate in
+mkdir build && cd build
+
+#Currently, a SIGN_IDENTITY is required to sign the dynamic library(.dylib)
+cmake ..-D SIGN_IDENTITY=<Your Identity>
+make -j8
+
+#using pip to install the output
+pip install dist/paddle_mps*.whl
+```
+
+## Verification
+
+```bash
+#list available hardware backends
+python -c "import paddle; print(paddle.device.get_all_custom_device_type())"
+
+#expected output
+['mps']
+
+#run a simple model
+python -c "import paddle; paddle.set_device('mps'); print(paddle.nn.functional.softmax(paddle.ones([2])))"
+
+#expected similar output
+... ...
+Tensor(shape=[2], dtype=float32, place=Place(mps:0), stop_gradient=True,
+       [0.50000000, 0.50000000])
+```

--- a/backends/mps/cmake/paddle.cmake
+++ b/backends/mps/cmake/paddle.cmake
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+find_package(Python ${PYTHON_VERSION} REQUIRED COMPONENTS Interpreter
+                                                          Development)
+
+if(DEFINED ENV{PADDLE_CUSTOM_PATH})
+  set(PADDLE_DIR $ENV{PADDLE_CUSTOM_PATH})
+else()
+  execute_process(
+    COMMAND
+      "${Python_EXECUTABLE}" "-c"
+      "import re, paddle; print(re.compile('/__init__.py.*').sub('',paddle.__file__))"
+    OUTPUT_VARIABLE PADDLE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(NOT EXISTS ${PADDLE_DIR})
+  message(FATAL_ERROR "NO Installed Paddle Found in ${PADDLE_DIR}")
+endif()
+
+set(PADDLE_INC_DIR "${PADDLE_DIR}/include/")
+set(PADDLE_LIB_DIR "${PADDLE_DIR}/fluid/")
+
+include_directories(${PADDLE_INC_DIR})
+
+if(EXISTS "${PADDLE_LIB_DIR}/libpaddle.so")
+  set(paddle_lib_name libpaddle.so)
+elseif(EXISTS "${PADDLE_LIB_DIR}/core_avx.so")
+  set(paddle_lib_name core_avx.so)
+else()
+  set(paddle_lib_name core_noavx.so)
+  message(WANRING "Cannot find core_avx.so, using core_noavx.so instead.")
+endif()
+
+find_library(PADDLE_CORE_LIB ${paddle_lib_name} PATHS ${PADDLE_LIB_DIR})
+if(NOT PADDLE_CORE_LIB)
+  message(FATAL "${paddle_lib_name} NOT found in ${PADDLE_LIB_DIR}")
+else()
+  message(STATUS "Found PADDLE_CORE_LIB: ${PADDLE_CORE_LIB}")
+endif()

--- a/backends/mps/kernels/op_utils.h
+++ b/backends/mps/kernels/op_utils.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include "runtime/mps_stream.h"
+
+namespace mps {
+
+MPSGraph *make_mps_graph();
+
+MPSGraphTensor *mpsGraphRankedPlaceHolder(MPSGraph *mpsGraph,
+                                          MPSDataType dataType,
+                                          MPSShape *mpsShape);
+
+void runMPSGraph(MPSStream *mpsStream,
+                 MPSGraph *mpsGraph,
+                 NSDictionary *feeds,
+                 NSDictionary *results);
+
+}  // namespace mps

--- a/backends/mps/kernels/op_utils.mm
+++ b/backends/mps/kernels/op_utils.mm
@@ -1,0 +1,23 @@
+#include "op_utils.h"
+
+namespace mps {
+
+MPSGraph *make_mps_graph() {
+  MPSGraph *mpsGraph = [[MPSGraph new] autorelease];
+  return mpsGraph;
+}
+
+MPSGraphTensor *mpsGraphRankedPlaceHolder(MPSGraph *mpsGraph,
+                                          MPSDataType dataType,
+                                          MPSShape *mpsShape) {
+  return [mpsGraph placeholderWithShape:mpsShape dataType:dataType name:nil];
+}
+
+void runMPSGraph(MPSStream *mpsStream,
+                 MPSGraph *mpsGraph,
+                 NSDictionary *feeds,
+                 NSDictionary *results) {
+  mpsStream->executeMPSGraph(mpsGraph, feeds, results, SyncType::COMMIT_AND_WAIT);
+}
+
+}  // namespace mps

--- a/backends/mps/kernels/op_utils.mm
+++ b/backends/mps/kernels/op_utils.mm
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "op_utils.h"
 
 namespace mps {

--- a/backends/mps/kernels/softmax_impl.h
+++ b/backends/mps/kernels/softmax_impl.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+namespace mps_kernel {
+
+void Softmax(const float* in,
+             float* out,
+             std::vector<int64_t> x_shape,
+             std::vector<int64_t> out_shape,
+             int axis);
+
+}  // namespace mps_kernel

--- a/backends/mps/kernels/softmax_impl.mm
+++ b/backends/mps/kernels/softmax_impl.mm
@@ -1,0 +1,42 @@
+#include "softmax_impl.h"
+#include <Foundation/Foundation.h>
+#include "mps_stream.h"
+#include "op_utils.h"
+
+namespace mps_kernel {
+
+void Softmax(const float *in,
+             float *out,
+             std::vector<int64_t> x_shape,
+             std::vector<int64_t> out_shape,
+             int axis) {
+  mps::MPSStream *stream = mps::getCurrentMPSStream();
+  @autoreleasepool {
+    MPSGraph *mpsGraph = mps::make_mps_graph();
+
+    int length = x_shape[0];
+    NSArray<NSNumber *> *input_shape = @[ @(length) ];
+
+    MPSGraphTensor *inputTensor =
+        mps::mpsGraphRankedPlaceHolder(mpsGraph, MPSDataTypeFloat32, input_shape);
+    MPSGraphTensor *outputTensor = [mpsGraph softMaxWithTensor:inputTensor axis:axis name:nil];
+
+    id<MTLBuffer> in_buffer = (id<MTLBuffer>)in;
+    id<MTLBuffer> out_buffer = (id<MTLBuffer>)out;
+
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *feeds = @{
+      inputTensor : [[[MPSGraphTensorData alloc] initWithMTLBuffer:in_buffer
+                                                             shape:input_shape
+                                                          dataType:MPSDataTypeFloat32] autorelease]
+    };
+    NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *results = @{
+      outputTensor : [[[MPSGraphTensorData alloc] initWithMTLBuffer:out_buffer
+                                                              shape:input_shape
+                                                           dataType:MPSDataTypeFloat32] autorelease]
+    };
+
+    runMPSGraph(stream, mpsGraph, feeds, results);
+  }
+}
+
+}  // namespace mps_kernel

--- a/backends/mps/kernels/softmax_kernel.cc
+++ b/backends/mps/kernels/softmax_kernel.cc
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/softmax_impl.h"
+#include "paddle/phi/capi/all.h"
+
+namespace custom_kernel {
+
+template <typename T>
+void SoftmaxKernel(const phi::Context& dev_ctx,
+                   const phi::DenseTensor& x,
+                   int axis,
+                   phi::DenseTensor* out) {
+  const int rank = x.dims().size();
+  // allocate memory on device.
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) {
+    return;
+  }
+
+  if (rank == 0) {
+    out_data[0] = static_cast<T>(1);
+    return;
+  }
+
+  mps_kernel::Softmax(x.data<T>(), out->data<T>(), x.dims(), out->dims(), axis);
+}
+
+}  // namespace custom_kernel
+
+PD_BUILD_PHI_KERNEL(
+    softmax, mps, ALL_LAYOUT, custom_kernel::SoftmaxKernel, float) {}

--- a/backends/mps/kernels/softmax_kernel.cc
+++ b/backends/mps/kernels/softmax_kernel.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/backends/mps/runtime/mps_device.h
+++ b/backends/mps/runtime/mps_device.h
@@ -30,7 +30,6 @@ class MPSDevice {
   ~MPSDevice();
 
  private:
-  static MPSDevice* _device;
   MTLDevice_t _mtl_device;
   MPSDevice();
 };

--- a/backends/mps/runtime/mps_device.h
+++ b/backends/mps/runtime/mps_device.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Foundation/Foundation.h>
+#include <MetalPerformanceShaders/MetalPerformanceShaders.h>
+typedef id<MTLDevice> MTLDevice_t;
+typedef id<MTLFunction> MTLFunction_t;
+
+namespace mps {
+
+class MPSDevice {
+ public:
+  MPSDevice(const MPSDevice& other) = delete;
+  void operator=(const MPSDevice&) = delete;
+  static MPSDevice* getInstance();
+  MTLDevice_t device() { return _mtl_device; }
+  ~MPSDevice();
+
+ private:
+  static MPSDevice* _device;
+  MTLDevice_t _mtl_device;
+  MPSDevice();
+};
+
+}  // namespace mps

--- a/backends/mps/runtime/mps_device.mm
+++ b/backends/mps/runtime/mps_device.mm
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <memory>
 #include <mutex>
 

--- a/backends/mps/runtime/mps_device.mm
+++ b/backends/mps/runtime/mps_device.mm
@@ -1,0 +1,68 @@
+#include <memory>
+#include <mutex>
+
+#include "mps_device.h"
+#include "mps_runtime.h"
+#include "mps_stream.h"
+
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+
+namespace mps {
+
+static std::unique_ptr<MPSDevice> mps_device;
+static std::once_flag mpsdev_init;
+
+MPSDevice *MPSDevice::getInstance() {
+  std::call_once(mpsdev_init, [] { mps_device = std::unique_ptr<MPSDevice>(new MPSDevice()); });
+  return mps_device.get();
+}
+
+MPSDevice::~MPSDevice() {
+  [_mtl_device release];
+  _mtl_device = nil;
+}
+
+MPSDevice::MPSDevice() : _mtl_device(nil) { _mtl_device = MTLCreateSystemDefaultDevice(); }
+
+bool init_device() {
+  return MPSDevice::getInstance()->device() != nil && getCurrentMPSStream() != nil;
+}
+
+bool alloc_memory(void **ptr, size_t size) {
+  *ptr =
+      (void *)[MPSDevice::getInstance()->device() newBufferWithLength:size
+                                                              options:MTLResourceStorageModeShared];
+  return *ptr ? true : false;
+}
+
+bool dealloc_memory(void *ptr) {
+  if (!ptr) return true;
+  id<MTLBuffer> buffer = (id<MTLBuffer>)ptr;
+  [buffer release];
+  ptr = 0;
+  return true;
+}
+
+bool memcpy_d2d(void *dst, const void *src, size_t size) {
+  if (!dst || !src) return false;
+  id<MTLBuffer> dst_buffer = (id<MTLBuffer>)dst;
+  id<MTLBuffer> src_buffer = (id<MTLBuffer>)src;
+  memcpy([dst_buffer contents], [src_buffer contents], size);
+  return true;
+}
+
+bool memcpy_d2h(void *dst, const void *src, size_t size) {
+  if (!dst || !src) return false;
+  id<MTLBuffer> src_buffer = (id<MTLBuffer>)src;
+  memcpy(dst, [src_buffer contents], size);
+  return true;
+}
+
+bool memcpy_h2d(void *dst, const void *src, size_t size) {
+  if (!dst || !src) return false;
+  id<MTLBuffer> dst_buffer = (id<MTLBuffer>)dst;
+  memcpy([dst_buffer contents], src, size);
+  return true;
+}
+
+}  // namespace mps

--- a/backends/mps/runtime/mps_runtime.h
+++ b/backends/mps/runtime/mps_runtime.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace mps {
+
+bool init_device(void);
+
+bool alloc_memory(void** ptr, size_t size);
+
+bool dealloc_memory(void* ptr);
+
+bool memcpy_d2d(void* dst, const void* src, size_t size);
+
+bool memcpy_d2h(void* dst, const void* src, size_t size);
+
+bool memcpy_h2d(void* dst, const void* src, size_t size);
+
+}  // namespace mps

--- a/backends/mps/runtime/mps_stream.h
+++ b/backends/mps/runtime/mps_stream.h
@@ -33,7 +33,10 @@ enum class SyncType {
 
 class MPSStream {
  public:
-  MPSStream();
+  MPSStream(const MPSStream &other) = delete;
+  void operator=(const MPSStream &) = delete;
+
+  static MPSStream *getInstance();
 
   ~MPSStream();
   MTLCommandQueue_t commandQueue() const { return _commandQueue; }
@@ -53,11 +56,11 @@ class MPSStream {
   MTLCommandQueue_t stream() const { return _commandQueue; }
 
  private:
+  MPSStream();
   MTLCommandQueue_t _commandQueue = nil;
   MPSCommandBuffer *_commandBuffer = nil;
   MPSGraphExecutionDescriptor *_executionDescriptor = nil;
   void _flush(bool commitAndWait) const;
-
   dispatch_queue_t _serialQueue = nullptr;
 };
 

--- a/backends/mps/runtime/mps_stream.h
+++ b/backends/mps/runtime/mps_stream.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Foundation/Foundation.h>
+#include <MetalPerformanceShadersGraph/MetalPerformanceShadersGraph.h>
+#include "runtime/mps_device.h"
+
+typedef id<MTLCommandQueue> MTLCommandQueue_t;
+typedef id<MTLCommandBuffer> MTLCommandBuffer_t;
+typedef id<MTLDevice> MTLDevice_t;
+
+namespace mps {
+
+enum class SyncType {
+  NONE,
+  COMMIT,
+  COMMIT_AND_WAIT,
+  COMMIT_AND_CONTINUE,
+};
+
+class MPSStream {
+ public:
+  MPSStream();
+
+  ~MPSStream();
+  MTLCommandQueue_t commandQueue() const { return _commandQueue; }
+  dispatch_queue_t queue() const { return _serialQueue; }
+
+  MPSCommandBuffer *commandBuffer();
+  void commit(bool flush);
+  void commitAndWait();
+  void commitAndContinue();
+  void synchronize(SyncType syncType);
+  void flush();
+  void executeMPSGraph(MPSGraph *mpsGraph,
+                       NSDictionary *feeds,
+                       NSDictionary *results,
+                       SyncType syncType = SyncType::NONE);
+
+  MTLCommandQueue_t stream() const { return _commandQueue; }
+
+ private:
+  MTLCommandQueue_t _commandQueue = nil;
+  MPSCommandBuffer *_commandBuffer = nil;
+  MPSGraphExecutionDescriptor *_executionDescriptor = nil;
+  void _flush(bool commitAndWait) const;
+
+  dispatch_queue_t _serialQueue = nullptr;
+};
+
+MPSStream *getCurrentMPSStream();
+
+MPSStream *getDefaultMPSStream();
+
+}  // namespace mps

--- a/backends/mps/runtime/mps_stream.mm
+++ b/backends/mps/runtime/mps_stream.mm
@@ -1,0 +1,140 @@
+#include "mps_stream.h"
+
+namespace mps {
+
+#define USE_COMMIT_AND_CONTINUE 1
+
+MPSStream::MPSStream() {
+  _commandQueue = [MPSDevice::getInstance()->device() newCommandQueue];
+  _serialQueue = dispatch_queue_create("metal gpu stream", nullptr);
+  _executionDescriptor = [MPSGraphExecutionDescriptor new];
+  _executionDescriptor.completionHandler =
+      ^(NSDictionary<MPSGraphTensor *, MPSGraphTensorData *> *resultsDictionary,
+        NSError *_Nullable error) {
+      };
+}
+
+MPSStream::~MPSStream() {
+  [_commandQueue release];
+  _commandQueue = nil;
+  [_executionDescriptor release];
+
+  assert(_commandBuffer == nil);
+}
+
+MPSCommandBuffer *MPSStream::commandBuffer() {
+  if (!_commandBuffer) {
+    _commandBuffer = [MPSCommandBuffer commandBufferFromCommandQueue:_commandQueue].retain;
+  }
+
+  return _commandBuffer;
+}
+
+void MPSStream::synchronize(SyncType syncType) {
+  if (!_commandBuffer) return;
+  switch (syncType) {
+    case SyncType::NONE:
+      // typically in GPU to GPU copies we won't commit explicitly
+      break;
+    case SyncType::COMMIT:
+      flush();
+      break;
+    case SyncType::COMMIT_AND_WAIT:
+      commitAndWait();
+      break;
+    case SyncType::COMMIT_AND_CONTINUE:
+      commitAndContinue();
+      break;
+  }
+}
+
+void MPSStream::commit(bool doFlush) {
+#if USE_COMMIT_AND_CONTINUE
+  [commandBuffer() commitAndContinue];
+#else
+  if (doFlush) {
+    flush();
+  }
+#endif
+}
+
+void MPSStream::commitAndWait() {
+  assert(_commandBuffer);
+  [_commandBuffer commit];
+  [_commandBuffer waitUntilCompleted];
+  [_commandBuffer release];
+  _commandBuffer = nil;
+}
+
+void MPSStream::commitAndContinue() {
+  assert(_commandBuffer);
+  [_commandBuffer commitAndContinue];
+}
+
+void MPSStream::flush() {
+  if (_commandBuffer) {
+    [_commandBuffer commit];
+    [_commandBuffer release];
+    _commandBuffer = nil;
+  }
+}
+
+void MPSStream::_flush(bool commitAndWait) const {
+  assert(_commandBuffer);
+  [_commandBuffer commit];
+  if (commitAndWait) {
+    [_commandBuffer waitUntilCompleted];
+  }
+  [_commandBuffer release];
+}
+
+void MPSStream::executeMPSGraph(MPSGraph *mpsGraph,
+                                NSDictionary *feeds,
+                                NSDictionary *results,
+                                SyncType syncType) {
+  dispatch_sync(_serialQueue, ^() {
+#if USE_COMMIT_AND_CONTINUE
+    [mpsGraph encodeToCommandBuffer:commandBuffer()
+                              feeds:feeds
+                   targetOperations:nil
+                  resultsDictionary:results
+                executionDescriptor:_executionDescriptor];
+    // mostly the syncType is NONE, but in some cases we may want to sync and
+    // wait (e.g., gatherViewTensor)
+    synchronize(syncType);
+#else
+    commit(true);
+    [mpsGraph runAsyncWithMTLCommandQueue:_commandQueue
+                                    feeds:feeds
+                         targetOperations:nil
+                        resultsDictionary:results
+                      executionDescriptor:_executionDescriptor];
+#endif
+  });
+}
+
+class MPSStreamImpl {
+ public:
+  static MPSStream *getInstance();
+
+ private:
+  static MPSStream *_stream;
+  MPSStreamImpl();
+};
+
+MPSStream *MPSStreamImpl::_stream = nullptr;
+
+MPSStream *MPSStreamImpl::getInstance() {
+  if (_stream == nullptr) {
+    _stream = new MPSStream();
+  }
+  return _stream;
+}
+
+MPSStreamImpl::MPSStreamImpl() {}
+
+MPSStream *getCurrentMPSStream() { return getDefaultMPSStream(); }
+
+MPSStream *getDefaultMPSStream() { return MPSStreamImpl::getInstance(); }
+
+}  // namespace mps

--- a/backends/mps/runtime/mps_stream.mm
+++ b/backends/mps/runtime/mps_stream.mm
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "mps_stream.h"
 
 namespace mps {

--- a/backends/mps/runtime/runtime.cc
+++ b/backends/mps/runtime/runtime.cc
@@ -1,0 +1,218 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <semaphore.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+
+#include "paddle/phi/backends/device_ext.h"
+#include "runtime/mps_runtime.h"
+
+#define MEMORY_FRACTION 0.5f
+
+C_Status Init() { return C_SUCCESS; }
+
+C_Status InitDevice(const C_Device device) {
+  return mps::init_device() ? C_SUCCESS : C_FAILED;
+}
+
+C_Status SetDevice(const C_Device device) { return C_SUCCESS; }
+
+C_Status GetDevice(const C_Device device) {
+  device->id = 0;
+  return C_SUCCESS;
+}
+
+C_Status DestroyDevice(const C_Device device) { return C_SUCCESS; }
+
+C_Status Finalize() { return C_SUCCESS; }
+
+C_Status GetDevicesCount(size_t* count) {
+  *count = 1;
+  return C_SUCCESS;
+}
+
+C_Status GetDevicesList(size_t* devices) {
+  devices[0] = 0;
+  return C_SUCCESS;
+}
+
+C_Status MemCpyH2D(const C_Device device,
+                   void* dst,
+                   const void* src,
+                   size_t size) {
+  return mps::memcpy_h2d(dst, src, size) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status MemCpyD2H(const C_Device device,
+                   void* dst,
+                   const void* src,
+                   size_t size) {
+  return mps::memcpy_d2h(dst, src, size) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status MemCpyD2D(const C_Device device,
+                   void* dst,
+                   const void* src,
+                   size_t size) {
+  return mps::memcpy_d2d(dst, src, size) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status AsyncMemCpy(const C_Device device,
+                     C_Stream stream,
+                     void* dst,
+                     const void* src,
+                     size_t size) {
+  return mps::memcpy_h2d(dst, src, size) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status HostAllocate(const C_Device device, void** ptr, size_t size) {
+  auto data = malloc(size);
+  if (data) {
+    *ptr = data;
+    return C_SUCCESS;
+  } else {
+    *ptr = nullptr;
+  }
+  return C_FAILED;
+}
+
+C_Status DeviceAllocate(const C_Device device, void** ptr, size_t size) {
+  return mps::alloc_memory(ptr, size) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status HostDeallocate(const C_Device device, void* ptr, size_t size) {
+  free(ptr);
+  return C_SUCCESS;
+}
+
+C_Status DeviceDeallocate(const C_Device device, void* ptr, size_t size) {
+  return mps::dealloc_memory(ptr) ? C_SUCCESS : C_FAILED;
+}
+
+C_Status CreateStream(const C_Device device, C_Stream* stream) {
+  stream = nullptr;
+  return C_SUCCESS;
+}
+
+C_Status DestroyStream(const C_Device device, C_Stream stream) {
+  return C_SUCCESS;
+}
+
+C_Status CreateEvent(const C_Device device, C_Event* event) {
+  return C_SUCCESS;
+}
+
+C_Status RecordEvent(const C_Device device, C_Stream stream, C_Event event) {
+  return C_SUCCESS;
+}
+
+C_Status DestroyEvent(const C_Device device, C_Event event) {
+  return C_SUCCESS;
+}
+
+C_Status SyncDevice(const C_Device device) { return C_SUCCESS; }
+
+C_Status SyncStream(const C_Device device, C_Stream stream) {
+  return C_SUCCESS;
+}
+
+C_Status SyncEvent(const C_Device device, C_Event event) { return C_SUCCESS; }
+
+C_Status StreamWaitEvent(const C_Device device,
+                         C_Stream stream,
+                         C_Event event) {
+  return C_SUCCESS;
+}
+
+C_Status VisibleDevices(size_t* devices) { return C_SUCCESS; }
+
+C_Status DeviceMemStats(const C_Device device,
+                        size_t* total_memory,
+                        size_t* free_memory) {
+  float memusage;
+  FILE* fp;
+  char buffer[1024];
+  size_t byte_read;
+  char* pos;
+
+  fp = fopen("/proc/meminfo", "r");
+  byte_read = fread(buffer, 1, sizeof(buffer), fp);
+  fclose(fp);
+  buffer[byte_read] = '\0';
+  pos = strstr(buffer, "MemTotal:");
+  sscanf(pos, "MemTotal: %lu kB", total_memory);
+  pos = strstr(pos, "MemFree:");
+  sscanf(pos, "MemFree: %lu kB", free_memory);
+  *total_memory = *total_memory * 1024;
+  *free_memory = *free_memory * 1024;
+  *free_memory = *free_memory * MEMORY_FRACTION;
+
+  return C_SUCCESS;
+}
+
+C_Status DeviceMinChunkSize(const C_Device device, size_t* size) {
+  *size = 512;
+  return C_SUCCESS;
+}
+
+void InitPlugin(CustomRuntimeParams* params) {
+  PADDLE_CUSTOM_RUNTIME_CHECK_VERSION(params);
+  params->device_type = "mps";
+  params->sub_device_type = "v0.1";
+
+  memset(
+      reinterpret_cast<void*>(params->interface), 0, sizeof(C_DeviceInterface));
+
+  params->interface->initialize = Init;
+  params->interface->finalize = Finalize;
+
+  params->interface->init_device = InitDevice;
+  params->interface->set_device = SetDevice;
+  params->interface->get_device = GetDevice;
+  params->interface->deinit_device = DestroyDevice;
+
+  params->interface->create_stream = CreateStream;
+  params->interface->destroy_stream = DestroyStream;
+
+  params->interface->create_event = CreateEvent;
+  params->interface->destroy_event = DestroyEvent;
+  params->interface->record_event = RecordEvent;
+
+  params->interface->synchronize_device = SyncDevice;
+  params->interface->synchronize_stream = SyncStream;
+  params->interface->synchronize_event = SyncEvent;
+  params->interface->stream_wait_event = StreamWaitEvent;
+
+  params->interface->memory_copy_h2d = MemCpyH2D;
+  params->interface->memory_copy_d2d = MemCpyD2D;
+  params->interface->memory_copy_d2h = MemCpyD2H;
+  params->interface->device_memory_allocate = DeviceAllocate;
+  params->interface->host_memory_allocate = HostAllocate;
+  params->interface->device_memory_deallocate = DeviceDeallocate;
+  params->interface->host_memory_deallocate = HostDeallocate;
+
+  params->interface->get_device_count = GetDevicesCount;
+  params->interface->get_device_list = GetDevicesList;
+  params->interface->device_memory_stats = DeviceMemStats;
+  params->interface->device_min_chunk_size = DeviceMinChunkSize;
+}

--- a/backends/mps/setup.py.in
+++ b/backends/mps/setup.py.in
@@ -1,0 +1,40 @@
+from setuptools import setup, Distribution
+
+packages = []
+package_data = {}
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
+
+setup(
+    name = '@CMAKE_PROJECT_NAME@',
+    version='@PLUGIN_VERSION@',
+    description='Paddle MPS plugin',
+    long_description='',
+    long_description_content_type="text/markdown",
+    author_email="Paddle-better@baidu.com",
+    maintainer="PaddlePaddle",
+    maintainer_email="Paddle-better@baidu.com",
+    project_urls={},
+    license='Apache Software License',
+    packages= [
+        'paddle-plugins',
+    ],
+    include_package_data=True,
+    package_data = {
+        '': ['*.dylib', '*.h', '*.py', '*.hpp'],
+    },
+    package_dir = {
+        '': 'python',
+    },
+    zip_safe=False,
+    distclass=BinaryDistribution,
+    entry_points={
+        'console_scripts': [
+        ]
+    },
+    classifiers=[
+    ],
+    keywords='Paddle MPS plugin',
+)


### PR DESCRIPTION
This pull request adds the MPS backend plugin to PaddlePaddle, allowing it to use GPU computing on Macbook. The first kernel, Softmax, has been added to the plugin. 
1. The plugin can be compiled, installed, and used by following the instructions in the README.md  
2. PaddlePaddle needs to expose capi on macOS. A pull request will be submitted soon. 
3. Note that the dylib in this plugin currently requires developer signing.
4. Currently all workloads are commited to the default stream, as same as pytorch does. 