### PR TITLE
[NPU]add log2/log2_grad and sum/sum_grad-fp64

### DIFF
--- a/backends/npu/kernels/activation_kernel.cc
+++ b/backends/npu/kernels/activation_kernel.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cmath>
-
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
 

--- a/backends/npu/kernels/reduce_sum_kernel.cc
+++ b/backends/npu/kernels/reduce_sum_kernel.cc
@@ -233,10 +233,11 @@ void SumGradKernel(const Context& dev_ctx,
   reduce_all = (reduce_all || full_dim || dims.size() == 0);
 
   if (keep_dims || reduce_all) {
-    const auto& runner = NpuOpRunner("BroadcastToD",
-                                     {out_grad_tmp},
-                                     {*x_grad},
-                                     {{"shape", phi::vectorize(x.dims())}});
+    NpuOpRunner runner;
+    runner.SetType("BroadcastTo")
+        .AddInput(out_grad_tmp)
+        .AddInput(dev_ctx, phi::vectorize(x.dims()))
+        .AddOutput(*x_grad);
     runner.Run(stream);
   } else {
     phi::DDim out_dims;
@@ -244,10 +245,11 @@ void SumGradKernel(const Context& dev_ctx,
 
     out_grad_tmp.Resize(out_dims);
 
-    const auto& runner = NpuOpRunner("BroadcastToD",
-                                     {out_grad_tmp},
-                                     {*x_grad},
-                                     {{"shape", phi::vectorize(x.dims())}});
+    NpuOpRunner runner;
+    runner.SetType("BroadcastTo")
+        .AddInput(out_grad_tmp)
+        .AddInput(dev_ctx, phi::vectorize(x.dims()))
+        .AddOutput(*x_grad);
     runner.Run(stream);
   }
 }
@@ -262,7 +264,8 @@ PD_REGISTER_PLUGIN_KERNEL(sum_raw,
                           int32_t,
                           int64_t,
                           phi::dtype::float16,
-                          float) {
+                          float,
+                          double) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 
@@ -274,7 +277,8 @@ PD_REGISTER_PLUGIN_KERNEL(sum,
                           int32_t,
                           int64_t,
                           phi::dtype::float16,
-                          float) {
+                          float,
+                          double) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }
 
@@ -285,6 +289,7 @@ PD_REGISTER_PLUGIN_KERNEL(sum_grad,
                           int32_t,
                           int64_t,
                           phi::dtype::float16,
-                          float) {
+                          float,
+                          double) {
   kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
 }

--- a/backends/npu/tests/unittests/test_reduce_sum_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_sum_op_npu.py
@@ -78,6 +78,11 @@ class TestReduceSumFP16(TestReduceSum):
         self.dtype = np.float16
 
 
+class TestRuceSumFP64(TestReduceSum):
+    def init_dtype(self):
+        self.dtype = np.double
+
+
 class TestReduceSumOp5D(TestReduceSum):
     def initTestCase(self):
         self.shape = (1, 2, 5, 6, 10)


### PR DESCRIPTION
CANN op Log在输入为double类型时计算结果错误，将double输入输出cast成fp32精度不能达标（[issue链接](https://gitee.com/ascend/modelzoo/issues/I7I2RZ?from=project-issue)），故暂时未支持log2算子的double数据类型。