### PR TITLE
[NPU]expand datatype support for clip and index_select

### DIFF
--- a/backends/npu/tests/unittests/test_clip_op_npu.py
+++ b/backends/npu/tests/unittests/test_clip_op_npu.py
@@ -109,6 +109,63 @@ class TestCase5(TestClipOp):
         self.min = 0.5
 
 
+class TestClipInt32(OpTest):
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+        self.place = paddle.CustomPlace("npu", 0)
+
+    def setUp(self):
+        self.set_npu()
+
+        self.inputs = {}
+        self.initTestCase()
+
+        self.op_type = "clip"
+        self.attrs = {}
+        self.attrs["min"] = self.min
+        self.attrs["max"] = self.max
+        if "Min" in self.inputs:
+            min_v = self.inputs["Min"]
+        else:
+            min_v = self.attrs["min"]
+
+        if "Max" in self.inputs:
+            max_v = self.inputs["Max"]
+        else:
+            max_v = self.attrs["max"]
+
+        input = np.random.randint(0, 10, self.shape, self.dtype)
+
+        self.inputs["X"] = input
+        self.outputs = {"Out": np.clip(self.inputs["X"], min_v, max_v)}
+
+    def test_check_output(self):
+        paddle.enable_static()
+        self.check_output_with_place(self.place)
+        paddle.disable_static()
+
+    def test_check_grad_normal(self):
+        pass
+
+    def initTestCase(self):
+        self.dtype = np.int32
+        self.shape = (4, 10, 10)
+        self.max = 7
+        self.min = 2
+        self.inputs["Max"] = np.array([7]).astype(self.dtype)
+        self.inputs["Min"] = np.array([2]).astype(self.dtype)
+
+
+class TestClipInt64(TestClipInt32):
+    def initTestCase(self):
+        self.dtype = np.int64
+        self.shape = (4, 10, 10)
+        self.max = 7
+        self.min = 2
+        self.inputs["Max"] = np.array([7]).astype(self.dtype)
+        self.inputs["Min"] = np.array([2]).astype(self.dtype)
+
+
 class TestClipOpError(unittest.TestCase):
     def test_errors(self):
         paddle.enable_static()

--- a/backends/npu/tests/unittests/test_index_select_op_npu.py
+++ b/backends/npu/tests/unittests/test_index_select_op_npu.py
@@ -103,6 +103,24 @@ class TestNPUIndexSelectCase4(TestNPUIndexSelect):
         self.index_size = 10
 
 
+class TestBpuIndexSelectDouble(TestNPUIndexSelect):
+    def config(self):
+        self.x_shape = (100, 4, 5)
+        self.x_type = np.double
+        self.dim = 1
+        self.index_size = 100
+        self.index_type = np.int64
+
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            self.place,
+            ["X"],
+            "Out",
+            numeric_place=paddle.CPUPlace(),
+            max_relative_error=3e-7,
+        )
+
+
 class TestNPUIndexSelectAPI(unittest.TestCase):
     def input_data(self):
         self.data_x = np.array(

--- a/python/tests/white_list/op_threshold_white_list.py
+++ b/python/tests/white_list/op_threshold_white_list.py
@@ -57,6 +57,7 @@ NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST = [
     "dropout",
     "softmax",
     "matmul_v2",
+    "index_select",
 ]
 
 NEED_FIX_FP64_CHECK_OUTPUT_THRESHOLD_OP_LIST = [


### PR DESCRIPTION
CANN对于int64、float64数据类型的运行效率不高，且经常会出现core dump。故采用cast成int32、float32的方式来实现对int64、float64的支持