### PR TITLE
[cherry-pick] add dtype for gather & assign

### DIFF
--- a/backends/npu/kernels/assign_kernel.cc
+++ b/backends/npu/kernels/assign_kernel.cc
@@ -112,7 +112,8 @@ PD_REGISTER_PLUGIN_KERNEL(assign,
                           int,
                           float,
                           double,
-                          int64_t) {
+                          int64_t,
+                          bool) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
 }
 
@@ -123,7 +124,8 @@ PD_REGISTER_PLUGIN_KERNEL(assign_raw,
                           int,
                           float,
                           double,
-                          int64_t) {
+                          int64_t,
+                          bool) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
 }
 
@@ -134,7 +136,8 @@ PD_REGISTER_PLUGIN_KERNEL(assign_array,
                           int,
                           float,
                           double,
-                          int64_t) {
+                          int64_t,
+                          bool) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
 }
 

--- a/backends/npu/kernels/gather_kernel.cc
+++ b/backends/npu/kernels/gather_kernel.cc
@@ -84,6 +84,7 @@ PD_REGISTER_PLUGIN_KERNEL(gather,
                           custom_kernel::GatherKernel,
                           float,
                           double,
+                          int32_t,
                           int64_t,
                           phi::dtype::float16) {}
 
@@ -93,5 +94,6 @@ PD_REGISTER_PLUGIN_KERNEL(gather_grad,
                           custom_kernel::GatherGradKernel,
                           float,
                           double,
+                          int32_t,
                           int64_t,
                           phi::dtype::float16) {}

--- a/backends/npu/tests/unittests/test_assign_op_npu.py
+++ b/backends/npu/tests/unittests/test_assign_op_npu.py
@@ -52,5 +52,10 @@ class TestAssignInt64(TestAssign):
         self.dtype = np.int64
 
 
+class TestAssignBool(TestAssign):
+    def init_dtype(self):
+        self.dtype = np.bool
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backends/npu/tests/unittests/test_gather_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_op_npu.py
@@ -91,6 +91,20 @@ class TestCase2(TestGatherOp):
         pass
 
 
+class TestCase3(TestGatherOp):
+    def config(self):
+        """
+        For one dimension input
+        """
+        self.x_shape = 100
+        self.x_type = "int32"
+        self.index = [1, 3, 5]
+        self.index_type = "int32"
+
+    def test_check_grad(self):
+        pass
+
+
 class API_TestGather(unittest.TestCase):
     def test_out1(self):
         with fluid.program_guard(fluid.Program(), fluid.Program()):


### PR DESCRIPTION
由于assign kernel的input被定义了`kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);`，在模型中fallback到cpu会有问题，需要修复至2.5分支
