### PR TITLE
[Test Mv]fix rm rnn cause err

### DIFF
--- a/backends/npu/tests/unittests/test_rnn_op_npu.py
+++ b/backends/npu/tests/unittests/test_rnn_op_npu.py
@@ -19,7 +19,8 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-
+import sys
+sys.path.append("../../../../../Paddle/test/rnn")
 from tests.convert import get_params_for_net
 from tests.rnn_numpy import LSTM, GRU
 


### PR DESCRIPTION
Paddle [pr52967](https://github.com/PaddlePaddle/Paddle/pull/52967) rm rnn will cause npu rnn ut err.