### PR TITLE
[custom cpu] Do not download the Paddle submodule to avoid the Paddle PY3-ci timeout when WITH_TESTING=OFF

### DIFF
--- a/backends/custom_cpu/CMakeLists.txt
+++ b/backends/custom_cpu/CMakeLists.txt
@@ -24,6 +24,9 @@ option(ON_INFER "compile with inference c++ lib" OFF)
 set(PLUGIN_NAME "paddle-custom-cpu")
 set(PLUGIN_VERSION "0.0.1")
 
+if(NOT WITH_TESTING)
+  set(NO_PADDLE_SUBMODULE ON)
+endif()
 include(paddle)
 
 include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}

--- a/cmake/paddle.cmake
+++ b/cmake/paddle.cmake
@@ -52,6 +52,10 @@ else()
   message(STATUS "PADDLE_CORE_LIB: ${PADDLE_CORE_LIB}")
 endif()
 
+if(NO_PADDLE_SUBMODULE)
+  return()
+endif()
+
 # submodule Paddle first
 get_filename_component(REPO_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../"
                        ABSOLUTE)


### PR DESCRIPTION
rt.