### PR TITLE
[NPU]fix batch_norm_grad when input is 5D

### DIFF
--- a/backends/npu/kernels/batch_norm_kernel.cc
+++ b/backends/npu/kernels/batch_norm_kernel.cc
@@ -352,6 +352,17 @@ void BatchNormGradKernel(
     inv_runner.Run(stream);
   }
 
+  // BN3DTrainingUpdateGrad will throw output size mismatch if output tensor in
+  // NCHW format, we should change output tensor format same with input tensor
+  // format NDCHW or NDHWC
+  phi::DenseTensorMeta meta = {
+      phi::DataType::FLOAT32, d_scale->dims(), x_tensor.layout()};
+
+  if (x_dims.size() == 5) {
+    d_scale->set_meta(meta);
+    d_bias->set_meta(meta);
+  }
+
   NpuOpRunner runner_update;
   runner_update.SetType(update_name)
       .AddInput(dy_tensor)


### PR DESCRIPTION
本地测试结果及单测结果如下：
![604b8d7eaaaea6850d636c0a1f96766b](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/50285351/cc58cfe0-5c33-4099-a263-88bd215025df)

![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/50285351/7c2d2651-1aaa-4ed6-9d28-358e5be80681)
