### PR TITLE
[NPU]fix slice_grad kernel

### DIFF
--- a/backends/npu/kernels/slice_kernel.cc
+++ b/backends/npu/kernels/slice_kernel.cc
@@ -15,7 +15,7 @@
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
 #include "kernels/funcs/slice_utils.h"
-#include "kernels/funcs/string_helper.h"
+
 namespace custom_kernel {
 
 void UpdateAttr(const phi::DDim& in_dims,
@@ -137,6 +137,12 @@ void SliceGradRawKernel(const Context& dev_ctx,
   std::vector<int> size(rank);
   UpdateAttr(in_dims, axes, starts, ends, &offsets, &size);
 
+  std::vector<std::vector<int64_t>> paddings(rank, std::vector<int64_t>(2));
+  for (int i = 0; i < rank; ++i) {
+    paddings[i][0] = static_cast<int64_t>(offsets[i]);
+    paddings[i][1] = static_cast<int64_t>(in_dims[i] - size[i] - offsets[i]);
+  }
+
   phi::DenseTensor tmp_dout(out_grad);
   auto out_dims = out_grad.dims();
 
@@ -163,37 +169,9 @@ void SliceGradRawKernel(const Context& dev_ctx,
 
   dev_ctx.template Alloc<T>(x_grad);
   auto stream = static_cast<aclrtStream>(dev_ctx.stream());
-
-  if (out_grad.dims().size() != 0) {
-    std::vector<int64_t> paddings(rank * 2);
-    for (int i = 0; i < rank; ++i) {
-      paddings[i * 2 + 0] = static_cast<int64_t>(offsets[i]);
-      paddings[i * 2 + 1] =
-          static_cast<int64_t>(in_dims[i] - size[i] - offsets[i]);
-    }
-    phi::DenseTensor paddings_t;
-    std::vector<int64_t> paddings_dims = {rank, 2};
-    paddings_t.Resize(phi::make_ddim(paddings_dims));
-    dev_ctx.template Alloc<int64_t>(&paddings_t);
-    custom_kernel::TensorFromVector<int64_t>(
-        dev_ctx, paddings, dev_ctx, &paddings_t);
-    paddings_t.Resize(phi::make_ddim(paddings_dims));
-    NpuOpRunner runner;
-    runner.SetType("Pad")
-        .AddInput(tmp_dout)
-        .AddInput(paddings_t)
-        .AddOutput(*x_grad);
-  } else {
-    std::vector<std::vector<int64_t>> paddings(rank, std::vector<int64_t>(2));
-    for (int i = 0; i < rank; ++i) {
-      paddings[i][0] = static_cast<int64_t>(offsets[i]);
-      paddings[i][1] = static_cast<int64_t>(in_dims[i] - size[i] - offsets[i]);
-    }
-
-    const auto& runner =
-        NpuOpRunner("PadD", {tmp_dout}, {*x_grad}, {{"paddings", paddings}});
-    runner.Run(stream);
-  }
+  const auto& runner =
+      NpuOpRunner("PadD", {tmp_dout}, {*x_grad}, {{"paddings", paddings}});
+  runner.Run(stream);
 }
 
 template <typename T, typename Context>

--- a/backends/npu/kernels/slice_kernel.cc
+++ b/backends/npu/kernels/slice_kernel.cc
@@ -167,8 +167,8 @@ void SliceGradRawKernel(const Context& dev_ctx,
   if (out_grad.dims().size() != 0) {
     std::vector<int64_t> paddings(rank * 2);
     for (int i = 0; i < rank; ++i) {
-      paddings[i * rank + 0] = static_cast<int64_t>(offsets[i]);
-      paddings[i * rank + 1] =
+      paddings[i * 2 + 0] = static_cast<int64_t>(offsets[i]);
+      paddings[i * 2 + 1] =
           static_cast<int64_t>(in_dims[i] - size[i] - offsets[i]);
     }
     phi::DenseTensor paddings_t;


### PR DESCRIPTION
1.fix the index error when initialize paddings vector.
2.after fix the index error, precision would not raise in the period of model training, but changing CANN op Pad used in slice_grad back to PadD solves this problem.