### PR TITLE
[NPU]remove stride check in avgpool2d grad

### DIFF
--- a/backends/npu/kernels/pool2d_kernel.cc
+++ b/backends/npu/kernels/pool2d_kernel.cc
@@ -359,13 +359,6 @@ void Pool2dGradKernel(const Context& dev_ctx,
                                      attrs);  // 0: floor, 1: ceil
     runner.Run(dev_ctx.stream());
   } else if (pooling_type == "avg") {
-    PADDLE_ENFORCE(strides[0] == strides[1],
-                   phi::errors::InvalidArgument(
-                       "AvgPoolGrad dose not support Asymmetric strides. but "
-                       "strides = (%d, %d)",
-                       strides[0],
-                       strides[1]));
-
     NpuOpRunner runner;
     runner.SetType("AvgPoolV2Grad");
     runner.AddInput(dev_ctx, phi::vectorize<int>(in_x.dims()));

--- a/backends/npu/tests/unittests/test_pool2d_op_npu.py
+++ b/backends/npu/tests/unittests/test_pool2d_op_npu.py
@@ -897,9 +897,7 @@ class TestAvgPoolAdaptive_AsyPadding_channel_last(TestAvgPoolAdaptive_AsyPadding
 class TestCase1_strides(TestCase1):
     def init_test_case(self):
         self.ksize = [2, 2]
-        # fixme: CANN AvgPoolGradV3 dose not support asymmetric strides
-        # self.strides = [1, 2]
-        self.strides = [2, 2]
+        self.strides = [1, 2]
 
     def init_shape(self):
         self.shape = [2, 3, 8, 8]


### PR DESCRIPTION
经测试，当前CANN版本下AvgPoolV2Grad已支持不对称的strides，故移除反向算子中对strides的检查