### PR TITLE
[DO NOT MERGE]try use cxx std17

### DIFF
--- a/backends/custom_cpu/CMakeLists.txt
+++ b/backends/custom_cpu/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}
                     ${CMAKE_SOURCE_DIR}/kernels)
 link_directories(${PADDLE_LIB_DIR})
 
-add_definitions(-std=c++14)
+add_definitions(-std=c++17)
 
 file(
   GLOB_RECURSE PLUGIN_SRCS


### PR DESCRIPTION
we found an issue in paddle hashmap when use llvm based compiler to build custom device, so i wanna do a experiment in https://github.com/PaddlePaddle/Paddle/pull/54817 to replace hash map with another hashmap. but some test failed on custom cpu