### PR TITLE
[MLU] add static print kernel.

### DIFF
--- a/backends/mlu/kernels/data_kernel.cc
+++ b/backends/mlu/kernels/data_kernel.cc
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/mlu_baseop.h"
+#include "kernels/funcs/mlu_funcs.h"
+#include "paddle/phi/kernels/funcs/tensor_formatter.h"
+
+namespace custom_kernel {
+
+const char kForward[] = "FORWARD";
+const char kBackward[] = "BACKWARD";
+
+template <typename T, typename Context>
+void PrintKernel(const Context& dev_ctx,
+                 const phi::DenseTensor& x,
+                 int first_n,
+                 const std::string& message,
+                 int summarize,
+                 bool print_tensor_name,
+                 bool print_tensor_type,
+                 bool print_tensor_shape,
+                 bool print_tensor_layout,
+                 bool print_tensor_lod,
+                 const std::string& print_phase,
+                 bool is_forward,
+                 phi::DenseTensor* out) {
+  TensorCopy(dev_ctx, x, false, out);
+  phi::DenseTensorMeta meta = {x.dtype(), x.dims()};
+  out->set_meta(meta);
+
+  if ((is_forward && print_phase == kBackward) ||
+      (!is_forward && print_phase == kForward)) {
+    return;
+  }
+
+  paddle::funcs::TensorFormatter formatter;
+  const std::string& name = print_tensor_name ? "var" : "";
+  formatter.SetPrintTensorType(print_tensor_type);
+  formatter.SetPrintTensorShape(print_tensor_shape);
+  formatter.SetPrintTensorLod(print_tensor_lod);
+  formatter.SetPrintTensorLayout(print_tensor_layout);
+  formatter.SetSummarize(summarize);
+  formatter.Print(x, name, message);
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(print_kernel,
+                          mlu,
+                          ALL_LAYOUT,
+                          custom_kernel::PrintKernel,
+                          bool,
+                          float,
+                          int32_t,
+                          int64_t,
+                          double,
+                          phi::float16) {}

--- a/backends/mlu/tests/unittests/test_static_print_mlu.py
+++ b/backends/mlu/tests/unittests/test_static_print_mlu.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+
+import paddle
+
+paddle.enable_static()
+np.random.seed(10)
+
+
+class TestNewIrPrint(unittest.TestCase):
+    def test_with_new_ir(self):
+        paddle.enable_static()
+        place = paddle.CustomPlace("mlu", 0)
+        exe = paddle.static.Executor(place)
+
+        main_program = paddle.static.Program()
+        new_scope = paddle.static.Scope()
+        with paddle.static.scope_guard(new_scope):
+            with paddle.static.program_guard(main_program):
+                x = paddle.ones([2, 2], dtype="float32")
+                y = paddle.ones([2, 2], dtype="float32")
+
+                z = x + y
+                z = paddle.static.Print(z)
+
+            out = exe.run(main_program, {}, fetch_list=[z.name])
+
+        gold_res = np.ones([2, 2], dtype="float32") * 2
+
+        np.testing.assert_array_equal(out[0], gold_res)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Print intermediate tensors for static-mode debugging usage. Please refer to [static-print](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/static/Print_cn.html#daimashili).

```python
x = paddle.full(shape=[2, 3], fill_value=3, dtype='int64')
out = paddle.static.Print(x, message="The content of input layer:")
```

**Note**: The output of *THE* `Print` node should be assigned to avoid breaking the computation graph.

Print looks like the following:
```
Variable: tmp_0
   - lod: {}
   - place: Place(mlu:0)
   - shape: [2, 2]
   - layout: NCHW
   - dtype: float32
   - data: [2 2 2 2]
```