### PR TITLE
[NPU] add support for launching host callback

### DIFF
--- a/backends/npu/runtime/runtime.cc
+++ b/backends/npu/runtime/runtime.cc
@@ -53,6 +53,8 @@ void SecondaryStream::Create(aclrtStream aicore_stream) {
 
 void SecondaryStream::Destroy(aclrtStream aicore_stream) {
   RUN_CHECK(aicpu_streams.find(aicore_stream) != aicpu_streams.cend());
+  HostCallbackManager::Instance().ReleaseProcessWorker(
+      aicpu_streams[aicore_stream]);
   ACL_CHECK(aclrtDestroyStream(aicpu_streams[aicore_stream]));
   aicpu_streams.erase(aicore_stream);
 }
@@ -244,6 +246,7 @@ C_Status ReleaseDevice(const C_Device device) {
 }
 
 C_Status Finalize() {
+  HostCallbackManager::Instance().ReleaseAllProcessWorkers();
   if (global_allocator_list) {
     delete global_allocator_list;
     global_allocator_list = nullptr;
@@ -378,6 +381,7 @@ C_Status CreateStream(const C_Device device, C_Stream *stream) {
 }
 
 C_Status DestroyStream(const C_Device device, C_Stream stream) {
+  HostCallbackManager::Instance().ReleaseProcessWorker(stream);
   ACL_CHECK(aclrtDestroyStream(reinterpret_cast<aclrtStream>(stream)));
   SecondaryStream::Instance().Destroy(reinterpret_cast<aclrtStream>(stream));
   return C_SUCCESS;


### PR DESCRIPTION
- ACL_CALLBACK_NO_BLOCK: 
- ACL_CALLBACK_BLOCK: 

```
template <typename T, typename Context>
void AbsKernel(const Context& dev_ctx,
               const phi::DenseTensor& x,
               phi::DenseTensor* out) {
  dev_ctx.template Alloc<T>(out);

  auto stream = dev_ctx.stream();

  HostCallbackManager::Instance().Launch(
      stream, []() { std::cout << "hello, world" << std::endl; });
  const auto& runner = NpuOpRunner("Abs", {x}, {*out}, {});
  runner.Run(stream);
}
```

![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/25691046/ac4c1c2c-d006-416b-941f-178ffdc48275)

