### PR TITLE
[NPU] optim index_sample

### DIFF
--- a/backends/npu/kernels/index_sample_kernel.cc
+++ b/backends/npu/kernels/index_sample_kernel.cc
@@ -28,108 +28,115 @@ void IndexSampleGather(const Context& dev_ctx,
   auto index_length = index_dims[1];
   auto stream = dev_ctx.stream();
 
-  phi::DenseTensor tmp_input;
-  phi::DenseTensorMeta input_meta = {input->dtype(),
-                                     phi::make_ddim({input->numel()})};
-  tmp_input.set_meta(input_meta);
-  dev_ctx.template Alloc<T>(&tmp_input);
-  TensorCopy(dev_ctx, *input, false, &tmp_input);
-  tmp_input.Resize({input->numel()});
-  std::vector<phi::DenseTensor> tmp_output;
-  for (auto i = 0; i < batch_size; ++i) {
-    // adds
-    phi::DenseTensor tmp_index, tmp_slice_t, trans_index;
-    tmp_index.Resize(index->dims());
-    tmp_slice_t.Resize(phi::make_ddim({index_length}));
-    trans_index.Resize(index->dims());
-    dev_ctx.template Alloc<int32_t>(&tmp_index);
-    dev_ctx.template Alloc<int32_t>(&tmp_slice_t);
-    dev_ctx.template Alloc<int32_t>(&trans_index);
-    if (index->dtype() == phi::DataType::INT64) {
-      const auto& cast_runner = NpuOpRunner(
-          "Cast", {*index}, {trans_index}, {{"dst_type", ACL_INT32}});
-      cast_runner.Run(stream);
-      const auto& adds_runner =
-          NpuOpRunner("Adds",
-                      {trans_index},
-                      {tmp_index},
-                      {{"value", static_cast<float>(i * input_dims[1])}});
-      adds_runner.Run(stream);
-    } else {
-      const auto& adds_runner =
-          NpuOpRunner("Adds",
-                      {*index},
-                      {tmp_index},
-                      {{"value", static_cast<float>(i * input_dims[1])}});
-      adds_runner.Run(stream);
+  // NPU implementation depends on spliting input in the first dimension.
+  // When the input shape is (100,1), this implementation costs lots of time
+  // to Slice and Gather. It makes more sense when input shape is (1,100).
+  if (input_dims[1] > input_dims[0] * 100) {
+    phi::DenseTensor tmp_input;
+    phi::DenseTensorMeta input_meta = {input->dtype(),
+                                       phi::make_ddim({input->numel()})};
+    tmp_input.set_meta(input_meta);
+    dev_ctx.template Alloc<T>(&tmp_input);
+    TensorCopy(dev_ctx, *input, false, &tmp_input);
+    tmp_input.Resize({input->numel()});
+    std::vector<phi::DenseTensor> tmp_output;
+    for (auto i = 0; i < batch_size; ++i) {
+      // adds
+      phi::DenseTensor tmp_index, tmp_slice_t, trans_index;
+      tmp_index.Resize(index->dims());
+      tmp_slice_t.Resize(phi::make_ddim({index_length}));
+      trans_index.Resize(index->dims());
+      dev_ctx.template Alloc<int32_t>(&tmp_index);
+      dev_ctx.template Alloc<int32_t>(&tmp_slice_t);
+      dev_ctx.template Alloc<int32_t>(&trans_index);
+      if (index->dtype() == phi::DataType::INT64) {
+        const auto& cast_runner = NpuOpRunner(
+            "Cast", {*index}, {trans_index}, {{"dst_type", ACL_INT32}});
+        cast_runner.Run(stream);
+        const auto& adds_runner =
+            NpuOpRunner("Adds",
+                        {trans_index},
+                        {tmp_index},
+                        {{"value", static_cast<float>(i * input_dims[1])}});
+        adds_runner.Run(stream);
+      } else {
+        const auto& adds_runner =
+            NpuOpRunner("Adds",
+                        {*index},
+                        {tmp_index},
+                        {{"value", static_cast<float>(i * input_dims[1])}});
+        adds_runner.Run(stream);
+      }
+      tmp_index.Resize({index->numel()});
+      // slice
+      NpuOpRunner runner1;
+      runner1.SetType("Slice")
+          .AddInput(tmp_index)
+          .AddInput(dev_ctx, std::vector<int32_t>{i * index_length})
+          .AddInput(dev_ctx, std::vector<int32_t>{index_length})
+          .AddOutput(tmp_slice_t)
+          .Run(stream);
+      // gather
+      phi::DenseTensor tmp_out_t;
+      phi::DenseTensorMeta meta = {tmp_input.dtype(),
+                                   phi::make_ddim({index_length})};
+      tmp_out_t.set_meta(meta);
+      if (tmp_input.dtype() == phi::DataType::FLOAT32) {
+        dev_ctx.template Alloc<float>(&tmp_out_t);
+      } else if (tmp_input.dtype() == phi::DataType::INT32) {
+        dev_ctx.template Alloc<int32_t>(&tmp_out_t);
+      } else if (tmp_input.dtype() == phi::DataType::INT64) {
+        dev_ctx.template Alloc<int64_t>(&tmp_out_t);
+      } else if (tmp_input.dtype() == phi::DataType::FLOAT16) {
+        dev_ctx.template Alloc<phi::dtype::float16>(&tmp_out_t);
+      }
+
+      NpuOpRunner gather_runner;
+      gather_runner.SetType("GatherV2")
+          .AddInput(tmp_input)
+          .AddInput(tmp_slice_t)
+          .AddInput(dev_ctx, std::vector<int32_t>{0})
+          .AddOutput(tmp_out_t)
+          .Run(stream);
+      tmp_output.push_back(tmp_out_t);
     }
-    tmp_index.Resize({index->numel()});
-    // slice
-    NpuOpRunner runner1;
-    runner1.SetType("Slice")
-        .AddInput(tmp_index)
-        .AddInput(dev_ctx, std::vector<int32_t>{i * index_length})
-        .AddInput(dev_ctx, std::vector<int32_t>{index_length})
-        .AddOutput(tmp_slice_t)
-        .Run(stream);
-    // gather
-    phi::DenseTensor tmp_out_t;
-    phi::DenseTensorMeta meta = {tmp_input.dtype(),
-                                 phi::make_ddim({index_length})};
-    tmp_out_t.set_meta(meta);
-    if (tmp_input.dtype() == phi::DataType::FLOAT32) {
-      dev_ctx.template Alloc<float>(&tmp_out_t);
-    } else if (tmp_input.dtype() == phi::DataType::INT32) {
-      dev_ctx.template Alloc<int32_t>(&tmp_out_t);
-    } else if (tmp_input.dtype() == phi::DataType::INT64) {
-      dev_ctx.template Alloc<int64_t>(&tmp_out_t);
+
+    // concat
+    std::vector<std::string> names;
+    names.emplace_back("concat_dim");
+    for (size_t i = 0; i < tmp_output.size(); ++i) {
+      names.emplace_back("x" + std::to_string(i));
     }
+    NpuOpRunner concat_runner;
+    concat_runner.SetType("Concat")
+        .AddInput(dev_ctx, std::move(std::vector<int>(1, 0)))
+        .AddInputs(tmp_output)
+        .AddOutput(*out)
+        .AddAttr("N", static_cast<int>(tmp_output.size()))
+        .AddInputNames(names);
+    concat_runner.Run(stream);
+  } else {
+    // CPU implementation for index
+    std::vector<T> gather_index_vec;
+    std::vector<T> index_vec;
+    TensorToVector(dev_ctx, *index, dev_ctx, &index_vec);
+    for (auto i = 0; i < batch_size; ++i) {
+      for (auto j = 0; j < index_length; j++) {
+        gather_index_vec.push_back(i);
+        gather_index_vec.push_back(index_vec[i * index_length + j]);
+      }
+    }
+    phi::DenseTensor gather_index;
+    TensorFromVector(dev_ctx, gather_index_vec, dev_ctx, &gather_index);
+    gather_index.Resize({batch_size, index_length, 2});
 
-    NpuOpRunner gather_runner;
-    gather_runner.SetType("GatherV2")
-        .AddInput(tmp_input)
-        .AddInput(tmp_slice_t)
-        .AddInput(dev_ctx, std::vector<int32_t>{0})
-        .AddOutput(tmp_out_t)
-        .Run(stream);
-    tmp_output.push_back(tmp_out_t);
+    NpuOpRunner runner;
+    runner.SetType("GatherNd")
+        .AddInput(*input)
+        .AddInput(gather_index)
+        .AddOutput(*out);
+    runner.Run(dev_ctx.stream());
   }
-
-  // concat
-  std::vector<std::string> names;
-  names.emplace_back("concat_dim");
-  for (size_t i = 0; i < tmp_output.size(); ++i) {
-    names.emplace_back("x" + std::to_string(i));
-  }
-  NpuOpRunner concat_runner;
-  concat_runner.SetType("Concat")
-      .AddInput(dev_ctx, std::move(std::vector<int>(1, 0)))
-      .AddInputs(tmp_output)
-      .AddOutput(*out)
-      .AddAttr("N", static_cast<int>(tmp_output.size()))
-      .AddInputNames(names);
-  concat_runner.Run(stream);
-
-  // CPU implementation for index
-  // std::vector<T> gather_index_vec;
-  // std::vector<T> index_vec;
-  // TensorToVector(dev_ctx, *index, dev_ctx, &index_vec);
-  // for (auto i = 0; i < batch_size; ++i) {
-  //   for (auto j = 0; j < index_length; j++) {
-  //     gather_index_vec.push_back(i);
-  //     gather_index_vec.push_back(index_vec[i * index_length + j]);
-  //   }
-  // }
-  // phi::DenseTensor gather_index;
-  // TensorFromVector(dev_ctx, gather_index_vec, dev_ctx, &gather_index);
-  // gather_index.Resize({batch_size, index_length, 2});
-
-  // NpuOpRunner runner;
-  // runner.SetType("GatherNd")
-  //     .AddInput(*input)
-  //     .AddInput(gather_index)
-  //     .AddOutput(*out);
-  // runner.Run(dev_ctx.stream());
 }
 
 template <typename T, typename Context>

--- a/backends/npu/kernels/index_sample_kernel.cc
+++ b/backends/npu/kernels/index_sample_kernel.cc
@@ -26,26 +26,110 @@ void IndexSampleGather(const Context& dev_ctx,
   auto input_dims = input->dims();
   auto batch_size = input_dims[0];
   auto index_length = index_dims[1];
+  auto stream = dev_ctx.stream();
 
-  std::vector<T> gather_index_vec;
-  std::vector<T> index_vec;
-  TensorToVector(dev_ctx, *index, dev_ctx, &index_vec);
+  phi::DenseTensor tmp_input;
+  phi::DenseTensorMeta input_meta = {input->dtype(),
+                                     phi::make_ddim({input->numel()})};
+  tmp_input.set_meta(input_meta);
+  dev_ctx.template Alloc<T>(&tmp_input);
+  TensorCopy(dev_ctx, *input, false, &tmp_input);
+  tmp_input.Resize({input->numel()});
+  std::vector<phi::DenseTensor> tmp_output;
   for (auto i = 0; i < batch_size; ++i) {
-    for (auto j = 0; j < index_length; j++) {
-      gather_index_vec.push_back(i);
-      gather_index_vec.push_back(index_vec[i * index_length + j]);
+    // adds
+    phi::DenseTensor tmp_index, tmp_slice_t, trans_index;
+    tmp_index.Resize(index->dims());
+    tmp_slice_t.Resize(phi::make_ddim({index_length}));
+    trans_index.Resize(index->dims());
+    dev_ctx.template Alloc<int32_t>(&tmp_index);
+    dev_ctx.template Alloc<int32_t>(&tmp_slice_t);
+    dev_ctx.template Alloc<int32_t>(&trans_index);
+    if (index->dtype() == phi::DataType::INT64) {
+      const auto& cast_runner = NpuOpRunner(
+          "Cast", {*index}, {trans_index}, {{"dst_type", ACL_INT32}});
+      cast_runner.Run(stream);
+      const auto& adds_runner =
+          NpuOpRunner("Adds",
+                      {trans_index},
+                      {tmp_index},
+                      {{"value", static_cast<float>(i * input_dims[1])}});
+      adds_runner.Run(stream);
+    } else {
+      const auto& adds_runner =
+          NpuOpRunner("Adds",
+                      {*index},
+                      {tmp_index},
+                      {{"value", static_cast<float>(i * input_dims[1])}});
+      adds_runner.Run(stream);
     }
-  }
-  phi::DenseTensor gather_index;
-  TensorFromVector(dev_ctx, gather_index_vec, dev_ctx, &gather_index);
-  gather_index.Resize({batch_size, index_length, 2});
+    tmp_index.Resize({index->numel()});
+    // slice
+    NpuOpRunner runner1;
+    runner1.SetType("Slice")
+        .AddInput(tmp_index)
+        .AddInput(dev_ctx, std::vector<int32_t>{i * index_length})
+        .AddInput(dev_ctx, std::vector<int32_t>{index_length})
+        .AddOutput(tmp_slice_t)
+        .Run(stream);
+    // gather
+    phi::DenseTensor tmp_out_t;
+    phi::DenseTensorMeta meta = {tmp_input.dtype(),
+                                 phi::make_ddim({index_length})};
+    tmp_out_t.set_meta(meta);
+    if (tmp_input.dtype() == phi::DataType::FLOAT32) {
+      dev_ctx.template Alloc<float>(&tmp_out_t);
+    } else if (tmp_input.dtype() == phi::DataType::INT32) {
+      dev_ctx.template Alloc<int32_t>(&tmp_out_t);
+    } else if (tmp_input.dtype() == phi::DataType::INT64) {
+      dev_ctx.template Alloc<int64_t>(&tmp_out_t);
+    }
 
-  NpuOpRunner runner;
-  runner.SetType("GatherNd")
-      .AddInput(*input)
-      .AddInput(gather_index)
-      .AddOutput(*out);
-  runner.Run(dev_ctx.stream());
+    NpuOpRunner gather_runner;
+    gather_runner.SetType("GatherV2")
+        .AddInput(tmp_input)
+        .AddInput(tmp_slice_t)
+        .AddInput(dev_ctx, std::vector<int32_t>{0})
+        .AddOutput(tmp_out_t)
+        .Run(stream);
+    tmp_output.push_back(tmp_out_t);
+  }
+
+  // concat
+  std::vector<std::string> names;
+  names.emplace_back("concat_dim");
+  for (size_t i = 0; i < tmp_output.size(); ++i) {
+    names.emplace_back("x" + std::to_string(i));
+  }
+  NpuOpRunner concat_runner;
+  concat_runner.SetType("Concat")
+      .AddInput(dev_ctx, std::move(std::vector<int>(1, 0)))
+      .AddInputs(tmp_output)
+      .AddOutput(*out)
+      .AddAttr("N", static_cast<int>(tmp_output.size()))
+      .AddInputNames(names);
+  concat_runner.Run(stream);
+
+  // CPU implementation for index
+  // std::vector<T> gather_index_vec;
+  // std::vector<T> index_vec;
+  // TensorToVector(dev_ctx, *index, dev_ctx, &index_vec);
+  // for (auto i = 0; i < batch_size; ++i) {
+  //   for (auto j = 0; j < index_length; j++) {
+  //     gather_index_vec.push_back(i);
+  //     gather_index_vec.push_back(index_vec[i * index_length + j]);
+  //   }
+  // }
+  // phi::DenseTensor gather_index;
+  // TensorFromVector(dev_ctx, gather_index_vec, dev_ctx, &gather_index);
+  // gather_index.Resize({batch_size, index_length, 2});
+
+  // NpuOpRunner runner;
+  // runner.SetType("GatherNd")
+  //     .AddInput(*input)
+  //     .AddInput(gather_index)
+  //     .AddOutput(*out);
+  // runner.Run(dev_ctx.stream());
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
use the combination of op instead of calculating index on cpu

以单测运行时间为baseline, 经过测试, npu实现/cpu实现时间对比如下表：
|     | 单测  | 单测中第二个维度*10 | 单测中第二个维度*100 | 单测中第二个维度*1000 |
|  ----  | ----  | ----  | ----  | ----  |
| npu实现   | 61.37s  | 257.37 s  | 950.02 s  | 9974.39 s  |
| cpu实现  | 34.67s | 119.73 s | 963.58 s | 37975.51s | 

并且从实现逻辑中可可以清楚的得到，当输入的tensor的第二个维度远大于第一个维度时，npu计算会具有明显的加速意义；但是当第一维度大于第二维度时，例如（100，1）, npu的实现会拆分输入至100个小tensor，会更加耗时；

将代码按照input shape来选择不同的逻辑实现