### PR TITLE
[NPU]fix gather_nd/gather_nd_grad and uts

### DIFF
--- a/backends/npu/tests/unittests/test_accuracy_op_npu.py
+++ b/backends/npu/tests/unittests/test_accuracy_op_npu.py
@@ -43,8 +43,8 @@ class TestAccuracy(OpTest):
                     num_correct += 1
                     break
         self.outputs = {
-            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
-            "Correct": np.array([num_correct]).astype("int32"),
+            "Accuracy": np.array(num_correct / float(n)).astype(self.dtype),
+            "Correct": np.array(num_correct).astype("int32"),
             "Total": np.array([n]).astype("int32"),
         }
 
@@ -77,8 +77,8 @@ class TestAccuracy2(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
-            "Correct": np.array([num_correct]).astype("int32"),
+            "Accuracy": np.array(num_correct / float(n)).astype(self.dtype),
+            "Correct": np.array(num_correct).astype("int32"),
             "Total": np.array([n]).astype("int32"),
         }
 
@@ -101,8 +101,8 @@ class TestAccuracyType(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
-            "Correct": np.array([num_correct]).astype("int32"),
+            "Accuracy": np.array(num_correct / float(n)).astype(self.dtype),
+            "Correct": np.array(num_correct).astype("int32"),
             "Total": np.array([n]).astype("int32"),
         }
 
@@ -125,8 +125,8 @@ class TestAccuracyType2(TestAccuracy):
                     num_correct += 1
                     break
         self.outputs = {
-            "Accuracy": np.array([num_correct / float(n)]).astype(self.dtype),
-            "Correct": np.array([num_correct]).astype("int32"),
+            "Accuracy": np.array(num_correct / float(n)).astype(self.dtype),
+            "Correct": np.array(num_correct).astype("int32"),
             "Total": np.array([n]).astype("int32"),
         }
 

--- a/backends/npu/tests/unittests/test_gather_nd_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_nd_op_npu.py
@@ -73,7 +73,7 @@ def test_class2(op_type, typename):
             self.op_type = "gather_nd"
             xnp = np.random.random((5, 20)).astype(typename)
             self.inputs = {"X": xnp, "Index": np.array([1]).astype("int32")}
-            self.outputs = {"Out": self.inputs["X"][self.inputs["Index"]]}
+            self.outputs = {"Out": self.inputs["X"][self.inputs["Index"][-1]]}
 
         def set_npu(self):
             self.__class__.use_custom_device = True

--- a/backends/npu/tests/unittests/test_linspace_op_npu.py
+++ b/backends/npu/tests/unittests/test_linspace_op_npu.py
@@ -125,7 +125,7 @@ class TestLinspaceOpNumOneCase(OpTest):
         }
         self.attrs = {"dtype": int(core.VarDesc.VarType.FP32)}
 
-        self.outputs = {"Out": np.array(10, dtype=dtype)}
+        self.outputs = {"Out": np.array([10], dtype=dtype)}
 
     def set_npu(self):
         self.__class__.use_custom_device = True

--- a/backends/npu/tests/unittests/test_reduce_all_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_all_op_npu.py
@@ -60,7 +60,7 @@ class TestAll8DOp(OpTest):
         self.inputs = {
             "X": np.random.randint(0, 2, (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {"reduce_all": True, "dim": (2, 3, 4)}
+        self.attrs = {"dim": (2, 3, 4)}
         self.outputs = {"Out": self.inputs["X"].all(axis=self.attrs["dim"])}
 
     def test_check_output(self):

--- a/backends/npu/tests/unittests/test_squared_l2_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_squared_l2_norm_op_npu.py
@@ -35,7 +35,7 @@ class TestL2LossOp(OpTest):
         X = np.random.uniform(-1, 1, (13, 19)).astype("float32")
         X[np.abs(X) < self.max_relative_error] = 0.1
         self.inputs = {"X": X}
-        self.outputs = {"Out": np.square(LA.norm(X))}
+        self.outputs = {"Out": np.array([np.square(LA.norm(X))])}
 
     def set_npu(self):
         self.__class__.use_custom_device = True

--- a/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
+++ b/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
@@ -69,7 +69,7 @@ class TestUnsqueeze2Op2(TestUnsqueeze2Op):
     def init_test_case(self):
         self.ori_shape = (20, 5)
         self.axes = ()
-        self.new_shape = (1, 20, 5)
+        self.new_shape = (20, 5)
 
 
 # Correct: Just part of axes be squeezed.

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -3,9 +3,3 @@ test_softmax_with_cross_entropy_op_npu
 test_parallel_dygraph_mp_layers
 test_zero_dim_tensor_npu
 test_dygraph_recompute_for_eager
-test_accuracy_op_npu
-test_gather_nd_op_npu
-test_linspace_op_npu
-test_reduce_all_op_npu
-test_squared_l2_norm_op_npu
-test_unsqueeze_op_npu


### PR DESCRIPTION
1.修复gather_nd/gather_nd_grad kernel在输入index为空时的计算逻辑
2.修复 #657 升级op_test造成的失败单测