### PR TITLE
compatible with paddle.base

### DIFF
--- a/cmake/paddle.cmake
+++ b/cmake/paddle.cmake
@@ -34,6 +34,10 @@ endif()
 set(PADDLE_INC_DIR "${PADDLE_DIR}/include/")
 set(PADDLE_LIB_DIR "${PADDLE_DIR}/fluid/")
 
+if(NOT EXISTS ${PADDLE_LIB_DIR})
+  set(PADDLE_LIB_DIR "${PADDLE_DIR}/base/")
+endif()
+
 include_directories(${PADDLE_INC_DIR})
 
 if(EXISTS "${PADDLE_LIB_DIR}/libpaddle.so")


### PR DESCRIPTION
现Paddle主仓库要将paddle/fluid重命名为paddle/base
- 迁移过程中发现py3流水线中test/custom_runtime下相关单测链接paddle动态库路径出错，
   因此需对CustomDevice中相关动态库路径进行修改
- 相关PR：https://github.com/PaddlePaddle/Paddle/pull/56281