### PR TITLE
Change paddle-plugins to paddle_custom_device

### DIFF
--- a/backends/custom_cpu/CMakeLists.txt
+++ b/backends/custom_cpu/CMakeLists.txt
@@ -1,16 +1,16 @@
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License
 
 cmake_minimum_required(VERSION 3.10)
 
@@ -18,58 +18,73 @@ project(paddle-custom-cpu CXX C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
-option(WITH_TESTING    "compile with unit testing"        ON)
-option(ON_INFER        "compile with inference c++ lib"   OFF)
+option(WITH_TESTING "compile with unit testing" ON)
+option(ON_INFER "compile with inference c++ lib" OFF)
 
-set(PLUGIN_NAME        "paddle-custom-cpu")
-set(PLUGIN_VERSION     "0.0.1")
+set(PLUGIN_NAME "paddle-custom-cpu")
+set(PLUGIN_VERSION "0.0.1")
 
 include(paddle)
 
-include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/kernels)
+include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}
+                    ${CMAKE_SOURCE_DIR}/kernels)
 link_directories(${PADDLE_LIB_DIR})
 
 add_definitions(-std=c++14)
 
-file(GLOB_RECURSE PLUGIN_SRCS RELATIVE ${CMAKE_SOURCE_DIR} kernels/*.cc)
+file(
+  GLOB_RECURSE PLUGIN_SRCS
+  RELATIVE ${CMAKE_SOURCE_DIR}
+  kernels/*.cc)
 list(APPEND PLUGIN_SRCS runtime/runtime.cc)
 
 # build shared library
 add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SRCS})
-if (ON_INFER)
-target_link_directories(${PLUGIN_NAME} PRIVATE ${PADDLE_INFERENCE_LIB_DIR})
-target_link_libraries(${PLUGIN_NAME} PRIVATE paddle_inference)
+if(ON_INFER)
+  target_link_directories(${PLUGIN_NAME} PRIVATE ${PADDLE_INFERENCE_LIB_DIR})
+  target_link_libraries(${PLUGIN_NAME} PRIVATE paddle_inference)
 else()
-target_link_libraries(${PLUGIN_NAME} PRIVATE ${PADDLE_CORE_LIB})
+  target_link_libraries(${PLUGIN_NAME} PRIVATE ${PADDLE_CORE_LIB})
 endif()
 
 # packing wheel package
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
-    ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+               ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 
-add_custom_command(TARGET ${PLUGIN_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
-    COMMENT "Creating plugin dirrectories------>>>"
-)
+add_custom_command(
+  TARGET ${PLUGIN_NAME}
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
+  COMMAND
+    ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
+  COMMENT "Creating plugin dirrectories------>>>")
 
-find_package(Python COMPONENTS Interpreter REQUIRED)
+find_package(
+  Python
+  COMPONENTS Interpreter
+  REQUIRED)
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py bdist_wheel
-    DEPENDS ${PLUGIN_NAME}
-    COMMENT "Packing whl packages------>>>"
-)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py bdist_wheel
+  DEPENDS ${PLUGIN_NAME}
+  COMMENT "Packing whl packages------>>>")
 
-add_custom_target(python_package ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp)
+add_custom_target(python_package ALL
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python/.timestamp)
 
-if (WITH_TESTING)
-set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../Paddle")
-enable_testing()
-add_subdirectory(tests)
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp
-COMMAND cp -r ${CMAKE_SOURCE_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR})
-add_custom_target(python_tests ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp)
+if(WITH_TESTING)
+  set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../Paddle")
+  enable_testing()
+  add_subdirectory(tests)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp
+    COMMAND cp -r ${CMAKE_SOURCE_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR})
+  add_custom_target(python_tests ALL
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tests/.timestamp)
 endif()

--- a/backends/custom_cpu/CMakeLists.txt
+++ b/backends/custom_cpu/CMakeLists.txt
@@ -50,8 +50,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
 add_custom_command(TARGET ${PLUGIN_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
     COMMENT "Creating plugin dirrectories------>>>"
 )
 

--- a/backends/custom_cpu/setup.py.in
+++ b/backends/custom_cpu/setup.py.in
@@ -19,7 +19,7 @@ setup(
     project_urls={},
     license='Apache Software License',
     packages= [
-        'paddle-plugins',
+        'paddle_custom_device',
     ],
     include_package_data=True,
     package_data = {

--- a/backends/custom_cpu/tests/CMakeLists.txt
+++ b/backends/custom_cpu/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ function(py_test_modules TARGET_NAME)
     cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     add_test(NAME ${TARGET_NAME}
-        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle-plugins/ PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/python/paddle/fluid/tests/unittests:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
+        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/ PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/python/paddle/fluid/tests/unittests:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
         # python ${PYTHON_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
         python ${CMAKE_CURRENT_BINARY_DIR}/${py_test_modules_MODULES}.py
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/backends/custom_cpu/tests/CMakeLists.txt
+++ b/backends/custom_cpu/tests/CMakeLists.txt
@@ -1,32 +1,39 @@
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License
 
 function(py_test_modules TARGET_NAME)
-    set(options SERIAL)
-    set(oneValueArgs "")
-    set(multiValueArgs MODULES DEPS ENVS)
-    cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options SERIAL)
+  set(oneValueArgs "")
+  set(multiValueArgs MODULES DEPS ENVS)
+  cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
 
-    add_test(NAME ${TARGET_NAME}
-        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/ PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/python/paddle/fluid/tests/unittests:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
-        # python ${PYTHON_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
-        python ${CMAKE_CURRENT_BINARY_DIR}/${py_test_modules_MODULES}.py
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(
+    NAME ${TARGET_NAME}
+    COMMAND
+      ${CMAKE_COMMAND} -E env
+      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/
+      PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/python/paddle/fluid/tests/unittests:$ENV{PYTHONPATH}
+      ${py_test_modules_ENVS}
+      # python ${PYTHON_SOURCE_DIR}/tools/test_runner.py
+      # ${py_test_modules_MODULES}
+      python ${CMAKE_CURRENT_BINARY_DIR}/${py_test_modules_MODULES}.py
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    if (py_test_modules_SERIAL)
-        set_property(TEST ${TARGET_NAME} PROPERTY RUN_SERIAL 1)
-    endif()
+  if(py_test_modules_SERIAL)
+    set_property(TEST ${TARGET_NAME} PROPERTY RUN_SERIAL 1)
+  endif()
 endfunction()
 
 add_subdirectory(unittests)

--- a/backends/intel_gpu/CMakeLists.txt
+++ b/backends/intel_gpu/CMakeLists.txt
@@ -107,11 +107,11 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory
-          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.so
-    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMENT "Creating plugin dirrectories------>>>")
 
 add_custom_command(

--- a/backends/intel_gpu/setup.py.in
+++ b/backends/intel_gpu/setup.py.in
@@ -19,7 +19,7 @@ setup(
     project_urls={},
     license='Apache Software License',
     packages= [
-        'paddle-plugins',
+        'paddle_custom_device',
     ],
     include_package_data=True,
     package_data = {

--- a/backends/intel_gpu/tests/CMakeLists.txt
+++ b/backends/intel_gpu/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ function(py_test_modules TARGET_NAME)
     NAME ${TARGET_NAME}
     COMMAND
       ${CMAKE_COMMAND} -E env
-      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle-plugins/
+      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/
       PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/python/paddle/fluid/tests/unittests:$ENV{PYTHONPATH}
       ${py_test_modules_ENVS}
       # python ${PYTHON_SOURCE_DIR}/tools/test_runner.py

--- a/backends/mlu/CMakeLists.txt
+++ b/backends/mlu/CMakeLists.txt
@@ -89,11 +89,11 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory
-          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/lib${CUSTOM_MLU_NAME}.so
-    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMENT "Creating custom device dirrectories------>>>")
 
 add_custom_command(

--- a/backends/mlu/setup.py.in
+++ b/backends/mlu/setup.py.in
@@ -19,7 +19,7 @@ setup(
     project_urls={},
     license='Apache Software License',
     packages= [
-        'paddle-plugins',
+        'paddle_custom_device',
     ],
     include_package_data=True,
     package_data = {

--- a/backends/mlu/tests/CMakeLists.txt
+++ b/backends/mlu/tests/CMakeLists.txt
@@ -1,31 +1,37 @@
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License
 
 function(py_test_modules TARGET_NAME)
-    set(options SERIAL)
-    set(oneValueArgs "")
-    set(multiValueArgs MODULES DEPS ENVS)
-    cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(options SERIAL)
+  set(oneValueArgs "")
+  set(multiValueArgs MODULES DEPS ENVS)
+  cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}"
+                        "${multiValueArgs}" ${ARGN})
 
-    add_test(NAME ${TARGET_NAME}
-        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/ PYTHONPATH=${PYTHON_SOURCE_DIR}:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
-        python ${PYTHON_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  add_test(
+    NAME ${TARGET_NAME}
+    COMMAND
+      ${CMAKE_COMMAND} -E env
+      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/
+      PYTHONPATH=${PYTHON_SOURCE_DIR}:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
+      python ${PYTHON_SOURCE_DIR}/tools/test_runner.py
+      ${py_test_modules_MODULES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-    if (py_test_modules_SERIAL)
-        set_property(TEST ${TARGET_NAME} PROPERTY RUN_SERIAL 1)
-    endif()
+  if(py_test_modules_SERIAL)
+    set_property(TEST ${TARGET_NAME} PROPERTY RUN_SERIAL 1)
+  endif()
 endfunction()
 
 py_test_modules(test_MNIST_model MODULES test_MNIST_model)

--- a/backends/mlu/tests/CMakeLists.txt
+++ b/backends/mlu/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ function(py_test_modules TARGET_NAME)
     cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     add_test(NAME ${TARGET_NAME}
-        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle-plugins/ PYTHONPATH=${PYTHON_SOURCE_DIR}:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
+        COMMAND ${CMAKE_COMMAND} -E env CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/ PYTHONPATH=${PYTHON_SOURCE_DIR}:$ENV{PYTHONPATH} ${py_test_modules_ENVS}
         python ${PYTHON_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/backends/mps/CMakeLists.txt
+++ b/backends/mps/CMakeLists.txt
@@ -76,14 +76,14 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/python/
   COMMAND ${CMAKE_COMMAND} -E make_directory
-          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+          ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_CURRENT_BINARY_DIR}/lib${PLUGIN_NAME}.dylib
-    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/
   COMMAND
     install_name_tool -change @loader_path/../libs/ ${PADDLE_CORE_LIB}
-    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle-plugins/lib${PLUGIN_NAME}.dylib
+    ${CMAKE_CURRENT_BINARY_DIR}/python/paddle_custom_device/lib${PLUGIN_NAME}.dylib
   COMMENT "Creating plugin dirrectories------>>>")
 
 find_package(

--- a/backends/mps/setup.py.in
+++ b/backends/mps/setup.py.in
@@ -19,7 +19,7 @@ setup(
     project_urls={},
     license='Apache Software License',
     packages= [
-        'paddle-plugins',
+        'paddle_custom_device',
     ],
     include_package_data=True,
     package_data = {


### PR DESCRIPTION
`python -c "import paddle; print(paddle.device.get_all_custom_device_type())"`，默认路径`paddle_custom_device`检查不到注册的自定义设备，需要手动设置环境变量。

为了与主框架统一路径，将`paddle-plugins`修改为`paddle_custom_device`

前置PR：
#507 
主框架PR修改默认 Custom Device 目录的PR已经合入
https://github.com/PaddlePaddle/Paddle/pull/53020
