### PR TITLE
remove fluid api in uts

### DIFF
--- a/backends/custom_cpu/tests/unittests/test_argsort_op.py
+++ b/backends/custom_cpu/tests/unittests/test_argsort_op.py
@@ -17,14 +17,14 @@ from __future__ import print_function
 import unittest
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import numpy as np
 import six
-import paddle.fluid.core as core
+import paddle.base.core as core
 
-from paddle.fluid.framework import Program, grad_var_name
-from paddle.fluid.executor import Executor
-from paddle.fluid.backward import append_backward
+from paddle.base.framework import Program, grad_var_name
+from paddle.base.executor import Executor
+from paddle.base.backward import append_backward
 
 paddle.enable_static()
 
@@ -95,7 +95,7 @@ class TestArgsortOpCPU(unittest.TestCase):
             self.input_shape, self.axis, self.descending, self.dtype
         )
 
-        with fluid.program_guard(self.main_program, self.startup_program):
+        with base.program_guard(self.main_program, self.startup_program):
             x = paddle.static.data(
                 name="x", shape=[-1] + self.input_shape, dtype=self.dtype
             )
@@ -103,12 +103,12 @@ class TestArgsortOpCPU(unittest.TestCase):
             label = paddle.static.data(
                 name="label", shape=[-1] + self.input_shape, dtype=self.dtype
             )
-            self.sorted_x, self.index = fluid.layers.argsort(
+            self.sorted_x, self.index = base.layers.argsort(
                 input=x, axis=self.axis, descending=self.descending
             )
             self.sorted_x.stop_gradient = False
-            loss = fluid.layers.elementwise_mul(self.sorted_x, label)
-            self.loss = fluid.layers.reduce_sum(loss)
+            loss = base.layers.elementwise_mul(self.sorted_x, label)
+            self.loss = base.layers.reduce_sum(loss)
 
     def forward(self):
         self.feed_map = {
@@ -144,7 +144,7 @@ class TestArgsortOpCPU(unittest.TestCase):
     def test_backward(self, numeric_grad_delta=1e-5, max_relative_error=1e-7):
         self.check_forward()
 
-        with fluid.program_guard(self.main_program, self.startup_program):
+        with base.program_guard(self.main_program, self.startup_program):
             append_backward(self.loss)
 
         ana_grad = [np.array(x) for x in self.backward()]
@@ -289,14 +289,14 @@ class TestArgsortErrorOnCPU(unittest.TestCase):
         self.place = core.CustomPlace("custom_cpu", 0)
 
     def test_error(self):
-        def test_fluid_var_type():
-            with fluid.program_guard(fluid.Program()):
+        def test_base_var_type():
+            with base.program_guard(base.Program()):
                 x = [1]
-                output = fluid.layers.argsort(input=x)
-            self.assertRaises(TypeError, test_fluid_var_type)
+                output = base.layers.argsort(input=x)
+            self.assertRaises(TypeError, test_base_var_type)
 
         def test_paddle_var_type():
-            with fluid.program_guard(fluid.Program()):
+            with base.program_guard(base.Program()):
                 x = [1]
                 output = paddle.argsort(input=x)
             self.assertRaises(TypeError, test_paddle_var_type)
@@ -318,7 +318,7 @@ class TestArgsort(unittest.TestCase):
         self.data = np.random.rand(*self.input_shape)
 
     def test_api(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             input = paddle.static.data(
                 name="input", shape=self.input_shape, dtype="float64"
             )
@@ -326,7 +326,7 @@ class TestArgsort(unittest.TestCase):
             output = paddle.argsort(input, axis=self.axis)
             output2 = paddle.argsort(input, axis=self.axis, descending=True)
 
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             result, result2 = exe.run(
                 feed={"input": self.data}, fetch_list=[output, output2]
             )

--- a/backends/custom_cpu/tests/unittests/test_cast_op.py
+++ b/backends/custom_cpu/tests/unittests/test_cast_op.py
@@ -18,9 +18,9 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base.core as core
+import paddle.base as base
+from paddle.base import Program, program_guard
 from op_test import OpTest, convert_uint16_to_float, convert_float_to_uint16
 
 paddle.enable_static()
@@ -119,8 +119,8 @@ class TestCastOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of cast_op must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([[-1]]), [[1]], fluid.CustomPlace("custom_cpu", 0)
+            x1 = base.create_lod_tensor(
+                np.array([[-1]]), [[1]], base.CustomPlace("custom_cpu", 0)
             )
             self.assertRaises(TypeError, paddle.cast, x1, "int32")
 

--- a/backends/custom_cpu/tests/unittests/test_compare_op.py
+++ b/backends/custom_cpu/tests/unittests/test_compare_op.py
@@ -20,9 +20,9 @@ import unittest
 import numpy
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+import paddle.base.core as core
+from paddle.base import Program, program_guard
 
 
 def get_places(self):
@@ -54,9 +54,9 @@ def create_test_class(op_type, typename, callback):
                 a = paddle.static.data(name="a", shape=[-1, 2], dtype="int16")
                 if self.op_type == "less_than":
                     self.assertRaises(
-                        TypeError, fluid.layers.less_than, x=x, y=y, force_cpu=1
+                        TypeError, base.layers.less_than, x=x, y=y, force_cpu=1
                     )
-                op = eval("fluid.layers.%s" % self.op_type)
+                op = eval("base.layers.%s" % self.op_type)
                 self.assertRaises(TypeError, op, x=x, y=y, cond=1)
                 self.assertRaises(TypeError, op, x=x, y=a)
                 self.assertRaises(TypeError, op, x=a, y=y)
@@ -85,7 +85,7 @@ def create_paddle_case(op_type, callback):
             self.input_x = np.array([1, 2, 3, 4]).astype(np.int64)
             self.input_y = np.array([1, 3, 2, 4]).astype(np.int64)
             self.real_result = callback(self.input_x, self.input_y)
-            self.place = fluid.CustomPlace("custom_cpu", 0)
+            self.place = base.CustomPlace("custom_cpu", 0)
             if core.is_compiled_with_cuda():
                 self.place = paddle.CustomPlace("custom_cpu", 0)
 
@@ -96,7 +96,7 @@ def create_paddle_case(op_type, callback):
                 y = paddle.static.data(name="y", shape=[4], dtype="int64")
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
-                exe = fluid.Executor(self.place)
+                exe = base.Executor(self.place)
                 (res,) = exe.run(
                     feed={"x": self.input_x, "y": self.input_y}, fetch_list=[out]
                 )
@@ -110,7 +110,7 @@ def create_paddle_case(op_type, callback):
                     y = paddle.static.data(name="y", shape=[1], dtype="int64")
                     op = eval("paddle.%s" % (self.op_type))
                     out = op(x, y)
-                    exe = fluid.Executor(self.place)
+                    exe = base.Executor(self.place)
                     (res,) = exe.run(
                         feed={"x": self.input_x, "y": 1.0}, fetch_list=[out]
                     )
@@ -276,30 +276,30 @@ class TestCompareOpError(unittest.TestCase):
         with program_guard(Program(), Program()):
             # The input x and y of compare_op must be Variable.
             x = paddle.static.data(name="x", shape=[1], dtype="float32")
-            y = fluid.create_lod_tensor(
-                numpy.array([[-1]]), [[1]], fluid.CustomPlace("custom_cpu", 0)
+            y = base.create_lod_tensor(
+                numpy.array([[-1]]), [[1]], base.CustomPlace("custom_cpu", 0)
             )
-            self.assertRaises(TypeError, fluid.layers.greater_equal, x, y)
+            self.assertRaises(TypeError, base.layers.greater_equal, x, y)
 
 
 class API_TestElementwise_Equal(unittest.TestCase):
     def test_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             label = paddle.assign(np.array([3, 3], dtype="int32"))
             limit = paddle.assign(np.array([3, 2], dtype="int32"))
             out = paddle.equal(x=label, y=limit)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             (res,) = exe.run(fetch_list=[out])
         self.assertEqual((res == np.array([True, False])).all(), True)
 
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             label = paddle.assign(np.array([3, 3], dtype="int32"))
             limit = paddle.assign(np.array([3, 3], dtype="int32"))
             out = paddle.equal(x=label, y=limit)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             (res,) = exe.run(fetch_list=[out])
         self.assertEqual((res == np.array([True, True])).all(), True)
 
@@ -312,8 +312,8 @@ class TestCompareOpPlace(unittest.TestCase):
             place = paddle.CustomPlace("custom_cpu", 0)
         label = paddle.assign(np.array([3, 3], dtype="int32"))
         limit = paddle.assign(np.array([3, 2], dtype="int32"))
-        out = fluid.layers.less_than(label, limit, force_cpu=True)
-        exe = fluid.Executor(place)
+        out = base.layers.less_than(label, limit, force_cpu=True)
+        exe = base.Executor(place)
         (res,) = exe.run(fetch_list=[out])
         self.assertEqual((res == np.array([False, False])).all(), True)
 

--- a/backends/custom_cpu/tests/unittests/test_elementwise_mul_op.py
+++ b/backends/custom_cpu/tests/unittests/test_elementwise_mul_op.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 from op_test import OpTest, skip_check_grad_ci
 
@@ -45,8 +45,8 @@ class ElementwiseMulOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis, "use_mkldnn": self.use_mkldnn}
@@ -227,23 +227,23 @@ class TestElementwiseMulOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of elementwise_mul must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
-                fluid.CustomPlace("custom_cpu", 0),
+                base.CustomPlace("custom_cpu", 0),
             )
-            y1 = fluid.create_lod_tensor(
+            y1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
-                fluid.CustomPlace("custom_cpu", 0),
+                base.CustomPlace("custom_cpu", 0),
             )
-            self.assertRaises(TypeError, fluid.layers.elementwise_mul, x1, y1)
+            self.assertRaises(TypeError, base.layers.elementwise_mul, x1, y1)
 
             # the input dtype of elementwise_mul must be float16 or float32 or float64 or int32 or int64
             # float16 only can be set on GPU place
             x2 = paddle.static.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
             y2 = paddle.static.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.elementwise_mul, x2, y2)
+            self.assertRaises(TypeError, base.layers.elementwise_mul, x2, y2)
 
 
 if __name__ == "__main__":

--- a/backends/custom_cpu/tests/unittests/test_matmul_op.py
+++ b/backends/custom_cpu/tests/unittests/test_matmul_op.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -63,12 +63,12 @@ def reference_matmul(X, Y, transpose_x=False, transpose_y=False):
 
 class API_TestMm(unittest.TestCase):
     def test_out(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[2], dtype="float64")
             y = paddle.static.data(name="y", shape=[2], dtype="float64")
             res = paddle.static.data(name="output", shape=[1], dtype="float64")
             result = paddle.mm(x, y)
-            exe = fluid.Executor(fluid.CustomPlace("custom_cpu", 0))
+            exe = base.Executor(base.CustomPlace("custom_cpu", 0))
             data1 = np.random.rand(2)
             data2 = np.random.rand(2)
             np_res = exe.run(feed={"x": data1, "y": data2}, fetch_list=[result])
@@ -83,12 +83,12 @@ class API_TestMm(unittest.TestCase):
         )
 
     def test_out_fp16(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[2], dtype="float16")
             y = paddle.static.data(name="y", shape=[2], dtype="float16")
             res = paddle.static.data(name="output", shape=[1], dtype="float16")
             result = paddle.mm(x, y)
-            exe = fluid.Executor(fluid.CustomPlace("custom_cpu", 0))
+            exe = base.Executor(base.CustomPlace("custom_cpu", 0))
             data1 = np.random.rand(2).astype("float16")
             data2 = np.random.rand(2).astype("float16")
             np_res = exe.run(feed={"x": data1, "y": data2}, fetch_list=[result])
@@ -103,12 +103,12 @@ class API_TestMm(unittest.TestCase):
         )
 
     def test_dygraph_without_out(self):
-        device = fluid.CustomPlace("custom_cpu", 0)
-        with fluid.dygraph.guard(device):
+        device = base.CustomPlace("custom_cpu", 0)
+        with base.dygraph.guard(device):
             input_array1 = np.random.rand(3, 4).astype("float64")
             input_array2 = np.random.rand(4, 3).astype("float64")
-            data1 = fluid.dygraph.to_variable(input_array1)
-            data2 = fluid.dygraph.to_variable(input_array2)
+            data1 = base.dygraph.to_variable(input_array1)
+            data2 = base.dygraph.to_variable(input_array2)
             out = paddle.mm(data1, data2)
             expected_result = np.matmul(input_array1, input_array2)
         self.assertTrue(np.allclose(expected_result, out.numpy()))
@@ -125,12 +125,12 @@ class Test_API_Matmul2DX2D(unittest.TestCase):
     def test_dygraph_without_out(self):
         self.init_shape()
 
-        device = fluid.CustomPlace("custom_cpu", 0)
-        with fluid.dygraph.guard(device):
+        device = base.CustomPlace("custom_cpu", 0)
+        with base.dygraph.guard(device):
             input_array1 = np.random.random(self.shape_x).astype(self.dtype)
             input_array2 = np.random.random(self.shape_y).astype(self.dtype)
-            data1 = fluid.dygraph.to_variable(input_array1)
-            data2 = fluid.dygraph.to_variable(input_array2)
+            data1 = base.dygraph.to_variable(input_array1)
+            data2 = base.dygraph.to_variable(input_array2)
             out = paddle.matmul(
                 data1, data2, transpose_x=self.trans_x, transpose_y=self.trans_y
             )

--- a/backends/custom_cpu/tests/unittests/test_mean_op.py
+++ b/backends/custom_cpu/tests/unittests/test_mean_op.py
@@ -18,8 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 np.random.seed(10)
 
@@ -48,7 +48,7 @@ def reduce_mean_wrapper(x, axis=0, keepdim=False, reduce_all=False):
 class TestMeanOp(OpTest):
     def setUp(self):
         self.op_type = "mean"
-        self.python_api = fluid.layers.mean
+        self.python_api = base.layers.mean
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {"X": np.random.random((10, 10)).astype(self.dtype)}
@@ -69,14 +69,14 @@ class TestMeanOpError(unittest.TestCase):
         with program_guard(Program(), Program()):
             # The input type of mean_op must be Variable.
             input1 = 12
-            self.assertRaises(TypeError, fluid.layers.mean, input1)
+            self.assertRaises(TypeError, base.layers.mean, input1)
             # The input dtype of mean_op must be float16, float32, float64.
             input2 = paddle.static.data(
                 name="input2", shape=[-1, 12, 10], dtype="int32"
             )
-            self.assertRaises(TypeError, fluid.layers.mean, input2)
+            self.assertRaises(TypeError, base.layers.mean, input2)
             input3 = paddle.static.data(name="input3", shape=[-1, 4], dtype="float16")
-            fluid.layers.softmax(input3)
+            base.layers.softmax(input3)
 
 
 def ref_reduce_mean(x, axis=None, keepdim=False, reduce_all=False):

--- a/backends/custom_cpu/tests/unittests/test_reduce_op.py
+++ b/backends/custom_cpu/tests/unittests/test_reduce_op.py
@@ -18,10 +18,10 @@ import unittest
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
+import paddle.base.core as core
+import paddle.base as base
+from paddle.base import Program, program_guard
+from paddle.base.framework import convert_np_dtype_to_dtype_
 
 
 def get_places(self):
@@ -394,11 +394,11 @@ class TestProd8DOp(OpTest):
 #         with program_guard(Program(), Program()):
 #             # The input type of reduce_all_op must be Variable.
 #             input1 = 12
-#             self.assertRaises(TypeError, fluid.layers.reduce_all, input1)
+#             self.assertRaises(TypeError, base.layers.reduce_all, input1)
 #             # The input dtype of reduce_all_op must be bool.
 #             input2 = paddle.static.data(
 #                 name='input2', shape=[12, 10], dtype="int32")
-#             self.assertRaises(TypeError, fluid.layers.reduce_all, input2)
+#             self.assertRaises(TypeError, base.layers.reduce_all, input2)
 
 # class TestAnyOp(OpTest):
 #     def setUp(self):
@@ -486,11 +486,11 @@ class TestProd8DOp(OpTest):
 #         with program_guard(Program(), Program()):
 #             # The input type of reduce_any_op must be Variable.
 #             input1 = 12
-#             self.assertRaises(TypeError, fluid.layers.reduce_any, input1)
+#             self.assertRaises(TypeError, base.layers.reduce_any, input1)
 #             # The input dtype of reduce_any_op must be bool.
 #             input2 = paddle.static.data(
 #                 name='input2', shape=[12, 10], dtype="int32")
-#             self.assertRaises(TypeError, fluid.layers.reduce_any, input2)
+#             self.assertRaises(TypeError, base.layers.reduce_any, input2)
 
 
 class Test1DReduce(OpTest):
@@ -754,13 +754,13 @@ class TestReduceSumOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of reduce_sum_op must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([[-1]]), [[1]], fluid.CustomPlace("custom_cpu", 0)
+            x1 = base.create_lod_tensor(
+                np.array([[-1]]), [[1]], base.CustomPlace("custom_cpu", 0)
             )
-            self.assertRaises(TypeError, fluid.layers.reduce_sum, x1)
+            self.assertRaises(TypeError, base.layers.reduce_sum, x1)
             # The input dtype of reduce_sum_op  must be float32 or float64 or int32 or int64.
             x2 = paddle.static.data(name="x2", shape=[-1, 4], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.reduce_sum, x2)
+            self.assertRaises(TypeError, base.layers.reduce_sum, x2)
 
 
 class API_TestSumOp(unittest.TestCase):
@@ -768,13 +768,13 @@ class API_TestSumOp(unittest.TestCase):
         if np_axis is None:
             np_axis = attr_axis
 
-        places = [fluid.CustomPlace("custom_cpu", 0)]
+        places = [base.CustomPlace("custom_cpu", 0)]
         for place in places:
-            with fluid.program_guard(fluid.Program(), fluid.Program()):
+            with base.program_guard(base.Program(), base.Program()):
                 data = paddle.static.data("data", shape=shape, dtype=x_dtype)
                 result_sum = paddle.sum(x=data, axis=attr_axis, dtype=attr_dtype)
 
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 input_data = np.random.rand(*shape).astype(x_dtype)
                 (res,) = exe.run(feed={"data": input_data}, fetch_list=[result_sum])
 
@@ -815,8 +815,8 @@ class API_TestSumOp(unittest.TestCase):
 
     def test_dygraph(self):
         np_x = np.random.random([2, 3, 4]).astype("int32")
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
-            x = fluid.dygraph.to_variable(np_x)
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+            x = base.dygraph.to_variable(np_x)
             out0 = paddle.sum(x).numpy()
             out1 = paddle.sum(x, axis=0).numpy()
             out2 = paddle.sum(x, axis=(0, 1)).numpy()
@@ -832,19 +832,19 @@ class TestAllAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         paddle.enable_static()
-        self.places = [fluid.CustomPlace("custom_cpu", 0)]
+        self.places = [base.CustomPlace("custom_cpu", 0)]
         if core.is_compiled_with_cuda():
-            self.places.append(fluid.CustomPlace("custom_cpu", 0))
+            self.places.append(base.CustomPlace("custom_cpu", 0))
 
     def check_static_result(self, place):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = paddle.static.data(name="input", shape=[4, 4], dtype="bool")
             result = paddle.all(x=input)
             input_np = np.random.randint(0, 2, [4, 4]).astype("bool")
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             fetches = exe.run(
-                fluid.default_main_program(),
+                base.default_main_program(),
                 feed={"input": input_np},
                 fetch_list=[result],
             )
@@ -857,7 +857,7 @@ class TestAllAPI(unittest.TestCase):
     def test_dygraph(self):
         paddle.disable_static()
         for place in self.places:
-            with fluid.dygraph.guard(place):
+            with base.dygraph.guard(place):
                 np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool_)
                 x = paddle.assign(np_x)
                 x = paddle.cast(x, "bool")
@@ -889,19 +889,19 @@ class TestAnyAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         paddle.enable_static()
-        self.places = [fluid.CustomPlace("custom_cpu", 0)]
+        self.places = [base.CustomPlace("custom_cpu", 0)]
         if core.is_compiled_with_cuda():
-            self.places.append(fluid.CustomPlace("custom_cpu", 0))
+            self.places.append(base.CustomPlace("custom_cpu", 0))
 
     def check_static_result(self, place):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = paddle.static.data(name="input", shape=[4, 4], dtype="bool")
             result = paddle.any(x=input)
             input_np = np.random.randint(0, 2, [4, 4]).astype("bool")
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             fetches = exe.run(
-                fluid.default_main_program(),
+                base.default_main_program(),
                 feed={"input": input_np},
                 fetch_list=[result],
             )
@@ -914,7 +914,7 @@ class TestAnyAPI(unittest.TestCase):
     def test_dygraph(self):
         paddle.disable_static()
         for place in self.places:
-            with fluid.dygraph.guard(place):
+            with base.dygraph.guard(place):
                 np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool_)
                 x = paddle.assign(np_x)
                 x = paddle.cast(x, "bool")

--- a/backends/custom_cpu/tests/unittests/test_reshape_op.py
+++ b/backends/custom_cpu/tests/unittests/test_reshape_op.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from paddle.static import Program, program_guard
 
 
@@ -215,10 +215,10 @@ class TestReshapeAPI(unittest.TestCase):
     def _executed_api(self):
         self.reshape = paddle.reshape
 
-    def _set_fluid_api(self):
+    def _set_base_api(self):
         self.fill_constant = paddle.tensor.fill_constant
         self.data = paddle.static.data
-        self.reshape = fluid.layers.reshape
+        self.reshape = base.layers.reshape
 
     def _test_api(self):
         paddle.enable_static()
@@ -235,7 +235,7 @@ class TestReshapeAPI(unittest.TestCase):
             out_1 = self.reshape(x, shape)
 
             # situation 2: have shape(list, no tensor), have actual shape(Tensor)
-            out_2 = fluid.layers.reshape(x, shape=shape, actual_shape=actual_shape)
+            out_2 = base.layers.reshape(x, shape=shape, actual_shape=actual_shape)
 
             # Situation 3: have shape(list, have tensor), no actual shape(Tensor)
             out_3 = self.reshape(x, shape=[positive_five, 10])
@@ -259,15 +259,15 @@ class TestReshapeAPI(unittest.TestCase):
         self._set_paddle_api()
         self._test_api()
 
-    def test_fluid_api(self):
-        self._set_fluid_api()
+    def test_base_api(self):
+        self._set_base_api()
         self._test_api()
 
     def test_imperative(self):
         self._set_paddle_api()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             x = self.to_tensor(input)
             positive_five = self.fill_constant([1], "int32", 5)
 
@@ -291,7 +291,7 @@ class TestStaticReshape_(TestReshapeAPI):
         self._set_paddle_api()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             x = self.to_tensor(input)
             positive_five = self.fill_constant([1], "int32", 5)
 

--- a/backends/custom_cpu/tests/unittests/test_sgd_op.py
+++ b/backends/custom_cpu/tests/unittests/test_sgd_op.py
@@ -16,8 +16,8 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+import paddle.base.core as core
+from paddle.base.op import Operator
 from op_test import OpTest
 import paddle
 
@@ -199,19 +199,19 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
 #         data = paddle.tensor.fill_constant(shape=[1], value=128, dtype='int64')
 #         label = paddle.tensor.fill_constant(
 #             shape=[1, 150], value=0.5, dtype='float32')
-#         emb = fluid.embedding(input=data, size=(10000000, 150), dtype='float32')
-#         out = fluid.layers.l2_normalize(x=emb, axis=-1)
+#         emb = base.embedding(input=data, size=(10000000, 150), dtype='float32')
+#         out = base.layers.l2_normalize(x=emb, axis=-1)
 
-#         cost = fluid.layers.square_error_cost(input=out, label=label)
-#         avg_cost = fluid.layers.mean(cost)
+#         cost = base.layers.square_error_cost(input=out, label=label)
+#         avg_cost = base.layers.mean(cost)
 #         sgd_optimizer = paddle.optimizer.SGD(learning_rate=0.001)
 #         sgd_optimizer.minimize(avg_cost)
 
-#         place = fluid.CustomPlace('custom_cpu', 0)
-#         exe = fluid.Executor(place)
-#         exe.run(fluid.default_startup_program())
-#         compiled_prog = fluid.compiler.CompiledProgram(
-#             fluid.default_main_program())
+#         place = base.CustomPlace('custom_cpu', 0)
+#         exe = base.Executor(place)
+#         exe.run(base.default_startup_program())
+#         compiled_prog = base.compiler.CompiledProgram(
+#             base.default_main_program())
 #         result = exe.run(compiled_prog, fetch_list=[avg_cost])
 
 

--- a/backends/custom_cpu/tests/unittests/test_softmax_op.py
+++ b/backends/custom_cpu/tests/unittests/test_softmax_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
 import paddle.nn.functional as F
 
@@ -72,7 +72,7 @@ class TestSoftmaxOp(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.apply_along_axis(stable_softmax, self.axis, x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
         self.attrs = {
             "axis": self.axis,

--- a/backends/custom_cpu/tests/unittests/test_transpose_op.py
+++ b/backends/custom_cpu/tests/unittests/test_transpose_op.py
@@ -18,8 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -223,33 +223,33 @@ class TestTransposeOpError(unittest.TestCase):
 
             def test_x_Variable_check():
                 # the Input(x)'s type must be Variable
-                fluid.layers.transpose("not_variable", perm=[1, 0, 2])
+                base.layers.transpose("not_variable", perm=[1, 0, 2])
 
             self.assertRaises(TypeError, test_x_Variable_check)
 
             def test_x_dtype_check():
                 # the Input(x)'s dtype must be one of [bool, float16, float32, float64, int32, int64]
                 x1 = paddle.static.data(name="x1", shape=[-1, 10, 5, 3], dtype="int8")
-                fluid.layers.transpose(x1, perm=[1, 0, 2])
+                base.layers.transpose(x1, perm=[1, 0, 2])
 
             self.assertRaises(TypeError, test_x_dtype_check)
 
             def test_perm_list_check():
                 # Input(perm)'s type must be list
-                fluid.layers.transpose(x, perm="[1, 0, 2]")
+                base.layers.transpose(x, perm="[1, 0, 2]")
 
             self.assertRaises(TypeError, test_perm_list_check)
 
             def test_perm_length_and_x_dim_check():
                 # Input(perm) is the permutation of dimensions of Input(input)
                 # its length should be equal to dimensions of Input(input)
-                fluid.layers.transpose(x, perm=[1, 0, 2, 3, 4])
+                base.layers.transpose(x, perm=[1, 0, 2, 3, 4])
 
             self.assertRaises(ValueError, test_perm_length_and_x_dim_check)
 
             def test_each_elem_value_check():
                 # Each element in Input(perm) should be less than Input(x)'s dimension
-                fluid.layers.transpose(x, perm=[3, 5, 7])
+                base.layers.transpose(x, perm=[3, 5, 7])
 
             self.assertRaises(ValueError, test_each_elem_value_check)
 
@@ -293,62 +293,62 @@ class TestTransposeApi(unittest.TestCase):
 
 class TestTAPI(unittest.TestCase):
     def test_out(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10], dtype="float64", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([10]).astype("float64")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10, 5], dtype="float64", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([10, 5]).astype("float64")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[1, 5], dtype="float64", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([1, 5]).astype("float64")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([10]).astype("float64")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([10, 5]).astype("float64")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([1, 5]).astype("float64")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
     def test_errors(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[10, 5, 3], dtype="float64")
 
             def test_x_dimension_check():
@@ -362,7 +362,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 4, 5, 7)
         expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 4, 5, 7], dtype="float64")
             out = paddle.moveaxis(x, [0, 4, 3, 2], [1, 3, 2, 0])
 
@@ -382,7 +382,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 5)
         expected = np.moveaxis(x_np, -2, -1)
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 5], dtype="float64")
             out = x.moveaxis(-2, -1)
 

--- a/backends/custom_cpu/tests/unittests/test_uniform_random_op.py
+++ b/backends/custom_cpu/tests/unittests/test_uniform_random_op.py
@@ -18,11 +18,11 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.base.op import Operator
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -181,7 +181,7 @@ class TestUniformRandomOp(OpTest):
     def test_check_api(self):
         places = self._get_places()
         for place in places:
-            with fluid.dygraph.base.guard(place=place):
+            with base.dygraph.base.guard(place=place):
                 out = self.python_api(
                     self.attrs["shape"],
                     "float32",
@@ -202,30 +202,30 @@ class TestUniformRandomOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((4, 784)),
                     [[1, 1, 1, 1]],
-                    fluid.CustomPlace("custom_cpu", 0),
+                    base.CustomPlace("custom_cpu", 0),
                 )
-                fluid.layers.uniform_random(x1)
+                base.layers.uniform_random(x1)
 
             self.assertRaises(TypeError, test_Variable)
 
             def test_Variable2():
                 x1 = np.zeros((4, 784))
-                fluid.layers.uniform_random(x1)
+                base.layers.uniform_random(x1)
 
             self.assertRaises(TypeError, test_Variable2)
 
             def test_dtype():
                 x2 = paddle.static.data(name="x2", shape=[-1, 4, 784], dtype="float32")
-                fluid.layers.uniform_random(x2, "int32")
+                base.layers.uniform_random(x2, "int32")
 
             self.assertRaises(TypeError, test_dtype)
 
             def test_out_dtype():
-                out = fluid.layers.uniform_random(shape=[3, 4], dtype="float64")
-                self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+                out = base.layers.uniform_random(shape=[3, 4], dtype="float64")
+                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
 
@@ -301,63 +301,63 @@ class TestUniformRandomOpApi(unittest.TestCase):
         y = paddle.static.nn(
             x,
             size=16,
-            weight_attr=fluid.initializer.Uniform(
+            weight_attr=base.initializer.Uniform(
                 low=-0.5, high=0.5, seed=10, diag_num=16, diag_step=16, diag_val=1.0
             ),
         )
 
-        place = fluid.CustomPlace("custom_cpu", 0)
-        x_tensor = fluid.create_lod_tensor(
+        place = base.CustomPlace("custom_cpu", 0)
+        x_tensor = base.create_lod_tensor(
             np.random.rand(3, 16).astype("float32"), [[1, 2]], place
         )
-        exe = fluid.Executor(place)
-        exe.run(fluid.default_startup_program())
+        exe = base.Executor(place)
+        exe.run(base.default_startup_program())
         ret = exe.run(feed={"x": x_tensor}, fetch_list=[y], return_numpy=False)
 
 
 class TestUniformRandomOp_attr_tensor_API(unittest.TestCase):
     def test_attr_tensor_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             dim_tensor = paddle.tensor.fill_constant([1], "int64", 3)
-            ret = fluid.layers.nn.uniform_random([1, dim_tensor, 2])
+            ret = base.layers.nn.uniform_random([1, dim_tensor, 2])
 
-            place = fluid.CustomPlace("custom_cpu", 0)
-            if fluid.core.is_compiled_with_cuda():
-                place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            if base.core.is_compiled_with_cuda():
+                place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             outs = exe.run(train_program, fetch_list=[ret])
 
     def test_attr_tensorlist_int32_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             dim_1 = paddle.tensor.fill_constant([1], "int64", 3)
             dim_2 = paddle.tensor.fill_constant([1], "int32", 2)
-            ret = fluid.layers.nn.uniform_random([1, dim_1, dim_2])
+            ret = base.layers.nn.uniform_random([1, dim_1, dim_2])
 
-            place = fluid.CustomPlace("custom_cpu", 0)
-            if fluid.core.is_compiled_with_cuda():
-                place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            if base.core.is_compiled_with_cuda():
+                place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             outs = exe.run(train_program, fetch_list=[ret])
 
     def test_attr_tensor_int32_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             shape = paddle.static.data(name="shape_tensor", shape=[2], dtype="int32")
-            ret = fluid.layers.nn.uniform_random(shape)
+            ret = base.layers.nn.uniform_random(shape)
 
-            place = fluid.CustomPlace("custom_cpu", 0)
-            if fluid.core.is_compiled_with_cuda():
-                place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("custom_cpu", 0)
+            if base.core.is_compiled_with_cuda():
+                place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
             Shape = np.array([2, 3]).astype("int32")
             exe.run(startup_program)
             outs = exe.run(
@@ -369,23 +369,23 @@ class TestUniformRandomOp_API_seed(unittest.TestCase):
     def test_attr_tensor_API(self):
         _seed = 10
         gen = paddle.seed(_seed)
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             _min = 5
             _max = 10
 
-            ret = fluid.layers.nn.uniform_random(
+            ret = base.layers.nn.uniform_random(
                 [2, 3, 2], min=_min, max=_max, seed=_seed
             )
-            ret_2 = fluid.layers.nn.uniform_random(
+            ret_2 = base.layers.nn.uniform_random(
                 [2, 3, 2], min=_min, max=_max, seed=_seed
             )
-            res = fluid.layers.equal(ret, ret_2)
-            place = fluid.CustomPlace("custom_cpu", 0)
-            if fluid.core.is_compiled_with_cuda():
-                place = fluid.CustomPlace("custom_cpu", 0)
-            exe = fluid.Executor(place)
+            res = base.layers.equal(ret, ret_2)
+            place = base.CustomPlace("custom_cpu", 0)
+            if base.core.is_compiled_with_cuda():
+                place = base.CustomPlace("custom_cpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             ret_value, cmp_value = exe.run(train_program, fetch_list=[ret, res])
@@ -460,8 +460,8 @@ class TestUniformRandomOpSelectedRowsShapeTensorList(unittest.TestCase):
 
 class TestUniformRandomDygraphMode(unittest.TestCase):
     def test_check_output(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
-            x = fluid.layers.uniform_random([10], dtype="float32", min=0.0, max=1.0)
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+            x = base.layers.uniform_random([10], dtype="float32", min=0.0, max=1.0)
             x_np = x.numpy()
             for i in range(10):
                 self.assertTrue((x_np[i] > 0 and x_np[i] < 1.0))
@@ -474,12 +474,12 @@ class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((100, 784)),
                     [[10, 10, 10, 70]],
-                    fluid.CustomPlace("custom_cpu", 0),
+                    base.CustomPlace("custom_cpu", 0),
                 )
-                fluid.layers.uniform_random_batch_size_like(x1)
+                base.layers.uniform_random_batch_size_like(x1)
 
             self.assertRaises(TypeError, test_Variable)
 
@@ -487,7 +487,7 @@ class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
                 x1 = paddle.static.data(
                     name="x2", shape=[-1, 100, 784], dtype="float32"
                 )
-                fluid.layers.uniform_random_batch_size_like(x1, shape="shape")
+                base.layers.uniform_random_batch_size_like(x1, shape="shape")
 
             self.assertRaises(TypeError, test_shape)
 
@@ -495,7 +495,7 @@ class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
                 x2 = paddle.static.data(
                     name="x2", shape=[-1, 100, 784], dtype="float32"
                 )
-                fluid.layers.uniform_random_batch_size_like(x2, "int32")
+                base.layers.uniform_random_batch_size_like(x2, "int32")
 
             self.assertRaises(TypeError, test_dtype)
 
@@ -519,10 +519,10 @@ class TestUniformOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((100, 784)),
                     [[10, 10, 10, 70]],
-                    fluid.CustomPlace("custom_cpu", 0),
+                    base.CustomPlace("custom_cpu", 0),
                 )
                 paddle.tensor.random.uniform(x1)
 
@@ -544,14 +544,14 @@ class TestUniformOpError(unittest.TestCase):
 
             def test_out_dtype():
                 out = paddle.tensor.random.uniform(shape=[3, 4], dtype="float64")
-                self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
 
 
 class TestUniformDygraphMode(unittest.TestCase):
     def test_check_output(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             x = paddle.tensor.random.uniform([10], dtype="float32", min=0.0, max=1.0)
             x_np = x.numpy()
             for i in range(10):
@@ -571,12 +571,12 @@ class TestUniformDtype(unittest.TestCase):
         def test_default_fp32():
             paddle.framework.set_default_dtype("float32")
             out = paddle.tensor.random.uniform([2, 3])
-            self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP32)
+            self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP32)
 
         def test_default_fp64():
             paddle.framework.set_default_dtype("float64")
             out = paddle.tensor.random.uniform([2, 3])
-            self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+            self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
         test_default_fp64()
         test_default_fp32()

--- a/backends/intel_gpu/tests/test_mean_op.py
+++ b/backends/intel_gpu/tests/test_mean_op.py
@@ -20,7 +20,7 @@ from op_test import OpTest
 import paddle
 import paddle.static
 import paddle.nn
-from paddle.fluid import Program, program_guard
+from paddle.base import Program, program_guard
 
 np.random.seed(10)
 

--- a/backends/intel_gpu/tests/unittests/test_argsort_op.py
+++ b/backends/intel_gpu/tests/unittests/test_argsort_op.py
@@ -17,13 +17,13 @@ from __future__ import print_function
 import unittest
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import numpy as np
 import six
-import paddle.fluid.core as core
+import paddle.base.core as core
 
-from paddle.fluid.framework import Program, grad_var_name
-from paddle.fluid.executor import Executor
+from paddle.base.framework import Program, grad_var_name
+from paddle.base.executor import Executor
 
 paddle.enable_static()
 
@@ -94,18 +94,18 @@ class TestArgsortOpCPU(unittest.TestCase):
             self.input_shape, self.axis, self.descending, self.dtype
         )
 
-        with fluid.program_guard(self.main_program, self.startup_program):
-            x = fluid.layers.data(name="x", shape=self.input_shape, dtype=self.dtype)
+        with base.program_guard(self.main_program, self.startup_program):
+            x = base.layers.data(name="x", shape=self.input_shape, dtype=self.dtype)
             x.stop_gradient = False
-            label = fluid.layers.data(
+            label = base.layers.data(
                 name="label", shape=self.input_shape, dtype=self.dtype
             )
-            self.sorted_x, self.index = fluid.layers.argsort(
+            self.sorted_x, self.index = base.layers.argsort(
                 input=x, axis=self.axis, descending=self.descending
             )
             self.sorted_x.stop_gradient = False
-            loss = fluid.layers.elementwise_mul(self.sorted_x, label)
-            self.loss = fluid.layers.reduce_sum(loss)
+            loss = base.layers.elementwise_mul(self.sorted_x, label)
+            self.loss = base.layers.reduce_sum(loss)
 
     def forward(self):
         self.feed_map = {
@@ -141,7 +141,7 @@ class TestArgsortOpCPU(unittest.TestCase):
     # def test_backward(self, numeric_grad_delta=1e-5, max_relative_error=1e-7):
     #     self.check_forward()
 
-    #     with fluid.program_guard(self.main_program, self.startup_program):
+    #     with base.program_guard(self.main_program, self.startup_program):
     #         append_backward(self.loss)
 
     #     ana_grad = [np.array(x) for x in self.backward()]
@@ -285,14 +285,14 @@ class TestArgsortErrorOnCPU(unittest.TestCase):
         self.place = core.CustomPlace("intel_gpu", 0)
 
     def test_error(self):
-        def test_fluid_var_type():
-            with fluid.program_guard(fluid.Program()):
+        def test_base_var_type():
+            with base.program_guard(base.Program()):
                 x = [1]
-                output = fluid.layers.argsort(input=x)
-            self.assertRaises(TypeError, test_fluid_var_type)
+                output = base.layers.argsort(input=x)
+            self.assertRaises(TypeError, test_base_var_type)
 
         def test_paddle_var_type():
-            with fluid.program_guard(fluid.Program()):
+            with base.program_guard(base.Program()):
                 x = [1]
                 output = paddle.argsort(input=x)
             self.assertRaises(TypeError, test_paddle_var_type)
@@ -312,13 +312,13 @@ class TestArgsort(unittest.TestCase):
 
     def test_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
-            input = fluid.data(name="input", shape=self.input_shape, dtype="float32")
+        with base.program_guard(base.Program()):
+            input = base.data(name="input", shape=self.input_shape, dtype="float32")
 
             output = paddle.argsort(input, axis=self.axis)
             output2 = paddle.argsort(input, axis=self.axis, descending=True)
 
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             result, result2 = exe.run(
                 feed={"input": self.data}, fetch_list=[output, output2]
             )  # 始终有一半会被擦掉

--- a/backends/intel_gpu/tests/unittests/test_assign_value_op.py
+++ b/backends/intel_gpu/tests/unittests/test_assign_value_op.py
@@ -19,9 +19,9 @@ import numpy as np
 
 import op_test
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.framework as framework
-import paddle.fluid.layers as layers
+import paddle.base as base
+import paddle.base.framework as framework
+import paddle.base.layers as layers
 from op_test import OpTest
 
 paddle.enable_static()
@@ -80,12 +80,12 @@ class TestAssignApi(unittest.TestCase):
         self.dtype = "float32"
 
     def test_assign(self):
-        main_program = fluid.Program()
-        with fluid.program_guard(main_program):
+        main_program = base.Program()
+        with base.program_guard(main_program):
             x = layers.create_tensor(dtype=self.dtype)
             layers.assign(input=self.value, output=x)
 
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         [fetched_x] = exe.run(main_program, feed={}, fetch_list=[x])
         np.testing.assert_array_equal(fetched_x, self.value)
         self.assertEqual(fetched_x.dtype, self.value.dtype)

--- a/backends/intel_gpu/tests/unittests/test_cast_op.py
+++ b/backends/intel_gpu/tests/unittests/test_cast_op.py
@@ -18,9 +18,9 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base.core as core
+import paddle.base as base
+from paddle.base import Program, program_guard
 from op_test import OpTest, convert_uint16_to_float
 
 paddle.enable_static()
@@ -67,7 +67,7 @@ class TestCastOpFp16ToFp32(OpTest):
         self.check_output(atol=1e-3)
 
 
-# TODO(Zhiwei35): the case's expected dispatch to phi kernels, but fluid kernels
+# TODO(Zhiwei35): the case's expected dispatch to phi kernels, but base kernels
 # class TestCastOpFp32ToFp16(OpTest):
 #     def setUp(self):
 #         ipt = np.random.random(size=[10, 10])
@@ -100,7 +100,7 @@ class TestCastOpBf16ToFp32(OpTest):
         self.check_output()
 
 
-# TODO(Zhiwei35): the case's expected dispatch to phi kernels, but fluid kernels
+# TODO(Zhiwei35): the case's expected dispatch to phi kernels, but base kernels
 # class TestCastOpFp32ToBf16(OpTest):
 #     def setUp(self):
 #         ipt = np.random.random(size=[10, 10]).astype('float32')
@@ -121,10 +121,10 @@ class TestCastOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of cast_op must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([[-1]]), [[1]], fluid.CustomPlace("intel_gpu", 0)
+            x1 = base.create_lod_tensor(
+                np.array([[-1]]), [[1]], base.CustomPlace("intel_gpu", 0)
             )
-            self.assertRaises(TypeError, fluid.layers.cast, x1, "int32")
+            self.assertRaises(TypeError, base.layers.cast, x1, "int32")
 
 
 if __name__ == "__main__":

--- a/backends/intel_gpu/tests/unittests/test_elementwise_mul_op.py
+++ b/backends/intel_gpu/tests/unittests/test_elementwise_mul_op.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 from op_test import OpTest, skip_check_grad_ci
 
@@ -45,8 +45,8 @@ class ElementwiseMulOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis, "use_mkldnn": self.use_mkldnn}
@@ -216,23 +216,23 @@ class TestElementwiseMulOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of elementwise_mul must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
-                fluid.CustomPlace("intel_gpu", 0),
+                base.CustomPlace("intel_gpu", 0),
             )
-            y1 = fluid.create_lod_tensor(
+            y1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
-                fluid.CustomPlace("intel_gpu", 0),
+                base.CustomPlace("intel_gpu", 0),
             )
-            self.assertRaises(TypeError, fluid.layers.elementwise_mul, x1, y1)
+            self.assertRaises(TypeError, base.layers.elementwise_mul, x1, y1)
 
             # the input dtype of elementwise_mul must be float16 or float32 or float32 or int32 or int64
             # float16 only can be set on GPU place
-            x2 = fluid.layers.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
-            y2 = fluid.layers.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.elementwise_mul, x2, y2)
+            x2 = base.layers.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
+            y2 = base.layers.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
+            self.assertRaises(TypeError, base.layers.elementwise_mul, x2, y2)
 
 
 if __name__ == "__main__":

--- a/backends/intel_gpu/tests/unittests/test_fill_constant_op.py
+++ b/backends/intel_gpu/tests/unittests/test_fill_constant_op.py
@@ -19,8 +19,8 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+import paddle.base.core as core
+from paddle.base.op import Operator
 import numpy as np
 
 

--- a/backends/intel_gpu/tests/unittests/test_mean_op.py
+++ b/backends/intel_gpu/tests/unittests/test_mean_op.py
@@ -18,8 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 np.random.seed(10)
 
@@ -46,7 +46,7 @@ def reduce_mean_wrapper(x, axis=0, keepdim=False, reduce_all=False):
 class TestMeanOp(OpTest):
     def setUp(self):
         self.op_type = "mean"
-        self.python_api = fluid.layers.mean
+        self.python_api = base.layers.mean
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {"X": np.random.random((10, 10)).astype(self.dtype)}
@@ -67,12 +67,12 @@ class TestMeanOpError(unittest.TestCase):
         with program_guard(Program(), Program()):
             # The input type of mean_op must be Variable.
             input1 = 12
-            self.assertRaises(TypeError, fluid.layers.mean, input1)
+            self.assertRaises(TypeError, base.layers.mean, input1)
             # The input dtype of mean_op must be float16, float32, float64.
-            input2 = fluid.layers.data(name="input2", shape=[12, 10], dtype="int32")
-            self.assertRaises(TypeError, fluid.layers.mean, input2)
-            input3 = fluid.layers.data(name="input3", shape=[4], dtype="float16")
-            fluid.layers.softmax(input3)
+            input2 = base.layers.data(name="input2", shape=[12, 10], dtype="int32")
+            self.assertRaises(TypeError, base.layers.mean, input2)
+            input3 = base.layers.data(name="input3", shape=[4], dtype="float16")
+            base.layers.softmax(input3)
 
 
 def ref_reduce_mean(x, axis=None, keepdim=False, reduce_all=False):

--- a/backends/intel_gpu/tests/unittests/test_memcpy_op.py
+++ b/backends/intel_gpu/tests/unittests/test_memcpy_op.py
@@ -18,8 +18,8 @@ import numpy as np
 import unittest
 
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 SEED = 2021
 
@@ -82,7 +82,7 @@ class TestMemcpy_API(unittest.TestCase):
             attrs={"dst_place_type": 0},
         )
         place = paddle.CustomPlace("intel_gpu", 0)
-        exe = fluid.Executor(place)
+        exe = base.Executor(place)
         intel_gpu_, cpu_ = exe.run(
             main_program, feed={}, fetch_list=[intel_gpu_var.name, cpu_var.name]
         )
@@ -99,7 +99,7 @@ class TestMemcpy_API(unittest.TestCase):
             attrs={"dst_place_type": 6},
         )
         place = paddle.CustomPlace("intel_gpu", 0)
-        exe = fluid.Executor(place)
+        exe = base.Executor(place)
         intel_gpu_, cpu_ = exe.run(
             main_program, feed={}, fetch_list=[intel_gpu_var.name, cpu_var.name]
         )

--- a/backends/intel_gpu/tests/unittests/test_reduce_op.py
+++ b/backends/intel_gpu/tests/unittests/test_reduce_op.py
@@ -18,9 +18,9 @@ import unittest
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
+import paddle.base as base
+from paddle.base import Program, program_guard
+from paddle.base.framework import convert_np_dtype_to_dtype_
 
 
 def get_places(self):
@@ -382,13 +382,13 @@ class TestReduceSumOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of reduce_sum_op must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([[-1]]), [[1]], fluid.CustomPlace("intel_gpu", 0)
+            x1 = base.create_lod_tensor(
+                np.array([[-1]]), [[1]], base.CustomPlace("intel_gpu", 0)
             )
-            self.assertRaises(TypeError, fluid.layers.reduce_sum, x1)
+            self.assertRaises(TypeError, base.layers.reduce_sum, x1)
             # The input dtype of reduce_sum_op  must be float32 or float64 or int32 or int64.
-            x2 = fluid.layers.data(name="x2", shape=[4], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.reduce_sum, x2)
+            x2 = base.layers.data(name="x2", shape=[4], dtype="uint8")
+            self.assertRaises(TypeError, base.layers.reduce_sum, x2)
 
 
 class API_TestSumOp(unittest.TestCase):
@@ -396,13 +396,13 @@ class API_TestSumOp(unittest.TestCase):
         if np_axis is None:
             np_axis = attr_axis
 
-        places = [fluid.CustomPlace("intel_gpu", 0)]
+        places = [base.CustomPlace("intel_gpu", 0)]
         for place in places:
-            with fluid.program_guard(fluid.Program(), fluid.Program()):
-                data = fluid.data("data", shape=shape, dtype=x_dtype)
+            with base.program_guard(base.Program(), base.Program()):
+                data = base.data("data", shape=shape, dtype=x_dtype)
                 result_sum = paddle.sum(x=data, axis=attr_axis, dtype=attr_dtype)
 
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 input_data = np.random.rand(*shape).astype(x_dtype)
                 (res,) = exe.run(feed={"data": input_data}, fetch_list=[result_sum])
 
@@ -422,8 +422,8 @@ class API_TestSumOp(unittest.TestCase):
 
     def test_dygraph(self):
         np_x = np.random.random([2, 3, 4]).astype("float32")
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
-            x = fluid.dygraph.to_variable(np_x)
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+            x = base.dygraph.to_variable(np_x)
             out0 = paddle.sum(x).numpy()
             out1 = paddle.sum(x, axis=0).numpy()
             out2 = paddle.sum(x, axis=(0, 1)).numpy()

--- a/backends/intel_gpu/tests/unittests/test_reshape_op.py
+++ b/backends/intel_gpu/tests/unittests/test_reshape_op.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from paddle.static import Program, program_guard
 
 
@@ -208,7 +208,7 @@ class TestReshapeOpBool(TestReshapeOp):
 # Test python API
 class TestReshapeAPI(unittest.TestCase):
     def _set_paddle_api(self):
-        self.fill_constant = paddle.fluid.layers.fill_constant
+        self.fill_constant = paddle.base.layers.fill_constant
         self.data = paddle.static.data
         self.to_tensor = paddle.to_tensor
         self._executed_api()
@@ -216,10 +216,10 @@ class TestReshapeAPI(unittest.TestCase):
     def _executed_api(self):
         self.reshape = paddle.reshape
 
-    def _set_fluid_api(self):
-        self.fill_constant = fluid.layers.fill_constant
+    def _set_base_api(self):
+        self.fill_constant = base.layers.fill_constant
         self.data = paddle.static.data
-        self.reshape = fluid.layers.reshape
+        self.reshape = base.layers.reshape
 
     def _test_api(self):
         paddle.enable_static()
@@ -236,7 +236,7 @@ class TestReshapeAPI(unittest.TestCase):
             out_1 = self.reshape(x, shape)
 
             # situation 2: have shape(list, no tensor), have actual shape(Tensor)
-            out_2 = fluid.layers.reshape(x, shape=shape, actual_shape=actual_shape)
+            out_2 = base.layers.reshape(x, shape=shape, actual_shape=actual_shape)
 
             # Situation 3: have shape(list, have tensor), no actual shape(Tensor)
             out_3 = self.reshape(x, shape=[positive_five, 10])
@@ -260,15 +260,15 @@ class TestReshapeAPI(unittest.TestCase):
         self._set_paddle_api()
         self._test_api()
 
-    def test_fluid_api(self):
-        self._set_fluid_api()
+    def test_base_api(self):
+        self._set_base_api()
         self._test_api()
 
     def test_imperative(self):
         self._set_paddle_api()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             x = self.to_tensor(input)
             positive_five = self.fill_constant([1], "int32", 5)
 
@@ -292,7 +292,7 @@ class TestStaticReshape_(TestReshapeAPI):
         self._set_paddle_api()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             x = self.to_tensor(input)
             positive_five = self.fill_constant([1], "int32", 5)
 

--- a/backends/intel_gpu/tests/unittests/test_softmax_op.py
+++ b/backends/intel_gpu/tests/unittests/test_softmax_op.py
@@ -69,7 +69,7 @@ class TestSoftmaxOp(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.apply_along_axis(stable_softmax, self.axis, x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
         self.attrs = {
             "axis": self.axis,
@@ -142,7 +142,7 @@ class TestSoftmaxAPI(unittest.TestCase):
     def test_static_check(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.fluid.data("X", self.x_np.shape, "float32")
+            x = paddle.base.data("X", self.x_np.shape, "float32")
             out1 = self.softmax(x)
             m = paddle.nn.Softmax()
             out2 = m(x)

--- a/backends/intel_gpu/tests/unittests/test_transpose_op.py
+++ b/backends/intel_gpu/tests/unittests/test_transpose_op.py
@@ -18,8 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -183,37 +183,37 @@ class TestTransposeOpBool6D(TestTransposeOpBool):
 class TestTransposeOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            x = fluid.layers.data(name="x", shape=[10, 5, 3], dtype="float32")
+            x = base.layers.data(name="x", shape=[10, 5, 3], dtype="float32")
 
             def test_x_Variable_check():
                 # the Input(x)'s type must be Variable
-                fluid.layers.transpose("not_variable", perm=[1, 0, 2])
+                base.layers.transpose("not_variable", perm=[1, 0, 2])
 
             self.assertRaises(TypeError, test_x_Variable_check)
 
             def test_x_dtype_check():
                 # the Input(x)'s dtype must be one of [bool, float16, float32, float32, int32, int64]
-                x1 = fluid.layers.data(name="x1", shape=[10, 5, 3], dtype="int8")
-                fluid.layers.transpose(x1, perm=[1, 0, 2])
+                x1 = base.layers.data(name="x1", shape=[10, 5, 3], dtype="int8")
+                base.layers.transpose(x1, perm=[1, 0, 2])
 
             self.assertRaises(TypeError, test_x_dtype_check)
 
             def test_perm_list_check():
                 # Input(perm)'s type must be list
-                fluid.layers.transpose(x, perm="[1, 0, 2]")
+                base.layers.transpose(x, perm="[1, 0, 2]")
 
             self.assertRaises(TypeError, test_perm_list_check)
 
             def test_perm_length_and_x_dim_check():
                 # Input(perm) is the permutation of dimensions of Input(input)
                 # its length should be equal to dimensions of Input(input)
-                fluid.layers.transpose(x, perm=[1, 0, 2, 3, 4])
+                base.layers.transpose(x, perm=[1, 0, 2, 3, 4])
 
             self.assertRaises(ValueError, test_perm_length_and_x_dim_check)
 
             def test_each_elem_value_check():
                 # Each element in Input(perm) should be less than Input(x)'s dimension
-                fluid.layers.transpose(x, perm=[3, 5, 7])
+                base.layers.transpose(x, perm=[3, 5, 7])
 
             self.assertRaises(ValueError, test_each_elem_value_check)
 
@@ -258,63 +258,63 @@ class TestTransposeApi(unittest.TestCase):
 class TestTAPI(unittest.TestCase):
     def test_out(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
-            data = fluid.data(shape=[10], dtype="float32", name="data")
+        with base.program_guard(base.Program()):
+            data = base.data(shape=[10], dtype="float32", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([10]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
-            data = fluid.data(shape=[10, 5], dtype="float32", name="data")
+        with base.program_guard(base.Program()):
+            data = base.data(shape=[10, 5], dtype="float32", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([10, 5]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
-            data = fluid.data(shape=[1, 5], dtype="float32", name="data")
+        with base.program_guard(base.Program()):
+            data = base.data(shape=[1, 5], dtype="float32", name="data")
             data_t = paddle.t(data)
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
             data_np = np.random.random([1, 5]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([10]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([10, 5]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([1, 5]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
     def test_errors(self):
-        with fluid.program_guard(fluid.Program()):
-            x = fluid.data(name="x", shape=[10, 5, 3], dtype="float32")
+        with base.program_guard(base.Program()):
+            x = base.data(name="x", shape=[10, 5, 3], dtype="float32")
 
             def test_x_dimension_check():
                 paddle.t(x)
@@ -327,7 +327,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 4, 5, 7).astype("float32")
         expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 4, 5, 7], dtype="float32")
             out = paddle.moveaxis(x, [0, 4, 3, 2], [1, 3, 2, 0])
 
@@ -347,7 +347,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 5).astype("float32")
         expected = np.moveaxis(x_np, -2, -1)
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 5], dtype="float32")
             out = x.moveaxis(-2, -1)
 

--- a/backends/intel_gpu/tests/unittests/test_uniform_random_op.py
+++ b/backends/intel_gpu/tests/unittests/test_uniform_random_op.py
@@ -18,11 +18,11 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.base.op import Operator
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -181,7 +181,7 @@ class TestUniformRandomOp(OpTest):
     def test_check_api(self):
         places = self._get_places()
         for place in places:
-            with fluid.dygraph.base.guard(place=place):
+            with base.dygraph.base.guard(place=place):
                 out = self.python_api(
                     self.attrs["shape"],
                     "float32",
@@ -202,30 +202,30 @@ class TestUniformRandomOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((4, 784)),
                     [[1, 1, 1, 1]],
-                    fluid.CustomPlace("intel_gpu", 0),
+                    base.CustomPlace("intel_gpu", 0),
                 )
-                fluid.layers.uniform_random(x1)
+                base.layers.uniform_random(x1)
 
             self.assertRaises(TypeError, test_Variable)
 
             def test_Variable2():
                 x1 = np.zeros((4, 784))
-                fluid.layers.uniform_random(x1)
+                base.layers.uniform_random(x1)
 
             self.assertRaises(TypeError, test_Variable2)
 
             def test_dtype():
-                x2 = fluid.layers.data(name="x2", shape=[4, 784], dtype="float32")
-                fluid.layers.uniform_random(x2, "int32")
+                x2 = base.layers.data(name="x2", shape=[4, 784], dtype="float32")
+                base.layers.uniform_random(x2, "int32")
 
             self.assertRaises(TypeError, test_dtype)
 
             def test_out_dtype():
-                out = fluid.layers.uniform_random(shape=[3, 4], dtype="float64")
-                self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+                out = base.layers.uniform_random(shape=[3, 4], dtype="float64")
+                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
 
@@ -296,10 +296,10 @@ class TestUniformRandomOpSelectedRowsWithDiagInit(TestUniformRandomOpSelectedRow
 # class TestUniformRandomOpApi(unittest.TestCase):
 #     def test_api(self):
 #         paddle.seed(10)
-#         x = fluid.layers.data('x', shape=[16], dtype='float32', lod_level=1)
+#         x = base.layers.data('x', shape=[16], dtype='float32', lod_level=1)
 #         y = paddle.mm(x,
 #                             size=16,
-#                             param_attr=fluid.initializer.Uniform(
+#                             param_attr=base.initializer.Uniform(
 #                                 low=-0.5,
 #                                 high=0.5,
 #                                 seed=10,
@@ -307,51 +307,51 @@ class TestUniformRandomOpSelectedRowsWithDiagInit(TestUniformRandomOpSelectedRow
 #                                 diag_step=16,
 #                                 diag_val=1.0))
 
-#         place = fluid.CustomPlace('intel_gpu', 0)
-#         x_tensor = fluid.create_lod_tensor(
+#         place = base.CustomPlace('intel_gpu', 0)
+#         x_tensor = base.create_lod_tensor(
 #             np.random.rand(3, 16).astype("float32"), [[1, 2]], place)
-#         exe = fluid.Executor(place)
-#         exe.run(fluid.default_startup_program())
+#         exe = base.Executor(place)
+#         exe.run(base.default_startup_program())
 #         ret = exe.run(feed={'x': x_tensor}, fetch_list=[y], return_numpy=False)
 
 
 class TestUniformRandomOp_attr_tensor_API(unittest.TestCase):
     def test_attr_tensor_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
-            dim_tensor = fluid.layers.fill_constant([1], "int64", 3)
-            ret = fluid.layers.nn.uniform_random([1, dim_tensor, 2])
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
+            dim_tensor = base.layers.fill_constant([1], "int64", 3)
+            ret = base.layers.nn.uniform_random([1, dim_tensor, 2])
 
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             outs = exe.run(train_program, fetch_list=[ret])
 
     def test_attr_tensorlist_int32_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
-            dim_1 = fluid.layers.fill_constant([1], "int64", 3)
-            dim_2 = fluid.layers.fill_constant([1], "int32", 2)
-            ret = fluid.layers.nn.uniform_random([1, dim_1, dim_2])
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
+            dim_1 = base.layers.fill_constant([1], "int64", 3)
+            dim_2 = base.layers.fill_constant([1], "int32", 2)
+            ret = base.layers.nn.uniform_random([1, dim_1, dim_2])
 
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             outs = exe.run(train_program, fetch_list=[ret])
 
     def test_attr_tensor_int32_API(self):
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
-            shape = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
-            ret = fluid.layers.nn.uniform_random(shape)
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
+            shape = base.data(name="shape_tensor", shape=[2], dtype="int32")
+            ret = base.layers.nn.uniform_random(shape)
 
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
             Shape = np.array([2, 3]).astype("int32")
             exe.run(startup_program)
             outs = exe.run(
@@ -363,21 +363,21 @@ class TestUniformRandomOp_API_seed(unittest.TestCase):
     def test_attr_tensor_API(self):
         _seed = 10
         gen = paddle.seed(_seed)
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             _min = 5
             _max = 10
 
-            ret = fluid.layers.nn.uniform_random(
+            ret = base.layers.nn.uniform_random(
                 [2, 3, 2], min=_min, max=_max, seed=_seed
             )
-            ret_2 = fluid.layers.nn.uniform_random(
+            ret_2 = base.layers.nn.uniform_random(
                 [2, 3, 2], min=_min, max=_max, seed=_seed
             )
-            res = fluid.layers.equal(ret, ret_2)
-            place = fluid.CustomPlace("intel_gpu", 0)
-            exe = fluid.Executor(place)
+            res = base.layers.equal(ret, ret_2)
+            place = base.CustomPlace("intel_gpu", 0)
+            exe = base.Executor(place)
 
             exe.run(startup_program)
             ret_value, cmp_value = exe.run(train_program, fetch_list=[ret, res])
@@ -448,8 +448,8 @@ class TestUniformRandomOpSelectedRowsShapeTensorList(unittest.TestCase):
 
 class TestUniformRandomDygraphMode(unittest.TestCase):
     def test_check_output(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
-            x = fluid.layers.uniform_random([10], dtype="float32", min=0.0, max=1.0)
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+            x = base.layers.uniform_random([10], dtype="float32", min=0.0, max=1.0)
             x_np = x.numpy()
             for i in range(10):
                 self.assertTrue((x_np[i] > 0 and x_np[i] < 1.0))
@@ -462,24 +462,24 @@ class TestUniformRandomBatchSizeLikeOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((100, 784)),
                     [[10, 10, 10, 70]],
-                    fluid.CustomPlace("intel_gpu", 0),
+                    base.CustomPlace("intel_gpu", 0),
                 )
-                fluid.layers.uniform_random_batch_size_like(x1)
+                base.layers.uniform_random_batch_size_like(x1)
 
             self.assertRaises(TypeError, test_Variable)
 
             def test_shape():
-                x1 = fluid.layers.data(name="x2", shape=[100, 784], dtype="float32")
-                fluid.layers.uniform_random_batch_size_like(x1, shape="shape")
+                x1 = base.layers.data(name="x2", shape=[100, 784], dtype="float32")
+                base.layers.uniform_random_batch_size_like(x1, shape="shape")
 
             self.assertRaises(TypeError, test_shape)
 
             def test_dtype():
-                x2 = fluid.layers.data(name="x2", shape=[100, 784], dtype="float32")
-                fluid.layers.uniform_random_batch_size_like(x2, "int32")
+                x2 = base.layers.data(name="x2", shape=[100, 784], dtype="float32")
+                base.layers.uniform_random_batch_size_like(x2, "int32")
 
             self.assertRaises(TypeError, test_dtype)
 
@@ -503,10 +503,10 @@ class TestUniformOpError(unittest.TestCase):
         with program_guard(main_prog, start_prog):
 
             def test_Variable():
-                x1 = fluid.create_lod_tensor(
+                x1 = base.create_lod_tensor(
                     np.zeros((100, 784)),
                     [[10, 10, 10, 70]],
-                    fluid.CustomPlace("intel_gpu", 0),
+                    base.CustomPlace("intel_gpu", 0),
                 )
                 paddle.tensor.random.uniform(x1)
 
@@ -519,21 +519,21 @@ class TestUniformOpError(unittest.TestCase):
             self.assertRaises(TypeError, test_Variable2)
 
             def test_dtype():
-                x2 = fluid.layers.data(name="x2", shape=[100, 784], dtype="float32")
+                x2 = base.layers.data(name="x2", shape=[100, 784], dtype="float32")
                 paddle.tensor.random.uniform(x2, "int32")
 
             self.assertRaises(TypeError, test_dtype)
 
             def test_out_dtype():
                 out = paddle.tensor.random.uniform(shape=[3, 4], dtype="float64")
-                self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+                self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
             test_out_dtype()
 
 
 class TestUniformDygraphMode(unittest.TestCase):
     def test_check_output(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             x = paddle.tensor.random.uniform([10], dtype="float32", min=0.0, max=1.0)
             x_np = x.numpy()
             for i in range(10):
@@ -553,12 +553,12 @@ class TestUniformDtype(unittest.TestCase):
         def test_default_fp32():
             paddle.framework.set_default_dtype("float32")
             out = paddle.tensor.random.uniform([2, 3])
-            self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP32)
+            self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP32)
 
         def test_default_fp64():
             paddle.framework.set_default_dtype("float64")
             out = paddle.tensor.random.uniform([2, 3])
-            self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+            self.assertEqual(out.dtype, base.core.VarDesc.VarType.FP64)
 
         test_default_fp64()
         test_default_fp32()

--- a/backends/mlu/tests/unittests/parallel_dygraph_sync_batch_norm.py
+++ b/backends/mlu/tests/unittests/parallel_dygraph_sync_batch_norm.py
@@ -16,8 +16,8 @@ import numpy as np
 from test_dist_base import TestParallelDyGraphRunnerBase, runtime_main
 
 import paddle
-from paddle import fluid
-from paddle.fluid.dygraph.base import to_variable
+from paddle import base
+from paddle.base.dygraph.base import to_variable
 from paddle.nn import Conv2D, SyncBatchNorm
 
 
@@ -76,9 +76,7 @@ class TestSyncBatchNorm(TestParallelDyGraphRunnerBase):
             batch_size=32,
             drop_last=True,
         )
-        opt = fluid.optimizer.Adam(
-            learning_rate=1e-3, parameter_list=model.parameters()
-        )
+        opt = base.optimizer.Adam(learning_rate=1e-3, parameter_list=model.parameters())
         return model, train_reader, opt
 
     def run_one_loop(self, model, opt, data):

--- a/backends/mlu/tests/unittests/test_abs_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_abs_op_mlu.py
@@ -39,7 +39,7 @@ class TestAbs(OpTest):
         x[np.abs(x) < 0.005] = 0.02
         out = np.abs(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):
@@ -69,7 +69,7 @@ class TestAbsHalf(OpTest):
         x[np.abs(x) < 0.005] = 0.02
         out = np.abs(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):

--- a/backends/mlu/tests/unittests/test_accuracy_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_accuracy_op_mlu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -91,7 +91,7 @@ class TestAccuracyAPI1(unittest.TestCase):
 class TestAccuracyAPI2(unittest.TestCase):
     def test_api(self):
         paddle.set_device("mlu")
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             predictions = paddle.to_tensor(
                 [[0.2, 0.1, 0.4, 0.1, 0.1], [0.2, 0.3, 0.1, 0.15, 0.25]],
                 dtype="float32",
@@ -105,7 +105,7 @@ class TestAccuracyAPI2(unittest.TestCase):
 class TestAccuracyAPI(unittest.TestCase):
     def test_api(self):
         paddle.set_device("mlu")
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             predictions = paddle.to_tensor(
                 [[0.2, 0.1, 0.4, 0.1, 0.1], [0.2, 0.3, 0.1, 0.15, 0.25]],
                 dtype="float32",

--- a/backends/mlu/tests/unittests/test_adam_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_adam_op_mlu.py
@@ -290,7 +290,7 @@ class TestNet(unittest.TestCase):
             prediction = paddle.static.nn.fc(x=fc_1, size=2, activation="softmax")
 
             cost = paddle.nn.functional.cross_entropy(input=prediction, label=label)
-            # loss = fluid.layers.reduce_mean(cost)
+            # loss = base.layers.reduce_mean(cost)
             loss = paddle.mean(cost)
             adam = paddle.optimizer.Adam(learning_rate=0.01)
             adam.minimize(loss)

--- a/backends/mlu/tests/unittests/test_adamw_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_adamw_op_mlu.py
@@ -18,7 +18,7 @@ from tests.op_test import OpTest
 import paddle
 import random
 from functools import partial
-from paddle import fluid
+from paddle import base
 
 paddle.enable_static()
 SEED = 2022
@@ -257,11 +257,11 @@ class TestAdamWOp(unittest.TestCase):
     def test_adamw_op(self):
         paddle.enable_static()
         shape = [2, 3, 8, 8]
-        exe = fluid.Executor(self.place)
-        train_prog = fluid.Program()
-        startup = fluid.Program()
-        with fluid.program_guard(train_prog, startup):
-            with fluid.unique_name.guard():
+        exe = base.Executor(self.place)
+        train_prog = base.Program()
+        startup = base.Program()
+        with base.program_guard(train_prog, startup):
+            with base.unique_name.guard():
                 data = paddle.static.data(name="data", shape=shape)
                 conv = paddle.static.nn.conv2d(data, 8, 3)
                 loss = paddle.mean(conv)
@@ -771,10 +771,10 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
         weight_decay = 0.01
         epsilon = 1e-8
 
-        train_prog = fluid.Program()
-        startup = fluid.Program()
-        with fluid.program_guard(train_prog, startup):
-            with fluid.unique_name.guard():
+        train_prog = base.Program()
+        startup = base.Program()
+        with base.program_guard(train_prog, startup):
+            with base.unique_name.guard():
                 x = paddle.static.data(name="x", shape=[None, 10], dtype="float32")
                 y = paddle.static.data(name="y", shape=[None, 1], dtype="float32")
 
@@ -861,7 +861,7 @@ class TestAdamWOpLayerwiseLR(TestAdamWOp):
             "linear_1.b_0@GRAD",
         ]
 
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         exe.run(startup)
         test_prog = train_prog.clone(for_test=True)
 

--- a/backends/mlu/tests/unittests/test_arg_max_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_arg_max_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/mlu/tests/unittests/test_assign_value_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_assign_value_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.framework as framework
+import paddle.base.framework as framework
 
 paddle.enable_static()
 numpy.random.seed(2022)

--- a/backends/mlu/tests/unittests/test_atan_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_atan_op_mlu.py
@@ -35,7 +35,7 @@ class TestAtan(OpTest):
         x = np.random.uniform(0, 2, [13, 17]).astype(self.dtype)
         out = np.arctan(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -63,7 +63,7 @@ class TestAtanFp16(OpTest):
         x = np.random.uniform(0, 2, [13, 14]).astype(self.dtype)
         out = np.arctan(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
@@ -18,13 +18,13 @@ import os
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from tests.op import Operator
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.base.framework import grad_var_name
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 _set_use_system_allocator(True)
 paddle.enable_static()
@@ -256,19 +256,19 @@ class TestBatchNormOpInference(unittest.TestCase):
 
         # create input
         x_tensor = create_or_get_tensor(
-            scope, "x_val", OpTest.np_dtype_to_fluid_dtype(x_val), place
+            scope, "x_val", OpTest.np_dtype_to_base_dtype(x_val), place
         )
         scale_tensor = create_or_get_tensor(
-            scope, "scale_val", OpTest.np_dtype_to_fluid_dtype(scale_val), place
+            scope, "scale_val", OpTest.np_dtype_to_base_dtype(scale_val), place
         )
         bias_tensor = create_or_get_tensor(
-            scope, "bias_val", OpTest.np_dtype_to_fluid_dtype(bias_val), place
+            scope, "bias_val", OpTest.np_dtype_to_base_dtype(bias_val), place
         )
         mean_tensor = create_or_get_tensor(
-            scope, "mean", OpTest.np_dtype_to_fluid_dtype(mean), place
+            scope, "mean", OpTest.np_dtype_to_base_dtype(mean), place
         )
         variance_tensor = create_or_get_tensor(
-            scope, "variance", OpTest.np_dtype_to_fluid_dtype(variance), place
+            scope, "variance", OpTest.np_dtype_to_base_dtype(variance), place
         )
 
         # create output
@@ -478,8 +478,8 @@ class TestBatchNormOpTraining(unittest.TestCase):
             ]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = fluid.Program()
-            with fluid.program_guard(program):
+            program = base.Program()
+            with base.program_guard(program):
                 block = program.global_block()
                 for name in ground_truth:
                     block.create_var(
@@ -536,7 +536,7 @@ class TestBatchNormOpTraining(unittest.TestCase):
 
                 program._sync_with_cpp()
 
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 out = exe.run(
                     program,
                     feed={
@@ -705,8 +705,8 @@ class TestDygraphBatchNormAPIError(unittest.TestCase):
         with program_guard(Program(), Program()):
             batch_norm = paddle.nn.BatchNorm(10)
             # the input of BatchNorm must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace()
+            x1 = base.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], base.CPUPlace()
             )
             self.assertRaises(TypeError, batch_norm, x1)
 
@@ -723,13 +723,13 @@ class TestDygraphBatchNormTrainableStats(unittest.TestCase):
             shape = [4, 10, 4, 4]
 
             def compute(x, is_test, trainable_statistics):
-                with fluid.dygraph.guard(p):
+                with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm(
                         shape[1],
                         is_test=is_test,
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(fluid.dygraph.to_variable(x))
+                    y = bn(base.dygraph.to_variable(x))
                 return y.numpy()
 
             x = np.random.randn(*shape).astype("float32")
@@ -740,7 +740,7 @@ class TestDygraphBatchNormTrainableStats(unittest.TestCase):
     def test_static(self):
         places = [paddle.CustomPlace("mlu", 0)]
         for p in places:
-            exe = fluid.Executor(p)
+            exe = base.Executor(p)
             shape = [4, 10, 16, 16]
 
             def compute(x_np, is_test, trainable_statistics):
@@ -752,7 +752,7 @@ class TestDygraphBatchNormTrainableStats(unittest.TestCase):
                     )
                     x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
                     y = bn(x)
-                    exe.run(fluid.default_startup_program())
+                    exe.run(base.default_startup_program())
                     r = exe.run(feed={"x": x_np}, fetch_list=[y])[0]
                 return r
 

--- a/backends/mlu/tests/unittests/test_batch_norm_op_mlu_v2.py
+++ b/backends/mlu/tests/unittests/test_batch_norm_op_mlu_v2.py
@@ -14,9 +14,9 @@
 
 import unittest
 import numpy as np
-import paddle.fluid as fluid
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+import paddle.base as base
+from paddle.base import Program, program_guard
 import paddle
 
 paddle.enable_static()
@@ -26,7 +26,7 @@ class TestBatchNorm(unittest.TestCase):
     def test_name(self):
         places = [paddle.CustomPlace("mlu", 0)]
         for p in places:
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 batch_norm1d = paddle.nn.BatchNorm1D(1, name="test")
 
     def test_error(self):
@@ -39,34 +39,34 @@ class TestBatchNorm(unittest.TestCase):
             def error1d_dataformat():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm1d = paddle.nn.BatchNorm1D(1, data_format="NCDHW")
-                batch_norm1d(fluid.dygraph.to_variable(x_data_4))
+                batch_norm1d(base.dygraph.to_variable(x_data_4))
 
             def error2d_dataformat():
                 x_data_3 = np.random.random(size=(2, 1, 3)).astype("float32")
                 batch_norm2d = paddle.nn.BatchNorm2D(1, data_format="NCDHW")
-                batch_norm2d(fluid.dygraph.to_variable(x_data_3))
+                batch_norm2d(base.dygraph.to_variable(x_data_3))
 
             def error3d_dataformat():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm3d = paddle.nn.BatchNorm3D(1, data_format="NCL")
-                batch_norm3d(fluid.dygraph.to_variable(x_data_4))
+                batch_norm3d(base.dygraph.to_variable(x_data_4))
 
             def error1d():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm1d = paddle.nn.BatchNorm1D(1)
-                batch_norm1d(fluid.dygraph.to_variable(x_data_4))
+                batch_norm1d(base.dygraph.to_variable(x_data_4))
 
             def error2d():
                 x_data_3 = np.random.random(size=(2, 1, 3)).astype("float32")
                 batch_norm2d = paddle.nn.BatchNorm2D(1)
-                batch_norm2d(fluid.dygraph.to_variable(x_data_3))
+                batch_norm2d(base.dygraph.to_variable(x_data_3))
 
             def error3d():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm3d = paddle.nn.BatchNorm3D(1)
-                batch_norm3d(fluid.dygraph.to_variable(x_data_4))
+                batch_norm3d(base.dygraph.to_variable(x_data_4))
 
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 self.assertRaises(ValueError, error1d)
                 self.assertRaises(ValueError, error2d)
                 self.assertRaises(ValueError, error3d)
@@ -80,45 +80,45 @@ class TestBatchNorm(unittest.TestCase):
             shape = [4, 10, 4, 4]
 
             def compute_v1(x, is_test, trainable_statistics):
-                with fluid.dygraph.guard(p):
+                with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm(
                         shape[1],
                         is_test=is_test,
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(fluid.dygraph.to_variable(x))
+                    y = bn(base.dygraph.to_variable(x))
                 return y.numpy()
 
             def compute_v2(x):
-                with fluid.dygraph.guard(p):
+                with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm2D(shape[1])
-                    y = bn(fluid.dygraph.to_variable(x))
+                    y = bn(base.dygraph.to_variable(x))
                 return y.numpy()
 
             def compute_v3(x, is_test, trainable_statistics):
-                with fluid.dygraph.guard(p):
+                with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm(
                         shape[1],
                         is_test=is_test,
-                        param_attr=fluid.ParamAttr(
+                        param_attr=base.ParamAttr(
                             initializer=paddle.nn.initializer.Constant(1.0),
                             trainable=False,
                         ),
-                        bias_attr=fluid.ParamAttr(
+                        bias_attr=base.ParamAttr(
                             initializer=paddle.nn.initializer.Constant(0.0),
                             trainable=False,
                         ),
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(fluid.dygraph.to_variable(x))
+                    y = bn(base.dygraph.to_variable(x))
                 return y.numpy()
 
             def compute_v4(x):
-                with fluid.dygraph.guard(p):
+                with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm2D(
                         shape[1], weight_attr=False, bias_attr=False
                     )
-                    y = bn(fluid.dygraph.to_variable(x))
+                    y = bn(base.dygraph.to_variable(x))
                 return y.numpy()
 
             x = np.random.randn(*shape).astype("float32")
@@ -132,7 +132,7 @@ class TestBatchNorm(unittest.TestCase):
     def test_static(self):
         places = [paddle.CustomPlace("mlu", 0)]
         for p in places:
-            exe = fluid.Executor(p)
+            exe = base.Executor(p)
             shape = [4, 10, 16, 16]
 
             def compute_v1(x_np, is_test, trainable_statistics):
@@ -144,7 +144,7 @@ class TestBatchNorm(unittest.TestCase):
                     )
                     x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
                     y = bn(x)
-                    exe.run(fluid.default_startup_program())
+                    exe.run(base.default_startup_program())
                     r = exe.run(feed={"x": x_np}, fetch_list=[y])[0]
                 return r
 
@@ -153,7 +153,7 @@ class TestBatchNorm(unittest.TestCase):
                     bn = paddle.nn.BatchNorm2D(shape[1])
                     x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
                     y = bn(x)
-                    exe.run(fluid.default_startup_program())
+                    exe.run(base.default_startup_program())
                     r = exe.run(feed={"x": x_np}, fetch_list=[y])[0]
                 return r
 
@@ -174,7 +174,7 @@ class TestBatchNormChannelLast(unittest.TestCase):
 
     def test_1d(self):
         for p in self.places:
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 x = paddle.randn([2, 6, 4])
                 net1 = paddle.nn.BatchNorm1D(4, data_format="NLC")
                 net2 = paddle.nn.BatchNorm1D(4)
@@ -190,7 +190,7 @@ class TestBatchNormChannelLast(unittest.TestCase):
 
     def test_2d(self):
         for p in self.places:
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 x = paddle.randn([2, 6, 6, 4])
                 net1 = paddle.nn.BatchNorm2D(4, data_format="NHWC")
                 net2 = paddle.nn.BatchNorm2D(4)
@@ -206,7 +206,7 @@ class TestBatchNormChannelLast(unittest.TestCase):
 
     def test_3d(self):
         for p in self.places:
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 x = paddle.randn([2, 6, 6, 6, 4])
                 net1 = paddle.nn.BatchNorm3D(4, data_format="NDHWC")
                 net2 = paddle.nn.BatchNorm3D(4)
@@ -238,11 +238,11 @@ class TestBatchNormUseGlobalStats(unittest.TestCase):
 
     def test_global_stats(self):
         for p in self.places:
-            with fluid.dygraph.guard(p):
+            with base.dygraph.guard(p):
                 x = paddle.randn([2, 6, 6, 4])
                 net1 = paddle.nn.BatchNorm(
                     6,
-                    param_attr=fluid.ParamAttr(
+                    param_attr=base.ParamAttr(
                         initializer=paddle.nn.initializer.Constant(1.0)
                     ),
                     use_global_stats=self.use_global_stats,

--- a/backends/mlu/tests/unittests/test_bilinear_interp_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_bilinear_interp_v2_op_mlu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 from paddle.nn.functional import interpolate
 import paddle
 
@@ -513,7 +513,7 @@ class TestBilinearInterpOpAPI_dy(unittest.TestCase):
         import paddle
 
         place = paddle.CustomPlace("mlu", 0)
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
             input_x = paddle.to_tensor(input_data)
             expect_res = bilinear_interp_np(
@@ -530,7 +530,7 @@ class TestBilinearInterpOpAPI_dy2(unittest.TestCase):
         import paddle
 
         place = paddle.CustomPlace("mlu", 0)
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
             size_np = np.array([12, 12]).astype("int64")
             input_x = paddle.to_tensor(input_data)
@@ -549,7 +549,7 @@ class TestBilinearInterpOpAPI_dy3(unittest.TestCase):
         import paddle
 
         place = paddle.CustomPlace("mlu", 0)
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
             size_1 = np.array([12]).astype("int64")
             input_x = paddle.to_tensor(input_data)
@@ -568,7 +568,7 @@ class TestBilinearInterpOpAPI_dy4(unittest.TestCase):
         import paddle
 
         place = paddle.CustomPlace("mlu", 0)
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
             scale_np = np.array([2, 2]).astype("int64")
             input_x = paddle.to_tensor(input_data)

--- a/backends/mlu/tests/unittests/test_cast_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_cast_op_mlu.py
@@ -19,9 +19,9 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base.core as core
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -135,7 +135,7 @@ class TestCastOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of cast_op must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([[-1]]), [[1]], paddle.CustomPlace("mlu", 0)
             )
             self.assertRaises(TypeError, paddle.cast, x1, "int32")

--- a/backends/mlu/tests/unittests/test_coalesce_tensor_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_coalesce_tensor_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.fluid import core
+from paddle.base import core
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -30,7 +30,7 @@ class TestAllocContinuousSpace(OpTest):
     def setUp(self):
         self.__class__.use_custom_device = True
         self.op_type = "coalesce_tensor"
-        self.dtype, self.fluid_dtype = self.init_dtype()
+        self.dtype, self.base_dtype = self.init_dtype()
         attrs = self.init_attr()
         self.copy_data = attrs["copy_data"]
         self.constant = attrs["constant"]
@@ -58,7 +58,7 @@ class TestAllocContinuousSpace(OpTest):
             "set_constant": False,
             "constant": 0.0,
             "use_align": True,
-            "dtype": self.fluid_dtype,
+            "dtype": self.base_dtype,
         }
 
     def init_output(self, input_list, set_constant, constant):
@@ -102,7 +102,7 @@ class TestAllocContinuousSpace2(TestAllocContinuousSpace):
             "set_constant": False,
             "constant": 0.5,
             "use_align": True,
-            "dtype": self.fluid_dtype,
+            "dtype": self.base_dtype,
             "user_defined_size_of_dtype": 2,
         }
 

--- a/backends/mlu/tests/unittests/test_compare_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_compare_op_mlu.py
@@ -18,9 +18,9 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
-from paddle.fluid import Program, program_guard
+from paddle.base import Program, program_guard
 
 
 def create_test_class(op_type, typename, callback):
@@ -47,7 +47,7 @@ def create_test_class(op_type, typename, callback):
                 a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
                 b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
                 c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
-                d = fluid.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
+                d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
 
                 op = eval("paddle.%s" % self.op_type)
                 self.assertRaises(TypeError, op, x=a, y=b, axis=True)

--- a/backends/mlu/tests/unittests/test_conv2d_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_conv2d_op_mlu.py
@@ -209,8 +209,8 @@ class TestConv2DOp(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,
@@ -414,8 +414,8 @@ class TestConv2DOp_v2(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,

--- a/backends/mlu/tests/unittests/test_conv2d_transposed_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_conv2d_transposed_op_mlu.py
@@ -21,7 +21,7 @@ import paddle
 import paddle.nn as nn
 
 paddle.enable_static()
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 
@@ -541,10 +541,10 @@ class TestConv2DTransposeAPI(unittest.TestCase):
         data1_np = np.random.random((2, 3, 5, 5)).astype("float32")
         data2_np = np.random.random((2, 5, 5, 3)).astype("float32")
 
-        exe = fluid.Executor(self.place)
-        exe.run(fluid.default_startup_program())
+        exe = base.Executor(self.place)
+        exe.run(base.default_startup_program())
         results = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"data1": data1_np, "data2": data2_np},
             fetch_list=[out1, out2, out3, out4, out5, out6, out7],
             return_numpy=True,

--- a/backends/mlu/tests/unittests/test_cos_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_cos_op_mlu.py
@@ -34,7 +34,7 @@ class TestCos(OpTest):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.cos(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):
@@ -59,7 +59,7 @@ class TestCosHalf(OpTest):
         x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
         out = np.cos(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):

--- a/backends/mlu/tests/unittests/test_deformable_conv_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_deformable_conv_op_mlu.py
@@ -157,10 +157,10 @@ class TestModulatedDeformableConvOp(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Offset": OpTest.np_dtype_to_fluid_dtype(offset),
-            "Mask": OpTest.np_dtype_to_fluid_dtype(mask),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Offset": OpTest.np_dtype_to_base_dtype(offset),
+            "Mask": OpTest.np_dtype_to_base_dtype(mask),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,

--- a/backends/mlu/tests/unittests/test_dist_base.py
+++ b/backends/mlu/tests/unittests/test_dist_base.py
@@ -26,7 +26,7 @@ from contextlib import closing
 import numpy as np
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 RUN_STEP = 5
 DEFAULT_BATCH_SIZE = 2
@@ -68,9 +68,9 @@ class TestParallelDyGraphRunnerBase:
         device_id = int(os.getenv("FLAGS_selected_mlus", "0"))
         place = paddle.CustomPlace("mlu", device_id)
 
-        with fluid.dygraph.guard(place):
-            fluid.default_startup_program().random_seed = seed
-            fluid.default_main_program().random_seed = seed
+        with base.dygraph.guard(place):
+            base.default_startup_program().random_seed = seed
+            base.default_main_program().random_seed = seed
             np.random.seed(seed)
             import random
 

--- a/backends/mlu/tests/unittests/test_dropout_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_dropout_op_mlu.py
@@ -18,7 +18,7 @@ import numpy as np
 import unittest
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -247,10 +247,10 @@ class TestDropoutOpFp16(TestDropoutOp):
 class TestDropoutAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
-        self.places = [fluid.CPUPlace(), paddle.CustomPlace("mlu", 0)]
+        self.places = [base.CPUPlace(), paddle.CustomPlace("mlu", 0)]
 
     def check_static_result(self, place):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = paddle.static.data(name="input", shape=[40, 40], dtype="float32")
             res1 = paddle.nn.functional.dropout(
                 x=input, p=0.0, training=False, mode="upscale_in_train"
@@ -305,17 +305,17 @@ class TestDropoutAPI(unittest.TestCase):
             res_np = in_np
             res_np2 = np.zeros_like(in_np)
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             res_list = [res1, res2, res3, res4, res5, res7, res8]
             for res in res_list:
                 fetches = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"input": in_np},
                     fetch_list=[res],
                 )
                 np.testing.assert_allclose(fetches[0], res_np)
             fetches2 = exe.run(
-                fluid.default_main_program(), feed={"input": in_np}, fetch_list=[res6]
+                base.default_main_program(), feed={"input": in_np}, fetch_list=[res6]
             )
             np.testing.assert_allclose(fetches2[0], res_np2)
 

--- a/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
@@ -16,11 +16,11 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 from tests.op_test import OpTest, skip_check_grad_ci
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -38,8 +38,8 @@ class TestElementwiseAddOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}
@@ -379,12 +379,12 @@ class TestElementwiseAddOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of elementwise_add must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
                 paddle.CustomPlace("mlu", 0),
             )
-            y1 = fluid.create_lod_tensor(
+            y1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]),
                 [[1, 1, 1, 1]],
                 paddle.CustomPlace("mlu", 0),
@@ -402,7 +402,7 @@ class TestAddApi(unittest.TestCase):
         return paddle.add(x, y, name)
 
     def test_name(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
             y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
@@ -410,7 +410,7 @@ class TestAddApi(unittest.TestCase):
             self.assertEqual(("add_res" in y_1.name), True)
 
     def test_declarative(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
 
             def gen_data():
                 return {
@@ -423,17 +423,17 @@ class TestAddApi(unittest.TestCase):
             z = self._executed_api(x, y)
 
             place = paddle.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 
     def test_dygraph(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.array([2, 3, 4]).astype("float32")
             np_y = np.array([1, 5, 2]).astype("float32")
-            x = fluid.dygraph.to_variable(np_x)
-            y = fluid.dygraph.to_variable(np_y)
+            x = base.dygraph.to_variable(np_x)
+            y = base.dygraph.to_variable(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/backends/mlu/tests/unittests/test_elementwise_div_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_div_op_mlu.py
@@ -35,8 +35,8 @@ class TestElementwiseDiv(OpTest):
         out = np.divide(x, y)
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(y),
+            "X": OpTest.np_dtype_to_base_dtype(x),
+            "Y": OpTest.np_dtype_to_base_dtype(y),
         }
         self.attrs = {}
         self.outputs = {"Out": out}
@@ -79,8 +79,8 @@ class TestElementwiseDivFp16(OpTest):
         out = np.divide(x, y)
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(y),
+            "X": OpTest.np_dtype_to_base_dtype(x),
+            "Y": OpTest.np_dtype_to_base_dtype(y),
         }
         self.attrs = {}
         self.outputs = {"Out": out}

--- a/backends/mlu/tests/unittests/test_elementwise_max_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_max_op_mlu.py
@@ -95,8 +95,8 @@ class TestElementwiseMaxOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}

--- a/backends/mlu/tests/unittests/test_elementwise_min_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_min_op_mlu.py
@@ -30,8 +30,8 @@ class TestElementwiseMinOp(OpTest):
         self.init_dtype()
         self.init_input_output()
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis}

--- a/backends/mlu/tests/unittests/test_elementwise_mul_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_mul_op_mlu.py
@@ -39,8 +39,8 @@ class ElementwiseMulOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis}

--- a/backends/mlu/tests/unittests/test_elementwise_pow_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_pow_op_mlu.py
@@ -87,8 +87,8 @@ class TestElementwisePow(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}

--- a/backends/mlu/tests/unittests/test_elementwise_sub_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_sub_op_mlu.py
@@ -33,8 +33,8 @@ class TestElementwiseSubOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}

--- a/backends/mlu/tests/unittests/test_exp_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_exp_op_mlu.py
@@ -34,7 +34,7 @@ class TestExp(OpTest):
         x = np.random.rand(20, 5).astype(self.dtype)
         out = np.exp(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -62,7 +62,7 @@ class TestExpFp16(OpTest):
         x = np.random.rand(20, 5).astype(self.dtype)
         out = np.exp(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -89,7 +89,7 @@ class TestExpNeg(OpTest):
         x -= 1
         out = np.exp(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_expand_as_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_expand_as_v2_op_mlu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -141,9 +141,9 @@ class TestExpandAsV2API(unittest.TestCase):
 
         out_1 = paddle.expand_as(x, y=y)
 
-        exe = fluid.Executor(place=fluid.CustomPlace("mlu", 0))
+        exe = base.Executor(place=base.CustomPlace("mlu", 0))
         res_1 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input1, "target_tensor": input2},
             fetch_list=[out_1],
         )

--- a/backends/mlu/tests/unittests/test_expand_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_expand_v2_op_mlu.py
@@ -17,8 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 import paddle
 
 paddle.enable_static()
@@ -210,7 +210,7 @@ class TestExpandV2OpInt64_t(OpTest):
 class TestExpandV2Error(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([[-1]]), [[1]], paddle.CustomPlace("mlu", 0)
             )
             shape = [2, 2]
@@ -233,9 +233,9 @@ class TestExpandAsV2API(unittest.TestCase):
 
         out_1 = paddle.expand_as(x, y=y)
 
-        exe = fluid.Executor(place=fluid.CustomPlace("mlu", 0))
+        exe = base.Executor(place=base.CustomPlace("mlu", 0))
         res_1 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input1, "target_tensor": input2},
             fetch_list=[out_1],
         )

--- a/backends/mlu/tests/unittests/test_fill_constant_batch_size_like_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_fill_constant_batch_size_like_op_mlu.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import unittest
 import numpy as np
 from tests.op_test import OpTest
@@ -26,7 +26,7 @@ paddle.enable_static()
 def fill_constant_batch_size_like(
     input, shape, value, data_type, input_dim_idx=0, output_dim_idx=0, force_cpu=False
 ):
-    return paddle.fluid.layers.fill_constant_batch_size_like(
+    return paddle.base.layers.fill_constant_batch_size_like(
         input, shape, data_type, value, input_dim_idx, output_dim_idx, force_cpu
     )
 

--- a/backends/mlu/tests/unittests/test_fill_constant_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_fill_constant_op_mlu.py
@@ -19,7 +19,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from tests.op import Operator
 import numpy as np
 

--- a/backends/mlu/tests/unittests/test_floor_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_floor_op_mlu.py
@@ -36,7 +36,7 @@ class TestFloor(OpTest):
         x = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
         out = np.floor(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_output(self):

--- a/backends/mlu/tests/unittests/test_gather_nd_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_gather_nd_op_mlu.py
@@ -17,7 +17,7 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -262,8 +262,8 @@ class TestGatherNdAPI2(unittest.TestCase):
         paddle.set_device("mlu")
         input_1 = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
         index_1 = np.array([[1]]).astype("int32")
-        input = fluid.dygraph.to_variable(input_1)
-        index = fluid.dygraph.to_variable(index_1)
+        input = base.dygraph.to_variable(input_1)
+        index = base.dygraph.to_variable(index_1)
         output = paddle.gather(input, index)
         output_np = output.numpy()
         expected_output = np.array([3, 4])

--- a/backends/mlu/tests/unittests/test_gather_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_gather_op_mlu.py
@@ -17,7 +17,7 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -155,7 +155,7 @@ class TestGathertError(unittest.TestCase):
             self.assertRaises(TypeError, test_axis_dtype1)
 
     def test_error2(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             paddle.set_device("mlu")
 
             shape = [8, 9, 6]

--- a/backends/mlu/tests/unittests/test_gelu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_gelu_op_mlu.py
@@ -38,7 +38,7 @@ class TestGelu(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = np_gelu(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -66,7 +66,7 @@ class TestGeluFp16(OpTest):
         x = np.random.uniform(1, 2, [3, 4]).astype(self.dtype)
         out = np_gelu(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_hard_sigmoid_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_hard_sigmoid_op_mlu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 
 paddle.enable_static()
@@ -160,12 +160,12 @@ class TestHardsigmoidAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-6)
         paddle.enable_static()
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
             out = paddle.nn.functional.hardsigmoid(x, slope=0.2)
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
         out_ref = ref_hardsigmoid(self.x_np, 0.2, 0.5)
         np.testing.assert_allclose(out_ref, res[0])

--- a/backends/mlu/tests/unittests/test_huber_loss_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_huber_loss_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-from paddle.fluid import Program, program_guard
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 

--- a/backends/mlu/tests/unittests/test_index_sample_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_index_sample_op_mlu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -163,9 +163,9 @@ class TestIndexSampleShape(unittest.TestCase):
         index = paddle.static.data(name="index", shape=[-1, 3], dtype="int32")
         output = paddle.index_sample(x=x, index=index)
 
-        place = fluid.CustomPlace("mlu", 0)
-        exe = fluid.Executor(place=place)
-        exe.run(fluid.default_startup_program())
+        place = base.CustomPlace("mlu", 0)
+        exe = base.Executor(place=place)
+        exe.run(base.default_startup_program())
 
         feed = {"x": x_np, "index": index_np}
         res = exe.run(feed=feed, fetch_list=[output])
@@ -173,7 +173,7 @@ class TestIndexSampleShape(unittest.TestCase):
 
 class TestIndexSampleDynamic(unittest.TestCase):
     def test_result(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("mlu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("mlu", 0)):
             x = paddle.to_tensor(
                 [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
                 dtype="float32",

--- a/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
@@ -18,9 +18,9 @@ import numpy as np
 import paddle
 
 from operator import mul
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle.nn.functional as F
-import paddle.fluid as fluid
+import paddle.base as base
 from functools import reduce
 from tests.op_test import _set_use_system_allocator
 from paddle.static.amp.fp16_utils import (
@@ -168,8 +168,8 @@ class TestLayerNormOp(unittest.TestCase):
                 var_names += ["bias"]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = fluid.Program()
-            with fluid.program_guard(program):
+            program = base.Program()
+            with base.program_guard(program):
                 block = program.global_block()
                 for name in ground_truth:
                     block.create_var(
@@ -218,7 +218,7 @@ class TestLayerNormOp(unittest.TestCase):
                     grad_var.set_dtype(core.VarDesc.VarType.FP32)
 
                 program._sync_with_cpp()
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 out = exe.run(
                     program,
                     feed={

--- a/backends/mlu/tests/unittests/test_leaky_relu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_leaky_relu_op_mlu.py
@@ -45,7 +45,7 @@ class TestLeadyRelu(OpTest):
 
     def set_inputs(self):
         x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
 
     def set_attrs(self):
         self.attrs = {}

--- a/backends/mlu/tests/unittests/test_log_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_log_op_mlu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 SEED = 2021
@@ -37,7 +37,7 @@ class TestActivation(OpTest):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.exp(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_output(self):
@@ -69,7 +69,7 @@ class TestLog(TestActivation):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.log(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -89,7 +89,7 @@ class TestLog2(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.log2(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad_with_place(self):
@@ -98,7 +98,7 @@ class TestLog2(TestActivation):
         self.check_grad_with_place(self.place, ["X"], "Out")
 
     def test_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -122,7 +122,7 @@ class TestLog2(TestActivation):
             np.testing.assert_allclose(res1, expected_res, rtol=rtol)
 
         # dygraph
-        with fluid.dygraph.guard(self.place):
+        with base.dygraph.guard(self.place):
             np_x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
             data_x = paddle.to_tensor(np_x)
             z = paddle.log2(data_x)
@@ -145,7 +145,7 @@ class TestLog10(TestActivation):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.log10(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad_with_place(self):
@@ -154,7 +154,7 @@ class TestLog10(TestActivation):
         self.check_grad_with_place(self.place, ["X"], "Out")
 
     def test_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -175,7 +175,7 @@ class TestLog10(TestActivation):
             np.testing.assert_allclose(res1[0], expected_res, rtol=1e-5)
 
         # dygraph
-        with fluid.dygraph.guard(self.place):
+        with base.dygraph.guard(self.place):
             np_x = np.random.uniform(0.1, 1, [11, 17]).astype("float32")
             data_x = paddle.to_tensor(np_x)
             z = paddle.log10(data_x)

--- a/backends/mlu/tests/unittests/test_log_softmax_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_log_softmax_op_mlu.py
@@ -126,7 +126,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
         self.place = (
             paddle.CustomPlace("mlu", 0)
-            if ("mlu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("mlu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
 
@@ -160,7 +160,7 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
         self.place = (
             paddle.CustomPlace("mlu", 0)
-            if ("mlu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("mlu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
 

--- a/backends/mlu/tests/unittests/test_lookup_table_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_lookup_table_v2_op_mlu.py
@@ -42,8 +42,8 @@ class TestLookupTableV2(OpTest):
             out[np.squeeze(x == self.padding_idx)] = np.zeros(self.dim)
 
         self.inputs = {
-            "W": OpTest.np_dtype_to_fluid_dtype(w),
-            "Ids": OpTest.np_dtype_to_fluid_dtype(x),
+            "W": OpTest.np_dtype_to_base_dtype(w),
+            "Ids": OpTest.np_dtype_to_base_dtype(x),
         }
         self.attrs = {
             "is_sparse": False,

--- a/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
@@ -15,7 +15,7 @@ import unittest
 import paddle
 import numpy as np
 from paddle import _C_ops, _legacy_C_ops
-from paddle.fluid.framework import in_dygraph_mode
+from paddle.base.framework import in_dygraph_mode
 
 
 def run_adam_op(
@@ -44,14 +44,14 @@ def run_adam_op(
     paddle.disable_static()
     paddle.set_device("mlu")
 
-    param_vars = [paddle.fluid.dygraph.to_variable(p) for p in params]
-    grad_vars = [paddle.fluid.dygraph.to_variable(g) for g in grads]
-    lr_vars = [paddle.fluid.dygraph.to_variable(l) for l in lrs]
-    moment1_vars = [paddle.fluid.dygraph.to_variable(m) for m in moment1s]
-    moment2_vars = [paddle.fluid.dygraph.to_variable(m) for m in moment2s]
-    beta1_pow_vars = [paddle.fluid.dygraph.to_variable(b) for b in beta1_pows]
-    beta2_pow_vars = [paddle.fluid.dygraph.to_variable(b) for b in beta2_pows]
-    master_param_vars = [paddle.fluid.dygraph.to_variable(m_p) for m_p in master_params]
+    param_vars = [paddle.base.dygraph.to_variable(p) for p in params]
+    grad_vars = [paddle.base.dygraph.to_variable(g) for g in grads]
+    lr_vars = [paddle.base.dygraph.to_variable(l) for l in lrs]
+    moment1_vars = [paddle.base.dygraph.to_variable(m) for m in moment1s]
+    moment2_vars = [paddle.base.dygraph.to_variable(m) for m in moment2s]
+    beta1_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta1_pows]
+    beta2_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta2_pows]
+    master_param_vars = [paddle.base.dygraph.to_variable(m_p) for m_p in master_params]
 
     if not use_merged:
         for i in range(len(param_vars)):

--- a/backends/mlu/tests/unittests/test_merged_momentum_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_merged_momentum_op_mlu.py
@@ -15,7 +15,7 @@
 import unittest
 import paddle
 import numpy as np
-from paddle.fluid.layer_helper import LayerHelper
+from paddle.base.layer_helper import LayerHelper
 from collections import OrderedDict
 
 

--- a/backends/mlu/tests/unittests/test_meshgrid_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_meshgrid_op_mlu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -87,10 +87,10 @@ class TestMeshgridOp3(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("mlu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid(x, y)
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )
@@ -123,10 +123,10 @@ class TestMeshgridOp4(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("mlu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid([x, y])
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )
@@ -160,10 +160,10 @@ class TestMeshgridOp5(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("mlu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid((x, y))
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )
@@ -189,9 +189,9 @@ class TestMeshgridOp7(unittest.TestCase):
             ],
         ).astype("int32")
 
-        with fluid.dygraph.guard():
-            tensor_3 = fluid.dygraph.to_variable(input_3)
-            tensor_4 = fluid.dygraph.to_variable(input_4)
+        with base.dygraph.guard():
+            tensor_3 = base.dygraph.to_variable(input_3)
+            tensor_4 = base.dygraph.to_variable(input_4)
             res_3, res_4 = paddle.tensor.meshgrid([tensor_3, tensor_4])
 
             assert np.array_equal(res_3.shape, [100, 200])
@@ -216,9 +216,9 @@ class TestMeshgridOp8(unittest.TestCase):
         ).astype("int32")
 
         paddle.set_device("mlu")
-        with fluid.dygraph.guard():
-            tensor_3 = fluid.dygraph.to_variable(input_3)
-            tensor_4 = fluid.dygraph.to_variable(input_4)
+        with base.dygraph.guard():
+            tensor_3 = base.dygraph.to_variable(input_3)
+            tensor_4 = base.dygraph.to_variable(input_4)
             res_3, res_4 = paddle.tensor.meshgrid((tensor_3, tensor_4))
 
             assert np.array_equal(res_3.shape, [100, 200])

--- a/backends/mlu/tests/unittests/test_momentum_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_momentum_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import numpy
 
 paddle.enable_static()
@@ -165,8 +165,8 @@ class TestMomentumV2(unittest.TestCase):
     def test_momentum(self):
         paddle.enable_static()
         place = paddle.CustomPlace("mlu", 0)
-        main = fluid.Program()
-        with fluid.program_guard(main):
+        main = base.Program()
+        with base.program_guard(main):
             x = paddle.static.data(name="x", shape=[-1, 13], dtype="float32")
             y = paddle.static.data(name="y", shape=[-1, 1], dtype="float32")
             y_predict = paddle.static.nn.fc(x, size=1)
@@ -180,9 +180,9 @@ class TestMomentumV2(unittest.TestCase):
             train_reader = paddle.batch(
                 paddle.dataset.uci_housing.train(), batch_size=1
             )
-            feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            feeder = base.DataFeeder(place=place, feed_list=[x, y])
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             for data in train_reader():
                 exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
 
@@ -287,8 +287,8 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
     def test_momentum_static(self):
         paddle.enable_static()
         place = paddle.CustomPlace("mlu", 0)
-        main = fluid.Program()
-        with fluid.program_guard(main):
+        main = base.Program()
+        with base.program_guard(main):
             x = paddle.static.data(name="x", shape=[-1, 13], dtype="float32")
             y = paddle.static.data(name="y", shape=[-1, 1], dtype="float32")
             y_predict = paddle.static.nn.fc(x, size=1)
@@ -304,9 +304,9 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
             train_reader = paddle.batch(
                 paddle.dataset.uci_housing.train(), batch_size=1
             )
-            feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            feeder = base.DataFeeder(place=place, feed_list=[x, y])
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             for data in train_reader():
                 exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
 

--- a/backends/mlu/tests/unittests/test_multinomial_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_multinomial_op_mlu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 from tests.op_test import OpTest
 import numpy as np
@@ -165,14 +165,14 @@ class TestMultinomialApi(unittest.TestCase):
 
     def test_static(self):
         paddle.set_device("mlu:0")
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             x = paddle.static.data("x", shape=[4], dtype="float32")
             out = paddle.multinomial(x, num_samples=100000, replacement=True)
 
-            place = fluid.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("mlu", 0)
+            exe = base.Executor(place)
 
         exe.run(startup_program)
         x_np = np.random.rand(4).astype("float32")

--- a/backends/mlu/tests/unittests/test_one_hot_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_one_hot_v2_op_mlu.py
@@ -18,9 +18,9 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.framework import Program, program_guard
+import paddle.base as base
+import paddle.base.core as core
+from paddle.base.framework import Program, program_guard
 
 paddle.enable_static()
 
@@ -156,7 +156,7 @@ class TestOneHotOp_exception(unittest.TestCase):
                 attrs={"depth": self.depth},
                 outputs={"Out": one_hot_out},
             )
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
 
             def run():
                 exe.run(
@@ -184,13 +184,13 @@ class TestOneHotOpApi(unittest.TestCase):
         label = np.array([np.random.randint(0, depth - 1) for i in range(6)]).reshape(
             [6, 1]
         )
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             one_hot_label = paddle.nn.functional.one_hot(
-                fluid.dygraph.to_variable(label), depth
+                base.dygraph.to_variable(label), depth
             )
 
             one_hot_label = paddle.nn.functional.one_hot(
-                fluid.dygraph.to_variable(label), depth
+                base.dygraph.to_variable(label), depth
             )
             # with _test_eager_guard():
             #     one_hot_label = paddle.nn.functional.one_hot(
@@ -204,8 +204,8 @@ class TestOneHotOpApi(unittest.TestCase):
             [6, 1]
         )
 
-        exe = fluid.Executor(self.place)
-        exe.run(fluid.default_startup_program())
+        exe = base.Executor(self.place)
+        exe.run(base.default_startup_program())
         ret = exe.run(
             feed={
                 "label": label_data,
@@ -221,7 +221,7 @@ class BadInputTestOnehotV2(unittest.TestCase):
         self.__class__.use_custom_device = True
 
     def test_error(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
 
             def test_bad_x():
                 label = paddle.static.data(name="label", shape=[4], dtype="float32")

--- a/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
@@ -19,9 +19,9 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base.core as core
+import paddle.base as base
+from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
 # from test_pool2d_op import pool2D_forward_naive, avg_pool2D_forward_naive, max_pool2D_forward_naive, adaptive_start_index, adaptive_end_index
@@ -446,7 +446,7 @@ class TestPool2D_Op_Mixin(object):
             self.pool_type,
             self.padding_algorithm,
         ).astype(self.dtype)
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(input)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(input)}
 
         self.attrs = {
             "strides": self.strides,
@@ -1052,10 +1052,10 @@ class TestPool2DAPI(unittest.TestCase):
         )
         assert out_10.shape == (2, 3, -1, -1)
 
-        exe = fluid.Executor(place=paddle.CustomPlace("mlu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
 
         [res_1, res_2, res_3, res_4, res_5, res_6, res_7, res_8] = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={
                 "input_NHWC": x_NHWC,
                 "input_NCHW": x_NCHW,
@@ -1247,9 +1247,9 @@ class TestDygraphPool2DAPIError(unittest.TestCase):
 
 class TestDygraphPool2DAPI(unittest.TestCase):
     def test_nhwc(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = fluid.dygraph.to_variable(data)
+            x = base.dygraph.to_variable(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,
@@ -1268,9 +1268,9 @@ class TestDygraphPool2DAPI(unittest.TestCase):
             np.testing.assert_allclose(out1.numpy(), out2)
 
     def test_lower_case(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = fluid.dygraph.to_variable(data)
+            x = base.dygraph.to_variable(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,
@@ -1289,9 +1289,9 @@ class TestDygraphPool2DAPI(unittest.TestCase):
             np.testing.assert_allclose(out1.numpy(), out2)
 
     def test_upper_case(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = fluid.dygraph.to_variable(data)
+            x = base.dygraph.to_variable(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,

--- a/backends/mlu/tests/unittests/test_pow_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_pow_op_mlu.py
@@ -36,7 +36,7 @@ class TestPow(OpTest):
         factor = 2
         out = np.power(x, factor)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"factor": factor}
         self.outputs = {"Out": out}
 
@@ -66,7 +66,7 @@ class TestPowFp16(OpTest):
         factor = 2
         out = np.power(x, factor)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"factor": factor}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_randperm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_randperm_op_mlu.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from paddle.static import program_guard, Program
 
 paddle.enable_static()

--- a/backends/mlu/tests/unittests/test_reciprocal_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_reciprocal_op_mlu.py
@@ -33,7 +33,7 @@ class TestMLUReciprocal(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = np.reciprocal(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_output(self):

--- a/backends/mlu/tests/unittests/test_reduce_max_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_reduce_max_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/mlu/tests/unittests/test_reduce_min_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_reduce_min_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/mlu/tests/unittests/test_relu6_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_relu6_op_mlu.py
@@ -42,7 +42,7 @@ class TestRelu6(OpTest):
         x[np.abs(x) < 0.005] = 0.02
         out = ref_relu6(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"threshold": 6.0}
         self.outputs = {"Out": out}
 
@@ -84,7 +84,7 @@ class TestReluNeg(TestRelu6):
         x[np.abs(x) < 0.005] = 0.02
         out = ref_relu6(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"threshold": 6.0}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_relu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_relu_op_mlu.py
@@ -34,7 +34,7 @@ class TestRelu(OpTest):
         x = np.random.rand(3, 2).astype(self.dtype)
         out = x
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -59,7 +59,7 @@ class TestReluFp16(OpTest):
         x = np.random.rand(3, 2).astype(self.dtype)
         out = x
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -85,7 +85,7 @@ class TestReluNeg(OpTest):
         x = np.array([0.1, -0.1, -1.0]).astype(self.dtype)
         out = np.array([0.1, 0.0, 0.0]).astype(self.dtype)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_rsqrt_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_rsqrt_op_mlu.py
@@ -34,7 +34,7 @@ class TestRsqrt(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = 1.0 / np.sqrt(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_scale_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_scale_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from tests.op import Operator
 from paddle.static import Program, program_guard
 

--- a/backends/mlu/tests/unittests/test_set_value_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_set_value_op_mlu.py
@@ -167,7 +167,7 @@ class TestSetValueItemSlice4(TestSetValueApi):
 # #             return i, x
 
 # #         i = paddle.zeros(shape=(1, ), dtype='int32')
-# #         i, x = paddle.fluid.layers.while_loop(cond, body, [i, x])
+# #         i, x = paddle.base.layers.while_loop(cond, body, [i, x])
 
 # #     def _get_answer(self):
 # #         self.data[0] = self.value

--- a/backends/mlu/tests/unittests/test_silu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_silu_op_mlu.py
@@ -35,7 +35,7 @@ class TestSilu(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = x / (1 + np.exp(-x))
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -64,7 +64,7 @@ class TestSiluFp16(OpTest):
         x = np.random.uniform(1, 2, [13, 14]).astype(self.dtype)
         out = x / (1 + np.exp(-x))
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_sin_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_sin_op_mlu.py
@@ -39,7 +39,7 @@ class TestSin(OpTest):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = np.sin(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):
@@ -74,7 +74,7 @@ class TestSinHalf(OpTest):
         x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
         out = np.sin(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):

--- a/backends/mlu/tests/unittests/test_slice_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_slice_op_mlu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -515,7 +515,7 @@ class TestFP16_2(OpTest):
 
 class TestSliceApiWithTensor(unittest.TestCase):
     def test_starts_ends_is_tensor(self):
-        with paddle.fluid.dygraph.guard():
+        with paddle.base.dygraph.guard():
             a = paddle.rand(shape=[4, 5, 6], dtype="float32")
             axes = [0, 1, 2]
             starts = [-3, 0, 2]
@@ -531,7 +531,7 @@ class TestSliceApiWithTensor(unittest.TestCase):
             np.testing.assert_allclose(a_1.numpy(), a_2.numpy())
 
     def test_bool_tensor(self):
-        with paddle.fluid.dygraph.guard():
+        with paddle.base.dygraph.guard():
             array = (np.arange(60).reshape([3, 4, 5]) % 3).astype("bool")
             tt = paddle.to_tensor(array)
             tt.stop_gradient = False
@@ -549,9 +549,9 @@ class TestSliceApiWithTensor(unittest.TestCase):
 
 class TestImperativeVarBaseGetItem(unittest.TestCase):
     def test_getitem_with_long(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             data = np.random.random((2, 80, 16128)).astype("float32")
-            var = fluid.dygraph.to_variable(data)
+            var = base.dygraph.to_variable(data)
             sliced = var[:, 10:, : var.shape[1]]  # var.shape[1] is 80L here
             self.assertEqual(sliced.shape, [2, 70, 80])
 
@@ -560,17 +560,17 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
 
     def test_getitem_with_float(self):
         def test_float_in_slice_item():
-            with fluid.dygraph.guard():
+            with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = fluid.dygraph.to_variable(data)
+                var = base.dygraph.to_variable(data)
                 sliced = var[:, 1.1:, : var.shape[1]]
 
         self.assertRaises(Exception, test_float_in_slice_item)
 
         def test_float_in_index():
-            with fluid.dygraph.guard():
+            with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = fluid.dygraph.to_variable(data)
+                var = base.dygraph.to_variable(data)
                 sliced = var[1.1]
 
         self.assertRaises(Exception, test_float_in_index)

--- a/backends/mlu/tests/unittests/test_softmax_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_softmax_op_mlu.py
@@ -66,7 +66,7 @@ class TestSoftmaxOp(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.apply_along_axis(stable_softmax, self.axis, x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
         self.attrs = {
             "axis": self.axis,

--- a/backends/mlu/tests/unittests/test_sqrt_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_sqrt_op_mlu.py
@@ -34,7 +34,7 @@ class TestSqrt(OpTest):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.sqrt(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):
@@ -59,7 +59,7 @@ class TestSqrtHalf(OpTest):
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
         out = np.sqrt(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def set_mlu(self):

--- a/backends/mlu/tests/unittests/test_square_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_square_op_mlu.py
@@ -40,7 +40,7 @@ class TestSquare(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.square(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):

--- a/backends/mlu/tests/unittests/test_squared_l2_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_squared_l2_norm_op_mlu.py
@@ -49,7 +49,7 @@ class TestL2LossOp(OpTest):
 
 class TestL2LossDeterministic(unittest.TestCase):
     def check_place(self, place):
-        with paddle.fluid.dygraph.guard(place):
+        with paddle.base.dygraph.guard(place):
             x_np = np.random.rand(5, 11, 13).astype("float32")
             x = paddle.to_tensor(x_np)
             y1 = _legacy_C_ops.squared_l2_norm(x)

--- a/backends/mlu/tests/unittests/test_stack_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_stack_op_mlu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -116,13 +116,13 @@ class TestStackOpHalf(TestStackOpBase):
 
 class API_test(unittest.TestCase):
     def test_out(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data("data1", shape=[1, 2], dtype="float32")
             data2 = paddle.static.data("data2", shape=[1, 2], dtype="float32")
             data3 = paddle.static.data("data3", shape=[1, 2], dtype="float32")
             result_stack = paddle.stack([data1, data2, data3], axis=0)
             place = paddle.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             input1 = np.random.random([1, 2]).astype("float32")
             input2 = np.random.random([1, 2]).astype("float32")
             input3 = np.random.random([1, 2]).astype("float32")
@@ -134,7 +134,7 @@ class API_test(unittest.TestCase):
             np.testing.assert_allclose(expected_result, result)
 
     def test_single_tensor_error(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             x = paddle.rand([2, 3])
             self.assertRaises(TypeError, paddle.stack, x)
 
@@ -144,24 +144,24 @@ class API_DygraphTest(unittest.TestCase):
         data1 = np.array([[1.0, 2.0]]).astype("float32")
         data2 = np.array([[3.0, 4.0]]).astype("float32")
         data3 = np.array([[5.0, 6.0]]).astype("float32")
-        with fluid.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
-            x1 = fluid.dygraph.to_variable(data1)
-            x2 = fluid.dygraph.to_variable(data2)
-            x3 = fluid.dygraph.to_variable(data3)
+        with base.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
+            x1 = base.dygraph.to_variable(data1)
+            x2 = base.dygraph.to_variable(data2)
+            x3 = base.dygraph.to_variable(data3)
             result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
         expected_result = np.stack([data1, data2, data3])
         np.testing.assert_allclose(expected_result, result_np)
 
-        with fluid.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
-            y1 = fluid.dygraph.to_variable(data1)
+        with base.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
+            y1 = base.dygraph.to_variable(data1)
             result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
         expected_result_2 = np.stack([data1], axis=0)
         np.testing.assert_allclose(expected_result_2, result_np_2)
 
     def test_single_tensor_error(self):
-        with fluid.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
+        with base.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
             x = paddle.to_tensor([1, 2, 3])
             self.assertRaises(Exception, paddle.stack, x)
 

--- a/backends/mlu/tests/unittests/test_strided_slice_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_strided_slice_op_mlu.py
@@ -16,7 +16,7 @@
 from tests.op_test import OpTest
 import numpy as np
 import unittest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -597,9 +597,9 @@ class TestStridedSliceAPI(unittest.TestCase):
         out_6 = x[minus_3:3:1, 0:100:2, :, minus_1:2:minus_1]
         out_7 = x[minus_1, 0:100:2, :, -1:2:-1]
 
-        exe = fluid.Executor(place=paddle.CustomPlace("mlu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
         res_1, res_2, res_3, res_4, res_5, res_6, res_7 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={
                 "x": input,
                 "starts": np.array([-3, 0, 2]).astype("int32"),

--- a/backends/mlu/tests/unittests/test_tanh_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_tanh_op_mlu.py
@@ -33,7 +33,7 @@ class TestTanh(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = np.tanh(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 
@@ -64,7 +64,7 @@ class TestTanhFp16(OpTest):
         x = np.random.uniform(1, 2, [3, 4]).astype(self.dtype)
         out = np.tanh(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/mlu/tests/unittests/test_tile_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_tile_op_mlu.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -342,7 +342,7 @@ class TestTileOpInt64_t(OpTest):
 class TestTileError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
+            x1 = base.create_lod_tensor(np.array([[-1]]), [[1]], base.CPUPlace())
             repeat_times = [2, 2]
             self.assertRaises(TypeError, paddle.tile, x1, repeat_times)
             x2 = paddle.static.data(name="x2", shape=[-1, 4], dtype="uint8")
@@ -365,7 +365,7 @@ class TestTileAPIStatic(unittest.TestCase):
 # Test python API
 class TestTileAPI(unittest.TestCase):
     def test_api(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.random.random([12, 14]).astype("float32")
             x = paddle.to_tensor(np_x)
 
@@ -386,7 +386,7 @@ class TestTileAPI(unittest.TestCase):
 
 class TestTileAPIFp16(unittest.TestCase):
     def test_api(self):
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.random.random([12, 14]).astype("float16")
             x = paddle.to_tensor(np_x)
 

--- a/backends/mlu/tests/unittests/test_transpose_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_transpose_op_mlu.py
@@ -18,8 +18,8 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 
@@ -253,62 +253,62 @@ class TestTransposeApi(unittest.TestCase):
 
 class TestTAPI(unittest.TestCase):
     def test_out(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10], dtype="float32", name="data")
             data_t = paddle.t(data)
             place = paddle.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             data_np = np.random.random([10]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[10, 5], dtype="float32", name="data")
             data_t = paddle.t(data)
             place = paddle.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             data_np = np.random.random([10, 5]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data = paddle.static.data(shape=[1, 5], dtype="float32", name="data")
             data_t = paddle.t(data)
             place = paddle.CustomPlace("mlu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             data_np = np.random.random([1, 5]).astype("float32")
             (result,) = exe.run(feed={"data": data_np}, fetch_list=[data_t])
             expected_result = np.transpose(data_np)
         self.assertEqual((result == expected_result).all(), True)
 
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.random.random([10]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.random.random([10, 5]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.random.random([1, 5]).astype("float32")
-            data = fluid.dygraph.to_variable(np_x)
+            data = base.dygraph.to_variable(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
         self.assertEqual((np_z == z_expected).all(), True)
 
     def test_errors(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[10, 5, 3], dtype="float32")
 
             def test_x_dimension_check():
@@ -323,7 +323,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 4, 5, 7).astype("float32")
         expected = np.moveaxis(x_np, [0, 4, 3, 2], [1, 3, 2, 0])
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 4, 5, 7], dtype="float32")
             out = paddle.moveaxis(x, [0, 4, 3, 2], [1, 3, 2, 0])
 
@@ -344,7 +344,7 @@ class TestMoveAxis(unittest.TestCase):
         x_np = np.random.randn(2, 3, 5).astype("float32")
         expected = np.moveaxis(x_np, -2, -1)
         paddle.enable_static()
-        with paddle.static.program_guard(fluid.Program()):
+        with paddle.static.program_guard(base.Program()):
             x = paddle.static.data("x", shape=[2, 3, 5], dtype="float32")
             out = x.moveaxis(-2, -1)
 

--- a/backends/mlu/tests/unittests/test_tril_triu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_tril_triu_op_mlu.py
@@ -18,9 +18,9 @@ import unittest
 from tests.op_test import OpTest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.tensor as tensor
-from paddle.fluid.framework import Program, program_guard
+from paddle.base.framework import Program, program_guard
 
 paddle.enable_static()
 
@@ -141,9 +141,9 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                 tril_out, triu_out = tensor.tril(x), tensor.triu(x)
 
                 place = paddle.CustomPlace("mlu", 0)
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 tril_out, triu_out = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"x": data},
                     fetch_list=[tril_out, triu_out],
                 )
@@ -155,14 +155,14 @@ class TestTrilTriuOpAPI(unittest.TestCase):
 
         dtypes = ["float16", "float32", "int32"]
         for dtype in dtypes:
-            with fluid.dygraph.guard():
+            with base.dygraph.guard():
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
-                x = fluid.dygraph.to_variable(data)
+                x = base.dygraph.to_variable(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
                 np.testing.assert_allclose(tril_out, np.tril(data))
                 np.testing.assert_allclose(triu_out, np.triu(data))
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
 
         dtypes = ["float16", "float32", "int32"]
@@ -175,9 +175,9 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                 triu_out = paddle.triu(x)
 
                 place = paddle.CustomPlace("mlu", 0)
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 triu_out = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"x": data},
                     fetch_list=[triu_out],
                 )

--- a/backends/mlu/tests/unittests/test_truncated_gaussian_random_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_truncated_gaussian_random_op_mlu.py
@@ -18,9 +18,9 @@ import unittest
 import numpy
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.executor import Executor
+import paddle.base as base
+import paddle.base.core as core
+from paddle.base.executor import Executor
 
 paddle.enable_static()
 
@@ -38,8 +38,8 @@ class TestTrunctedGaussianRandomOp(unittest.TestCase):
         self.outputs = ["Out"]
 
     def test_cpu(self):
-        self.gaussian_random_test(place=fluid.CPUPlace())
-        self.gaussian_random_test_eager(place=fluid.CPUPlace())
+        self.gaussian_random_test(place=base.CPUPlace())
+        self.gaussian_random_test_eager(place=base.CPUPlace())
 
     def test_mlu(self):
         if core.is_compiled_with_custom_device("mlu"):
@@ -47,7 +47,7 @@ class TestTrunctedGaussianRandomOp(unittest.TestCase):
 
     def gaussian_random_test(self, place):
 
-        program = fluid.Program()
+        program = base.Program()
         block = program.global_block()
         vout = block.create_var(name="Out")
         op = block.append_op(type=self.op_type, outputs={"Out": vout}, attrs=self.attrs)
@@ -68,8 +68,8 @@ class TestTrunctedGaussianRandomOp(unittest.TestCase):
     # TruncatedNormal.__call__ has no return value, so here call _C_ops api
     # directly
     def gaussian_random_test_eager(self, place):
-        with fluid.dygraph.guard(place):
-            with fluid.dygraph.base.guard():
+        with base.dygraph.guard(place):
+            with base.dygraph.base.guard():
                 out = paddle._C_ops.truncated_gaussian_random(
                     self.attrs["shape"],
                     self.attrs["mean"],

--- a/backends/mlu/tests/unittests/test_uniform_random_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_uniform_random_op_mlu.py
@@ -18,10 +18,10 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
 from tests.op import Operator
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -48,7 +48,7 @@ class TestUniformRandomOp(OpTest):
     def func_test_check_api(self):
         places = self._get_places()
         for place in places:
-            with fluid.dygraph.base.guard(place=place):
+            with base.dygraph.base.guard(place=place):
                 out = self.python_api(
                     self.attrs["shape"],
                     "float32",

--- a/backends/mlu/tests/unittests/test_where_index_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_where_index_op_mlu.py
@@ -17,10 +17,10 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.fluid.core as core
+import paddle.base.core as core
 from tests.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 import paddle
 
 paddle.enable_static()
@@ -109,10 +109,10 @@ class TestWhereOpError(unittest.TestCase):
             cond = paddle.static.data(name="cond", shape=[-1, 4], dtype="bool")
             result = paddle.nonzero(cond)
 
-            exe = fluid.Executor(paddle.CustomPlace("mlu", 0))
-            exe.run(fluid.default_startup_program())
+            exe = base.Executor(paddle.CustomPlace("mlu", 0))
+            exe.run(base.default_startup_program())
             cond_i = np.array([True, False, False, False]).astype("bool")
-            out = exe.run(fluid.default_main_program(), feed={"cond": cond_i})
+            out = exe.run(base.default_main_program(), feed={"cond": cond_i})
 
 
 if __name__ == "__main__":

--- a/backends/mps/tests/unittests/test_softmax_op.py
+++ b/backends/mps/tests/unittests/test_softmax_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
 import paddle.nn.functional as F
 
@@ -79,7 +79,7 @@ class TestSoftmaxOp(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.apply_along_axis(stable_softmax, self.axis, x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
         self.attrs = {
             "axis": self.axis,

--- a/backends/npu/tests/unittests/test_activation_op.py
+++ b/backends/npu/tests/unittests/test_activation_op.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy.special import erf, expit
 
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 from tests.op_test import OpTest
 
@@ -46,7 +46,7 @@ class TestActivation(OpTest):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.exp(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_output(self):
@@ -91,7 +91,7 @@ class TestAtan(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.arctan(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -100,19 +100,19 @@ class TestAtan(TestActivation):
         self.check_grad_with_place(self.place, ["X"], "Out")
 
     def test_out_name(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             np_x = np.array([0.1]).astype(np.float32)
             data = paddle.static.data(name="X", shape=[-1, 1])
             out = paddle.atan(data, name="Y")
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             (result,) = exe.run(feed={"X": np_x}, fetch_list=[out])
             expected = np.arctan(np_x)
             self.assertEqual(result, expected)
 
     def test_dygraph(self):
-        with fluid.dygraph.guard(self.place):
+        with base.dygraph.guard(self.place):
             np_x = np.array([0.1])
-            x = fluid.dygraph.to_variable(np_x)
+            x = base.dygraph.to_variable(np_x)
             z = paddle.atan(x).numpy()
             z_expected = np.arctan(np_x)
             self.assertEqual(z, z_expected)
@@ -134,7 +134,7 @@ class TestCos(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = np.cos(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):
@@ -438,7 +438,7 @@ class TestLog(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.log(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -468,7 +468,7 @@ class TestLog2(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.log2(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad_with_place(self):
@@ -477,7 +477,7 @@ class TestLog2(TestActivation):
         self.check_grad_with_place(self.place, ["X"], "Out")
 
     def test_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()
             ):
@@ -501,7 +501,7 @@ class TestLog2(TestActivation):
             np.testing.assert_allclose(res1, expected_res, rtol=rtol)
 
         # dygraph
-        with fluid.dygraph.guard(self.place):
+        with base.dygraph.guard(self.place):
             np_x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
             data_x = paddle.to_tensor(np_x)
             z = paddle.log2(data_x)
@@ -531,7 +531,7 @@ class TestPow(TestActivation):
         x = np.random.uniform(1, 2, self.shape).astype(self.dtype)
         out = np.power(x, 3)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"factor": 3.0}
         self.outputs = {"Out": out}
 
@@ -564,7 +564,7 @@ class TestPow_factor_tensor(TestActivation):
         out = np.power(x, 3)
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
+            "X": OpTest.np_dtype_to_base_dtype(x),
             "FactorTensor": np.array([3.0]).astype("float32"),
         }
 
@@ -721,12 +721,12 @@ class TestRelu6API(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
             out = paddle.nn.functional.relu6(x)
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
         out_ref = ref_relu6(self.x_np)
         np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
@@ -744,7 +744,7 @@ class TestSquare(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.square(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -775,7 +775,7 @@ class TestSqrt(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.sqrt(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -803,7 +803,7 @@ class TestSigmoid(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = 1 / (1 + np.exp(-x))
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -828,7 +828,7 @@ class TestTanh(TestActivation):
         x = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
         out = np.tanh(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_grad(self):
@@ -899,7 +899,7 @@ class TestFloor(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = np.floor(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):
@@ -1100,7 +1100,7 @@ class TestSin(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = np.sin(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):
@@ -1132,7 +1132,7 @@ class TestSwish(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = ref_swish(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
         self.attrs = {"beta": 1.0}
 
@@ -1165,7 +1165,7 @@ class TestSwishAPI(unittest.TestCase):
         self.place = paddle.CustomPlace("npu", 0)
 
     def test_static_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
                 out1 = F.swish(x)
@@ -1188,12 +1188,12 @@ class TestSwishAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
-        with paddle.fluid.framework._static_guard():
-            with fluid.program_guard(fluid.Program()):
+    def test_base_api(self):
+        with paddle.base.framework._static_guard():
+            with base.program_guard(base.Program()):
                 x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.swish(x)
-                exe = fluid.Executor(self.place)
+                exe = base.Executor(self.place)
                 res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
             out_ref = ref_swish(self.x_np)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
@@ -1209,7 +1209,7 @@ class TestSilu(TestActivation):
         np.random.seed(1024)
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = x / (np.exp(-x) + 1)
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_dtype(self):
@@ -1241,7 +1241,7 @@ class TestSiluAPI(unittest.TestCase):
         self.place = paddle.CustomPlace("npu", 0)
 
     def test_static_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data("X", [11, 17])
                 out1 = F.silu(x)
@@ -1281,7 +1281,7 @@ class TestMish(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = ref_mish(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):
@@ -1302,7 +1302,7 @@ class TestMishAPI(unittest.TestCase):
         self.place = paddle.CustomPlace("npu", 0)
 
     def test_static_api(self):
-        with paddle.fluid.framework._static_guard():
+        with paddle.base.framework._static_guard():
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
                 out1 = F.mish(x)
@@ -1325,12 +1325,12 @@ class TestMishAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
-        with paddle.fluid.framework._static_guard():
-            with fluid.program_guard(fluid.Program()):
+    def test_base_api(self):
+        with paddle.base.framework._static_guard():
+            with base.program_guard(base.Program()):
                 x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
                 out = paddle.nn.functional.mish(x)
-                exe = fluid.Executor(self.place)
+                exe = base.Executor(self.place)
                 res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
             out_ref = ref_mish(self.x_np)
             np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)
@@ -1347,7 +1347,7 @@ class TestRound(TestActivation):
         x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         out = np.round(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def init_shape(self):

--- a/backends/npu/tests/unittests/test_adadelta_op_npu.py
+++ b/backends/npu/tests/unittests/test_adadelta_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 
 def adadelta_wrapper(
@@ -176,8 +176,8 @@ class TestAdadeltaV2(unittest.TestCase):
     def test_adadelta(self):
         paddle.enable_static()
         place = paddle.CustomPlace("npu", 0)
-        main = fluid.Program()
-        with fluid.program_guard(main):
+        main = base.Program()
+        with base.program_guard(main):
             x = paddle.static.data(name="x", shape=[-1, 13], dtype="float32")
             y = paddle.static.data(name="y", shape=[-1, 1], dtype="float32")
             y_predict = paddle.static.nn.fc(x, size=1)
@@ -191,9 +191,9 @@ class TestAdadeltaV2(unittest.TestCase):
             train_reader = paddle.batch(
                 paddle.dataset.uci_housing.train(), batch_size=1
             )
-            feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            feeder = base.DataFeeder(place=place, feed_list=[x, y])
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             for data in train_reader():
                 exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
 

--- a/backends/npu/tests/unittests/test_arg_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_max_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_assign_value_op_npu.py
+++ b/backends/npu/tests/unittests/test_assign_value_op_npu.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.framework as framework
+import paddle.base as base
+import paddle.base.framework as framework
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -81,12 +81,12 @@ class TestAssignApi(unittest.TestCase):
         self.dtype = "float32"
 
     def test_assign(self):
-        main_program = fluid.Program()
-        with fluid.program_guard(main_program):
+        main_program = base.Program()
+        with base.program_guard(main_program):
             x = paddle.tensor.create_tensor(dtype=self.dtype)
             paddle.assign(self.value, output=x)
 
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         [fetched_x] = exe.run(main_program, feed={}, fetch_list=[x])
         self.assertTrue(
             numpy.array_equal(fetched_x, self.value),

--- a/backends/npu/tests/unittests/test_bce_loss_npu.py
+++ b/backends/npu/tests/unittests/test_bce_loss_npu.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division
 
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import numpy as np
 import unittest
 from tests.op_test import OpTest
@@ -136,8 +136,8 @@ class TestBCELoss(unittest.TestCase):
     def test_BCELoss(self):
         input_np = np.random.uniform(0.1, 0.8, size=(20, 30)).astype(np.float32)
         label_np = np.random.randint(0, 2, size=(20, 30)).astype(np.float32)
-        places = [fluid.CPUPlace()]
-        if "npu" in paddle.fluid.core.get_all_custom_device_type():
+        places = [base.CPUPlace()]
+        if "npu" in paddle.base.core.get_all_custom_device_type():
             places.append(paddle.CustomPlace("npu", 0))
         reductions = ["sum", "mean", "none"]
         for place in places:
@@ -164,8 +164,8 @@ class TestBCELoss(unittest.TestCase):
         weight_np = np.random.random(size=(3, 4, 10)).astype(np.float32)
         place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
-            else fluid.CPUPlace()
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
+            else base.CPUPlace()
         )
         for reduction in ["sum", "mean", "none"]:
             static_result = test_static_layer(

--- a/backends/npu/tests/unittests/test_bilinear_interp_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_bilinear_interp_v2_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -192,7 +192,7 @@ class TestBilinearInterpOp(OpTest):
         inputs_to_check = ["X"]
         output_names = ["Out"]
         no_grad_set = set()
-        cpu_place = fluid.CPUPlace()
+        cpu_place = base.CPUPlace()
         cpu_grads = self._get_gradient(
             inputs_to_check, cpu_place, output_names, no_grad_set
         )

--- a/backends/npu/tests/unittests/test_cast_op_npu.py
+++ b/backends/npu/tests/unittests/test_cast_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_check_finite_and_unscale_op_npu.py
+++ b/backends/npu/tests/unittests/test_check_finite_and_unscale_op_npu.py
@@ -16,8 +16,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import program_guard
+import paddle.base as base
+from paddle.base import program_guard
 from paddle.static.amp.amp_nn import check_finite_and_unscale
 
 paddle.enable_static()
@@ -39,8 +39,8 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
 
     def run_prog(self, a, b, scale):
         main_program, out, found_inf = self.get_prog()
-        place = fluid.CustomPlace("npu", 0)
-        exe = fluid.Executor(place)
+        place = base.CustomPlace("npu", 0)
+        exe = base.Executor(place)
         out_, founf_inf_ = exe.run(
             main_program,
             feed={"a": a, "b": b, "scale": scale},
@@ -98,8 +98,8 @@ class TestCheckFiniteAndUnscaleClearFloatStatus(unittest.TestCase):
 
     def run_prog(self, a, b, scale):
         main_program, out, found_inf = self.get_prog()
-        place = fluid.CustomPlace("npu", 0)
-        exe = fluid.Executor(place)
+        place = base.CustomPlace("npu", 0)
+        exe = base.Executor(place)
         out_, founf_inf_ = exe.run(
             main_program,
             feed={"a": a, "b": b, "scale": scale},

--- a/backends/npu/tests/unittests/test_clip_op_npu.py
+++ b/backends/npu/tests/unittests/test_clip_op_npu.py
@@ -17,8 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
 
@@ -194,10 +194,10 @@ class TestClipAPI(unittest.TestCase):
 
         place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
-            else fluid.CPUPlace()
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
+            else base.CPUPlace()
         )
-        exe = fluid.Executor(place)
+        exe = base.Executor(place)
 
         out_1 = self._executed_api(images, min=min, max=max)
         out_2 = self._executed_api(images, min=0.2, max=0.9)
@@ -209,7 +209,7 @@ class TestClipAPI(unittest.TestCase):
         out_8 = self._executed_api(images)
 
         res1, res2, res3, res4, res5, res6, res7, res8 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={
                 "image": data,
                 "min": np.array([0.2]).astype("float32"),
@@ -232,8 +232,8 @@ class TestClipAPI(unittest.TestCase):
         paddle.disable_static()
         place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
-            else fluid.CPUPlace()
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
+            else base.CPUPlace()
         )
         paddle.disable_static(place)
         data_shape = [1, 9, 9, 4]

--- a/backends/npu/tests/unittests/test_coalesce_tensor_op_npu.py
+++ b/backends/npu/tests/unittests/test_coalesce_tensor_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.fluid import core
+from paddle.base import core
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -30,7 +30,7 @@ class TestAllocContinuousSpace(OpTest):
     def setUp(self):
         self.__class__.use_custom_device = True
         self.op_type = "coalesce_tensor"
-        self.dtype, self.fluid_dtype = self.init_dtype()
+        self.dtype, self.base_dtype = self.init_dtype()
         attrs = self.init_attr()
         self.copy_data = attrs["copy_data"]
         self.constant = attrs["constant"]
@@ -58,7 +58,7 @@ class TestAllocContinuousSpace(OpTest):
             "set_constant": False,
             "constant": 0.0,
             "use_align": True,
-            "dtype": self.fluid_dtype,
+            "dtype": self.base_dtype,
         }
 
     def init_output(self, input_list, set_constant, constant):
@@ -98,7 +98,7 @@ class TestAllocContinuousSpace2(TestAllocContinuousSpace):
             "set_constant": False,
             "constant": 0.5,
             "use_align": True,
-            "dtype": self.fluid_dtype,
+            "dtype": self.base_dtype,
             "user_defined_size_of_dtype": 2,
         }
 

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
 
@@ -47,7 +47,7 @@ def create_test_class(op_type, typename, callback):
                 a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
                 b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
                 c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
-                d = fluid.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
+                d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
 
                 op = eval("paddle.%s" % self.op_type)
                 self.assertRaises(TypeError, op, x=a, y=b, axis=True)

--- a/backends/npu/tests/unittests/test_concat_op_npu.py
+++ b/backends/npu/tests/unittests/test_concat_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
@@ -205,11 +205,11 @@ class TestConcatAPIWithLoDTensorArray(unittest.TestCase):
         self.input_shape = [2, 3]
         self.x = np.random.random(self.input_shape).astype("float32")
 
-    def set_program(self, use_fluid_api):
+    def set_program(self, use_base_api):
         paddle.enable_static()
-        if use_fluid_api:
-            self.program = fluid.Program()
-            with fluid.program_guard(self.program):
+        if use_base_api:
+            self.program = base.Program()
+            with base.program_guard(self.program):
                 input = paddle.assign(self.x)
                 tensor_array = paddle.tensor.create_array(dtype="float32")
                 zero = paddle.tensor.fill_constant(shape=[1], value=0, dtype="int64")
@@ -233,16 +233,16 @@ class TestConcatAPIWithLoDTensorArray(unittest.TestCase):
     def set_npu(self):
         self.__class__.use_custom_device = True
 
-    def test_fluid_api(self):
-        self._run_static_mode(use_fluid_api=True)
+    def test_base_api(self):
+        self._run_static_mode(use_base_api=True)
 
     def test_paddle_api(self):
-        self._run_static_mode(use_fluid_api=False)
+        self._run_static_mode(use_base_api=False)
 
-    def _run_static_mode(self, use_fluid_api):
-        self.set_program(use_fluid_api)
+    def _run_static_mode(self, use_base_api):
+        self.set_program(use_base_api)
         self.assertTrue(self.out_var.shape[self.axis] == -1)
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         res = exe.run(self.program, fetch_list=self.out_var)
         self.assertTrue(
             np.array_equal(

--- a/backends/npu/tests/unittests/test_conv2d_op_depthwise_conv_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_op_depthwise_conv_npu.py
@@ -205,8 +205,8 @@ class TestDepthwiseConvNPU(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
 
         self.attrs = {
@@ -370,8 +370,8 @@ class TestDepthwiseConvNPU_Padding(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
 
         self.attrs = {

--- a/backends/npu/tests/unittests/test_conv2d_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_op_npu.py
@@ -212,8 +212,8 @@ class TestConv2DOp(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,
@@ -419,8 +419,8 @@ class TestConv2DOp_v2(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,

--- a/backends/npu/tests/unittests/test_conv2d_transpose_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv2d_transpose_op_npu.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 import paddle
 import paddle.nn as nn
-import paddle.fluid.core as core
-import paddle.fluid as fluid
+import paddle.base.core as core
+import paddle.base as base
 
 from tests.op_test import OpTest
 
@@ -581,10 +581,10 @@ class TestConv2DTransposeAPI(unittest.TestCase):
         data2_np = np.random.random((2, 5, 5, 3)).astype("float32")
 
         place = core.CustomPlace("npu", 0)
-        exe = fluid.Executor(place)
-        exe.run(fluid.default_startup_program())
+        exe = base.Executor(place)
+        exe.run(base.default_startup_program())
         results = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"data1": data1_np, "data2": data2_np},
             fetch_list=[out1, out2, out3, out4, out5, out6, out7],
             return_numpy=True,

--- a/backends/npu/tests/unittests/test_conv3d_op_npu.py
+++ b/backends/npu/tests/unittests/test_conv3d_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -212,8 +212,8 @@ class TestConv3DOp(OpTest):
         ).astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,
@@ -267,7 +267,7 @@ class TestConv3DOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = fluid.CustomPlace("npu", 0)
+        self.place = base.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -334,8 +334,8 @@ class TestConv3DOp_2(OpTest):
         ).astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,
@@ -390,7 +390,7 @@ class TestConv3DOp_2(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = fluid.CustomPlace("npu", 0)
+        self.place = base.CustomPlace("npu", 0)
 
     def init_dtype(self):
         self.dtype = np.float32

--- a/backends/npu/tests/unittests/test_cumsum_op_npu.py
+++ b/backends/npu/tests/unittests/test_cumsum_op_npu.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
+import paddle.base.core as core
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -53,7 +53,7 @@ class TestCumsumOp(unittest.TestCase):
         self.assertTrue(np.array_equal(z, y.numpy()))
 
     def run_static(self, use_custom_device=False):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             data_np = np.random.random((100, 100)).astype(np.float32)
             x = paddle.static.data("X", [100, 100])
             y = paddle.cumsum(x)
@@ -63,11 +63,9 @@ class TestCumsumOp(unittest.TestCase):
             y5 = paddle.cumsum(x, dtype=np.int32)
             y6 = paddle.cumsum(x, axis=-2)
 
-            place = (
-                fluid.CustomPlace("npu", 0) if use_custom_device else fluid.CPUPlace()
-            )
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            place = base.CustomPlace("npu", 0) if use_custom_device else base.CPUPlace()
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             out = exe.run(
                 feed={"X": data_np},
                 fetch_list=[y.name, y2.name, y3.name, y4.name, y5.name, y6.name],
@@ -90,7 +88,7 @@ class TestCumsumOp(unittest.TestCase):
         self.run_static(use_custom_device=True)
 
     def test_name(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("x", [3, 4])
             y = paddle.cumsum(x, name="out")
             self.assertTrue("out" in y.name)

--- a/backends/npu/tests/unittests/test_deformable_conv_op_npu.py
+++ b/backends/npu/tests/unittests/test_deformable_conv_op_npu.py
@@ -160,10 +160,10 @@ class TestModulatedDeformableConvOp(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Offset": OpTest.np_dtype_to_fluid_dtype(offset),
-            "Mask": OpTest.np_dtype_to_fluid_dtype(mask),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Offset": OpTest.np_dtype_to_base_dtype(offset),
+            "Mask": OpTest.np_dtype_to_base_dtype(mask),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,
@@ -281,10 +281,10 @@ class TestWithDilation(OpTest):
         output = output.astype(self.dtype)
 
         self.inputs = {
-            "Input": OpTest.np_dtype_to_fluid_dtype(input),
-            "Offset": OpTest.np_dtype_to_fluid_dtype(offset),
-            "Mask": OpTest.np_dtype_to_fluid_dtype(mask),
-            "Filter": OpTest.np_dtype_to_fluid_dtype(filter),
+            "Input": OpTest.np_dtype_to_base_dtype(input),
+            "Offset": OpTest.np_dtype_to_base_dtype(offset),
+            "Mask": OpTest.np_dtype_to_base_dtype(mask),
+            "Filter": OpTest.np_dtype_to_base_dtype(filter),
         }
         self.attrs = {
             "strides": self.stride,

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 import unittest
 
 import numpy as np
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest, skip_check_grad_ci
 
 import paddle
@@ -302,10 +302,10 @@ _list = [
 class TestDropoutAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
-        self.places = [fluid.CPUPlace(), paddle.CustomPlace("npu", 0)]
+        self.places = [base.CPUPlace(), paddle.CustomPlace("npu", 0)]
 
     def check_static_result(self, place):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = paddle.static.data(name="input", shape=[40, 40], dtype="float32")
             res1 = paddle.nn.functional.dropout(
                 x=input, p=0.0, training=False, mode="upscale_in_train"
@@ -359,7 +359,7 @@ class TestDropoutAPI(unittest.TestCase):
             res_np = in_np
             res_np2 = np.zeros_like(in_np)
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             res_list = [
                 res1,
                 res2,
@@ -378,13 +378,13 @@ class TestDropoutAPI(unittest.TestCase):
             ]
             for res in res_list:
                 fetches = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"input": in_np},
                     fetch_list=[res],
                 )
                 self.assertTrue(np.allclose(fetches[0], res_np))
             fetches2 = exe.run(
-                fluid.default_main_program(), feed={"input": in_np}, fetch_list=[res6]
+                base.default_main_program(), feed={"input": in_np}, fetch_list=[res6]
             )
             self.assertTrue(np.allclose(fetches2[0], res_np2))
 

--- a/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
@@ -35,8 +35,8 @@ class TestElementwiseAddOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis, "use_mkldnn": self.use_mkldnn}
         self.outputs = {"Out": self.out}
@@ -216,10 +216,10 @@ class TestAddError(unittest.TestCase):
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             # the input of elementwise_add must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], paddle.CustomPlace("npu", 0)
             )
-            y1 = fluid.create_lod_tensor(
+            y1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], paddle.CustomPlace("npu", 0)
             )
             self.assertRaises(TypeError, paddle.add, x1, y1)
@@ -490,7 +490,7 @@ class TestAddApi(unittest.TestCase):
         return paddle.add(x, y, name)
 
     def test_name(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
             y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
@@ -498,7 +498,7 @@ class TestAddApi(unittest.TestCase):
             self.assertEqual(("add_res" in y_1.name), True)
 
     def test_declarative(self):
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
 
             def gen_data():
                 return {
@@ -511,17 +511,17 @@ class TestAddApi(unittest.TestCase):
             z = self._executed_api(x, y)
 
             place = paddle.CustomPlace("npu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 
     def test_dygraph(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.array([2, 3, 4]).astype("float32")
             np_y = np.array([1, 5, 2]).astype("float32")
-            x = fluid.dygraph.to_variable(np_x)
-            y = fluid.dygraph.to_variable(np_y)
+            x = base.dygraph.to_variable(np_x)
+            y = base.dygraph.to_variable(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/backends/npu/tests/unittests/test_elementwise_div_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_div_op_npu.py
@@ -38,8 +38,8 @@ class TestElementwiseDiv(OpTest):
         out = np.divide(x, y)
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(y),
+            "X": OpTest.np_dtype_to_base_dtype(x),
+            "Y": OpTest.np_dtype_to_base_dtype(y),
         }
         self.attrs = {}
         self.outputs = {"Out": out}
@@ -87,8 +87,8 @@ class TestElementwiseDivFp16(OpTest):
         out = np.divide(x, y)
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(y),
+            "X": OpTest.np_dtype_to_base_dtype(x),
+            "Y": OpTest.np_dtype_to_base_dtype(y),
         }
         self.attrs = {}
         self.outputs = {"Out": out}

--- a/backends/npu/tests/unittests/test_elementwise_floordiv_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_floordiv_op_npu.py
@@ -31,8 +31,8 @@ class TestElementwiseFloorDiv(OpTest):
         self.init_input_output()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {}
         self.outputs = {"Out": self.out}

--- a/backends/npu/tests/unittests/test_elementwise_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_max_op_npu.py
@@ -97,8 +97,8 @@ class TestElementwiseMaxOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}

--- a/backends/npu/tests/unittests/test_elementwise_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_min_op_npu.py
@@ -32,8 +32,8 @@ class TestElementwiseMinOp(OpTest):
         self.init_dtype()
         self.init_input_output()
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis}

--- a/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
@@ -20,7 +20,7 @@ import unittest
 from tests.op_test import OpTest
 
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 import random
 
@@ -39,8 +39,8 @@ class TestElementwiseModOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis, "use_mkldnn": self.use_mkldnn}
         self.outputs = {"Out": self.out}
@@ -142,7 +142,7 @@ class TestElementwiseModOp_broadcast_2(TestElementwiseModOp):
 class TestRemainderOp(unittest.TestCase):
     def test_name(self):
         paddle.set_device("npu:0")
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data(name="x", shape=[2, 3], dtype="int64")
             y = paddle.static.data(name="y", shape=[2, 3], dtype="int64")
             y_1 = paddle.remainder(x, y, name="div_res")
@@ -150,7 +150,7 @@ class TestRemainderOp(unittest.TestCase):
 
     def test_dygraph(self):
         paddle.set_device("npu:0")
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             np_x = np.array([2, 3, 8, 7]).astype("int64")
             np_y = np.array([1, 5, 3, 3]).astype("int64")
             x = paddle.to_tensor(np_x)

--- a/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
@@ -37,8 +37,8 @@ class ElementwiseMulOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.outputs = {"Out": self.out}
         self.attrs = {"axis": self.axis}

--- a/backends/npu/tests/unittests/test_elementwise_pow_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_pow_op_npu.py
@@ -89,8 +89,8 @@ class TestElementwisePow(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis}
         self.outputs = {"Out": self.out}

--- a/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -37,8 +37,8 @@ class TestElementwiseSubOp(OpTest):
         self.init_axis()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(self.x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(self.y),
+            "X": OpTest.np_dtype_to_base_dtype(self.x),
+            "Y": OpTest.np_dtype_to_base_dtype(self.y),
         }
         self.attrs = {"axis": self.axis, "use_mkldnn": self.use_mkldnn}
         self.outputs = {"Out": self.out}
@@ -150,10 +150,10 @@ class TestSubtractError(unittest.TestCase):
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
             # the input of elementwise_add must be Variable.
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], paddle.CustomPlace("npu", 0)
             )
-            y1 = fluid.create_lod_tensor(
+            y1 = base.create_lod_tensor(
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], paddle.CustomPlace("npu", 0)
             )
             self.assertRaises(TypeError, paddle.subtract, x1, y1)

--- a/backends/npu/tests/unittests/test_elu_op_npu.py
+++ b/backends/npu/tests/unittests/test_elu_op_npu.py
@@ -18,7 +18,7 @@ from tests.op_test import OpTest
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 
 SEED = 2021
@@ -113,12 +113,12 @@ class TestEluAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
             out = F.elu(x, self.alpha)
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
         out_ref = ref_elu(self.x_np, self.alpha)
         np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)

--- a/backends/npu/tests/unittests/test_expand_as_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_expand_as_v2_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 np.random.seed(10)
@@ -128,9 +128,9 @@ class TestExpandAsV2API(unittest.TestCase):
 
         out_1 = paddle.expand_as(x, y=y)
 
-        exe = fluid.Executor(place=fluid.CustomPlace("npu", 0))
+        exe = base.Executor(place=base.CustomPlace("npu", 0))
         res_1 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input1, "target_tensor": input2},
             fetch_list=[out_1],
         )

--- a/backends/npu/tests/unittests/test_expand_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_expand_v2_op_npu.py
@@ -17,8 +17,8 @@ import unittest
 import numpy as np
 
 from tests.op_test import OpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 import paddle
 
 paddle.enable_static()
@@ -264,7 +264,7 @@ class TesstExpandV2OpBool(TestExpandV2OpInteger):
 class TestExpandV2Error(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            x1 = fluid.create_lod_tensor(
+            x1 = base.create_lod_tensor(
                 np.array([[-1]]), [[1]], paddle.CustomPlace("npu", 0)
             )
             shape = [2, 2]
@@ -279,7 +279,7 @@ class TestExpandV2Error(unittest.TestCase):
 # Test python API
 class TestExpandV2API(unittest.TestCase):
     def test_static(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = np.random.random([12, 14]).astype("float32")
             x = paddle.static.data(name="x", shape=[12, 14], dtype="float32")
 
@@ -292,11 +292,11 @@ class TestExpandV2API(unittest.TestCase):
             out_2 = paddle.expand(x, shape=[positive_2, 14])
             out_3 = paddle.expand(x, shape=expand_shape)
 
-            g0 = fluid.backward.calc_gradient(out_2, x)
+            g0 = base.backward.calc_gradient(out_2, x)
 
-            exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+            exe = base.Executor(place=paddle.CustomPlace("npu", 0))
             res_1, res_2, res_3 = exe.run(
-                fluid.default_main_program(),
+                base.default_main_program(),
                 feed={"x": input, "expand_shape": np.array([12, 14]).astype("int32")},
                 fetch_list=[out_1, out_2, out_3],
             )

--- a/backends/npu/tests/unittests/test_eye_op_npu.py
+++ b/backends/npu/tests/unittests/test_eye_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid.framework as framework
+import paddle.base.framework as framework
 from tests.op_test import OpTest
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_fill_constant_batch_size_like_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_constant_batch_size_like_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest
 import paddle
-from paddle.fluid import core
+from paddle.base import core
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_fill_constant_op_npu.py
+++ b/backends/npu/tests/unittests/test_fill_constant_op_npu.py
@@ -19,7 +19,7 @@ import unittest
 
 from tests.op_test import OpTest
 import paddle
-from paddle.fluid import core
+from paddle.base import core
 
 paddle.enable_static()
 SEED = 2021

--- a/backends/npu/tests/unittests/test_flip_op_npu.py
+++ b/backends/npu/tests/unittests/test_flip_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 
 paddle.enable_static()
@@ -29,16 +29,16 @@ class TestFlipOp_API(unittest.TestCase):
 
     def test_static_graph(self):
         paddle.enable_static()
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             axis = [0]
             input = paddle.static.data(name="input", dtype="float32", shape=[2, 3])
             output = paddle.flip(input, axis)
             output = paddle.flip(output, -1)
             output = output.flip(0)
             place = paddle.CustomPlace("npu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             exe.run(startup_program)
             img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
             res = exe.run(train_program, feed={"input": img}, fetch_list=[output])
@@ -52,8 +52,8 @@ class TestFlipOp_API(unittest.TestCase):
     def test_dygraph(self):
         paddle.disable_static(paddle.CustomPlace("npu", 0))
         img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
-        with fluid.dygraph.guard():
-            inputs = fluid.dygraph.to_variable(img)
+        with base.dygraph.guard():
+            inputs = base.dygraph.to_variable(img)
             ret = paddle.flip(inputs, [0])
             ret = ret.flip(0)
             ret = paddle.flip(ret, 1)

--- a/backends/npu/tests/unittests/test_gather_nd_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_nd_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 
 from tests.op_test import OpTest
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 
@@ -259,8 +259,8 @@ class TestGatherNdAPI(unittest.TestCase):
         paddle.disable_static()
         input_1 = np.array([[1, 2], [3, 4], [5, 6]])
         index_1 = np.array([[1]])
-        input = fluid.dygraph.to_variable(input_1)
-        index = fluid.dygraph.to_variable(index_1)
+        input = base.dygraph.to_variable(input_1)
+        index = base.dygraph.to_variable(index_1)
         output = paddle.gather(input, index)
         output_np = output.numpy()
         expected_output = np.array([3, 4])

--- a/backends/npu/tests/unittests/test_gather_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -121,12 +121,12 @@ class TestCase4(TestGatherOp):
 
 class API_TestGather(unittest.TestCase):
     def test_out1(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data("data1", shape=[-1, 2], dtype="float32")
             index = paddle.static.data("index", shape=[-1, 1], dtype="int32")
             out = paddle.gather(data1, index)
             place = paddle.CustomPlace("npu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             input = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
             index_1 = np.array([1, 2]).astype("int32")
             (result,) = exe.run(

--- a/backends/npu/tests/unittests/test_group_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_group_norm_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -45,7 +45,7 @@ def group_norm_naive(x, scale, bias, epsilon, groups, data_layout):
 
 class TestGroupNormOpError(unittest.TestCase):
     def test_errors(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
 
             def test_x_type():
                 input = np.random.random(2, 100, 3, 5).astype("float32")
@@ -94,9 +94,9 @@ class TestGroupNormOp(OpTest):
         )
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(input),
-            "Scale": OpTest.np_dtype_to_fluid_dtype(scale),
-            "Bias": OpTest.np_dtype_to_fluid_dtype(bias),
+            "X": OpTest.np_dtype_to_base_dtype(input),
+            "Scale": OpTest.np_dtype_to_base_dtype(scale),
+            "Bias": OpTest.np_dtype_to_base_dtype(bias),
         }
         self.outputs = {"Y": output, "Mean": mean, "Variance": var}
         self.attrs["data_layout"] = self.data_format

--- a/backends/npu/tests/unittests/test_hard_sigmoid_op_npu.py
+++ b/backends/npu/tests/unittests/test_hard_sigmoid_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 from tests.op_test import OpTest
 
@@ -122,11 +122,11 @@ class TestHardsigmoidAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
-        with fluid.program_guard(fluid.Program()):
+    def test_base_api(self):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
             out = paddle.nn.functional.hardsigmoid(x, slope=0.2)
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
         out_ref = ref_hardsigmoid(self.x_np, 0.2, 0.5)
         np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)

--- a/backends/npu/tests/unittests/test_hard_tanh_op_npu.py
+++ b/backends/npu/tests/unittests/test_hard_tanh_op_npu.py
@@ -51,7 +51,7 @@ class TestHardTanh(OpTest):
         t[t < t_min] = t_min
         t[t > t_max] = t_max
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {"t_min": t_min, "t_max": t_max}
         self.outputs = {"Out": t}
 

--- a/backends/npu/tests/unittests/test_histogram_op_npu.py
+++ b/backends/npu/tests/unittests/test_histogram_op_npu.py
@@ -18,18 +18,18 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 
 class TestHistogramOpError(unittest.TestCase):
     """Test histogram op error."""
 
     def run_network(self, net_func):
-        main_program = fluid.Program()
-        startup_program = fluid.Program()
-        with fluid.program_guard(main_program, startup_program):
+        main_program = base.Program()
+        startup_program = base.Program()
+        with base.program_guard(main_program, startup_program):
             net_func()
-            exe = fluid.Executor()
+            exe = base.Executor()
             exe.run(main_program)
 
     def test_bins_error(self):

--- a/backends/npu/tests/unittests/test_huber_loss_op_npu.py
+++ b/backends/npu/tests/unittests/test_huber_loss_op_npu.py
@@ -48,8 +48,8 @@ class TestHuberLossOp(OpTest):
         x = np.random.uniform(0, 1.0, shape).astype(self.dtype)
         y = np.random.uniform(0, 1.0, shape).astype(self.dtype)
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(x),
-            "Y": OpTest.np_dtype_to_fluid_dtype(y),
+            "X": OpTest.np_dtype_to_base_dtype(x),
+            "Y": OpTest.np_dtype_to_base_dtype(y),
         }
 
     def set_attrs(self):

--- a/backends/npu/tests/unittests/test_increment_op_npu.py
+++ b/backends/npu/tests/unittests/test_increment_op_npu.py
@@ -32,7 +32,7 @@ class TestIncrement(OpTest):
         self.init_dtype()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(np.array([1]).astype(self.dtype)),
+            "X": OpTest.np_dtype_to_base_dtype(np.array([1]).astype(self.dtype)),
         }
 
         self.attrs = {"Step": 1}
@@ -57,7 +57,7 @@ class TestIncrementFP16(OpTest):
         self.init_dtype()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(np.array([1]).astype(self.dtype)),
+            "X": OpTest.np_dtype_to_base_dtype(np.array([1]).astype(self.dtype)),
         }
         self.pre_input_id = id(self.inputs["X"])
 
@@ -82,7 +82,7 @@ class TestIncrementINT64(OpTest):
         self.init_dtype()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(np.array([1]).astype(self.dtype)),
+            "X": OpTest.np_dtype_to_base_dtype(np.array([1]).astype(self.dtype)),
         }
         self.pre_input_id = id(self.inputs["X"])
 

--- a/backends/npu/tests/unittests/test_index_sample_op_npu.py
+++ b/backends/npu/tests/unittests/test_index_sample_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -163,9 +163,9 @@ class TestIndexSampleShape(unittest.TestCase):
         index = paddle.static.data(name="index", shape=[-1, 3], dtype="int32")
         output = paddle.index_sample(x=x, index=index)
 
-        place = fluid.CustomPlace("npu", 0)
-        exe = fluid.Executor(place=place)
-        exe.run(fluid.default_startup_program())
+        place = base.CustomPlace("npu", 0)
+        exe = base.Executor(place=place)
+        exe.run(base.default_startup_program())
 
         feed = {"x": x_np, "index": index_np}
         res = exe.run(feed=feed, fetch_list=[output])
@@ -173,7 +173,7 @@ class TestIndexSampleShape(unittest.TestCase):
 
 class TestIndexSampleDynamic(unittest.TestCase):
     def test_result(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             x = paddle.to_tensor(
                 [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
                 dtype="float32",

--- a/backends/npu/tests/unittests/test_inverse_op_npu.py
+++ b/backends/npu/tests/unittests/test_inverse_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 
 class TestInverseOp(OpTest):
@@ -95,15 +95,15 @@ class TestInverseAPI(unittest.TestCase):
 
     def check_static_result(self, place):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input = paddle.static.data(name="input", shape=[4, 4], dtype="float64")
             result = paddle.inverse(x=input)
             input_np = np.random.random([4, 4]).astype("float64")
             result_np = np.linalg.inv(input_np)
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             fetches = exe.run(
-                fluid.default_main_program(),
+                base.default_main_program(),
                 feed={"input": input_np},
                 fetch_list=[result],
             )
@@ -115,9 +115,9 @@ class TestInverseAPI(unittest.TestCase):
 
     def test_dygraph(self):
         for place in self.places:
-            with fluid.dygraph.guard(place):
+            with base.dygraph.guard(place):
                 input_np = np.random.random([4, 4]).astype("float64")
-                input = fluid.dygraph.to_variable(input_np)
+                input = base.dygraph.to_variable(input_np)
                 result = paddle.inverse(input)
                 np.testing.assert_allclose(
                     result.numpy(), np.linalg.inv(input_np), rtol=1e-05

--- a/backends/npu/tests/unittests/test_isfinite_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_isfinite_v2_op_npu.py
@@ -17,16 +17,16 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 
 def run_static(x_np, dtype, op_str):
     paddle.enable_static()
-    startup_program = fluid.Program()
-    main_program = fluid.Program()
+    startup_program = base.Program()
+    main_program = base.Program()
     place = paddle.CustomPlace("npu", 0)
-    exe = fluid.Executor(place)
-    with fluid.program_guard(main_program, startup_program):
+    exe = base.Executor(place)
+    with base.program_guard(main_program, startup_program):
         x = paddle.static.data(name="x", shape=x_np.shape, dtype=dtype)
         res = getattr(paddle.tensor, op_str)(x)
         exe.run(startup_program)
@@ -43,7 +43,7 @@ def run_dygraph(x_np, op_str):
 
 
 def run_eager(x_np, op_str):
-    with paddle.fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+    with paddle.base.dygraph.guard(paddle.CustomPlace("npu", 0)):
         x = paddle.to_tensor(x_np)
         dygraph_result = getattr(paddle.tensor, op_str)(x)
         return dygraph_result

--- a/backends/npu/tests/unittests/test_kldiv_loss_op_npu.py
+++ b/backends/npu/tests/unittests/test_kldiv_loss_op_npu.py
@@ -138,7 +138,7 @@ class TestKLDivLossDygraph(unittest.TestCase):
         target = np.random.uniform(-10, 10, shape).astype("float32")
         gt_loss = kldiv_loss(x, target, reduction)
 
-        with paddle.fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with paddle.base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             kldiv_criterion = paddle.nn.KLDivLoss(reduction)
             pred_loss = kldiv_criterion(paddle.to_tensor(x), paddle.to_tensor(target))
             self.assertTrue(np.allclose(pred_loss.numpy(), gt_loss))
@@ -167,7 +167,7 @@ class TestKLDivLossDygraph(unittest.TestCase):
 
 class TestKLDivLossTypePromotion(unittest.TestCase):
     def test_kl_div_promotion(self):
-        with paddle.fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with paddle.base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             x1 = paddle.rand([5, 20], dtype="float32")
             target1 = paddle.rand([5, 20], dtype="float32")
 

--- a/backends/npu/tests/unittests/test_label_smooth_op_npu.py
+++ b/backends/npu/tests/unittests/test_label_smooth_op_npu.py
@@ -51,7 +51,7 @@ class TestLabelSmoothOp(OpTest):
         x = np.zeros((batch_size, label_dim)).astype(self.dtype)
         nonzero_index = np.random.randint(label_dim, size=(batch_size))
         x[np.arange(batch_size), nonzero_index] = 1
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
 
     def set_attrs(self):
         epsilon = 0.1

--- a/backends/npu/tests/unittests/test_layer_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_layer_norm_op_npu.py
@@ -20,8 +20,8 @@ from operator import mul
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
+import paddle.base as base
+import paddle.base.core as core
 
 paddle.enable_static()
 
@@ -177,8 +177,8 @@ class TestLayerNormOp(unittest.TestCase):
                 var_names += ["bias"]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = fluid.Program()
-            with fluid.program_guard(program):
+            program = base.Program()
+            with base.program_guard(program):
                 block = program.global_block()
                 for name in ground_truth:
                     block.create_var(
@@ -227,7 +227,7 @@ class TestLayerNormOp(unittest.TestCase):
                     grad_var.set_dtype(core.VarDesc.VarType.FP32)
 
                 program._sync_with_cpp()
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 out = exe.run(
                     program,
                     feed={

--- a/backends/npu/tests/unittests/test_linspace_op_npu.py
+++ b/backends/npu/tests/unittests/test_linspace_op_npu.py
@@ -18,8 +18,8 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
+import paddle.base as base
+from paddle.base import core
 
 paddle.enable_static()
 
@@ -138,13 +138,13 @@ class TestLinspaceOpNumOneCase(OpTest):
 class TestLinspaceAPI(unittest.TestCase):
     def test_variable_input1(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             start = paddle.full(shape=[1], fill_value=0, dtype="float32")
             stop = paddle.full(shape=[1], fill_value=10, dtype="float32")
             num = paddle.full(shape=[1], fill_value=5, dtype="int32")
             out = paddle.linspace(start, stop, num, dtype="float32")
-            exe = fluid.Executor(paddle.CustomPlace("npu", 0))
-            res = exe.run(fluid.default_main_program(), fetch_list=[out])
+            exe = base.Executor(paddle.CustomPlace("npu", 0))
+            res = exe.run(base.default_main_program(), fetch_list=[out])
         np_res = np.linspace(0, 10, 5, dtype="float32")
         self.assertEqual((res == np_res).all(), True)
 

--- a/backends/npu/tests/unittests/test_log_softmax_op_npu.py
+++ b/backends/npu/tests/unittests/test_log_softmax_op_npu.py
@@ -126,7 +126,7 @@ class TestNNLogSoftmaxAPI(unittest.TestCase):
         self.x = np.random.uniform(-1.0, 1.0, self.x_shape).astype(np.float32)
         self.place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
 
@@ -160,7 +160,7 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
         self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
         self.place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
 

--- a/backends/npu/tests/unittests/test_lookup_table_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_lookup_table_v2_op_npu.py
@@ -43,8 +43,8 @@ class TestLookupTableV2(OpTest):
             out[np.squeeze(x == self.padding_idx)] = np.zeros(self.dim)
 
         self.inputs = {
-            "W": OpTest.np_dtype_to_fluid_dtype(w),
-            "Ids": OpTest.np_dtype_to_fluid_dtype(x),
+            "W": OpTest.np_dtype_to_base_dtype(w),
+            "Ids": OpTest.np_dtype_to_base_dtype(x),
         }
         self.attrs = {
             "is_sparse": False,

--- a/backends/npu/tests/unittests/test_matmulv2_op_npu.py
+++ b/backends/npu/tests/unittests/test_matmulv2_op_npu.py
@@ -18,11 +18,11 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 from tests.op_test import OpTest
 from paddle.framework import set_flags
-from paddle.fluid import Program, program_guard
+from paddle.base import Program, program_guard
 
 
 paddle.enable_static()
@@ -431,7 +431,7 @@ class TestMatMulV2API(unittest.TestCase):
         self.places.append(paddle.CustomPlace("npu", 0))
 
     def check_static_result(self, place):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             input_x = paddle.static.data(name="input_x", shape=[4, 3], dtype="float32")
             input_y = paddle.static.data(name="input_y", shape=[3, 4], dtype="float32")
 
@@ -440,9 +440,9 @@ class TestMatMulV2API(unittest.TestCase):
             x_np = np.random.random([4, 3]).astype("float32")
             y_np = np.random.random([3, 4]).astype("float32")
 
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             fetches = exe.run(
-                fluid.default_main_program(),
+                base.default_main_program(),
                 feed={"input_x": x_np, "input_y": y_np},
                 fetch_list=[result],
             )
@@ -453,7 +453,7 @@ class TestMatMulV2API(unittest.TestCase):
 
     def test_dygraph(self):
         for place in self.places:
-            with fluid.dygraph.guard(place):
+            with base.dygraph.guard(place):
                 input_x = np.random.random([4, 3]).astype("float32")
                 input_y = np.random.random([3, 4]).astype("float32")
                 x = paddle.to_tensor(input_x)
@@ -462,7 +462,7 @@ class TestMatMulV2API(unittest.TestCase):
 
     def test_dygraph_fp16(self):
         place = paddle.CustomPlace("npu", 0)
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_x = np.random.random([4, 3]).astype("float16")
             input_y = np.random.random([3, 4]).astype("float16")
             x = paddle.to_tensor(input_x)
@@ -477,7 +477,7 @@ class TestDygraphMatmulTrainableStats(unittest.TestCase):
 
         def compute(x, y, npu_storage):
             set_flags({"FLAGS_npu_storage_format": npu_storage})
-            with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+            with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
                 x = paddle.to_tensor(x)
                 y = paddle.to_tensor(y)
                 if npu_storage:
@@ -493,7 +493,7 @@ class TestDygraphMatmulTrainableStats(unittest.TestCase):
         np.testing.assert_allclose(z1, z2, rtol=1e-05)
 
     def test_static(self):
-        exe = fluid.Executor(paddle.CustomPlace("npu", 0))
+        exe = base.Executor(paddle.CustomPlace("npu", 0))
         shape = [3, 2]
         paddle.set_default_dtype("float16")
 
@@ -512,7 +512,7 @@ class TestDygraphMatmulTrainableStats(unittest.TestCase):
                 )
                 x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
                 y = linear(x)
-                exe.run(fluid.default_startup_program())
+                exe.run(base.default_startup_program())
                 r = exe.run(feed={"x": x_np}, fetch_list=[y])[0]
             return r
 
@@ -533,7 +533,7 @@ class TestDygraphMatmulTrainableStats(unittest.TestCase):
                 x = paddle.static.data(name="x", shape=x_np.shape, dtype=x_np.dtype)
                 x = paddle.incubate._npu_identity(x, 29)
                 y = linear(x)
-                exe.run(fluid.default_startup_program())
+                exe.run(base.default_startup_program())
                 r = exe.run(feed={"x": x_np}, fetch_list=[y])[0]
             return r
 

--- a/backends/npu/tests/unittests/test_memcpy_op_npu.py
+++ b/backends/npu/tests/unittests/test_memcpy_op_npu.py
@@ -18,8 +18,8 @@ import numpy as np
 import unittest
 
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 
 paddle.enable_static()
 SEED = 2021
@@ -78,7 +78,7 @@ class TestMemcpy_FillConstant(unittest.TestCase):
             attrs={"dst_place_type": 0},
         )
         place = paddle.CustomPlace("npu", 0)
-        exe = fluid.Executor(place)
+        exe = base.Executor(place)
         npu_, cpu_ = exe.run(
             main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
         )
@@ -95,7 +95,7 @@ class TestMemcpy_FillConstant(unittest.TestCase):
             attrs={"dst_place_type": 6},
         )
         place = paddle.CustomPlace("npu", 0)
-        exe = fluid.Executor(place)
+        exe = base.Executor(place)
         npu_, cpu_ = exe.run(
             main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
         )

--- a/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 import unittest
 
 import paddle
-from paddle.fluid.layer_helper import LayerHelper
+from paddle.base.layer_helper import LayerHelper
 from collections import OrderedDict
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_meshgrid_op_npu.py
+++ b/backends/npu/tests/unittests/test_meshgrid_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -111,10 +111,10 @@ class TestMeshgridOp3(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid(x, y)
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )
@@ -148,10 +148,10 @@ class TestMeshgridOp4(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid([x, y])
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )
@@ -185,10 +185,10 @@ class TestMeshgridOp5(unittest.TestCase):
         out_2 = np.reshape(input_2, [1, 200])
         out_2 = np.broadcast_to(out_2, [100, 200])
 
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
         grid_x, grid_y = paddle.tensor.meshgrid((x, y))
         res_1, res_2 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x": input_1, "y": input_2},
             fetch_list=[grid_x, grid_y],
         )

--- a/backends/npu/tests/unittests/test_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_momentum_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -131,8 +131,8 @@ class TestMomentumV2(unittest.TestCase):
     def test_momentum(self):
         paddle.enable_static()
         place = paddle.CustomPlace("npu", 0)
-        main = fluid.Program()
-        with fluid.program_guard(main):
+        main = base.Program()
+        with base.program_guard(main):
             x = paddle.static.data(name="x", shape=[-1, 13], dtype="float32")
             y = paddle.static.data(name="y", shape=[-1, 1], dtype="float32")
             y_predict = paddle.static.nn.fc(x, size=1, activation=None)
@@ -146,9 +146,9 @@ class TestMomentumV2(unittest.TestCase):
             train_reader = paddle.batch(
                 paddle.dataset.uci_housing.train(), batch_size=1
             )
-            feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            feeder = base.DataFeeder(place=place, feed_list=[x, y])
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             for data in train_reader():
                 exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
 
@@ -253,8 +253,8 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
     def test_momentum_static(self):
         paddle.enable_static()
         place = paddle.CustomPlace("npu", 0)
-        main = fluid.Program()
-        with fluid.program_guard(main):
+        main = base.Program()
+        with base.program_guard(main):
             x = paddle.static.data(name="x", shape=[-1, 13], dtype="float32")
             y = paddle.static.data(name="y", shape=[-1, 1], dtype="float32")
             y_predict = paddle.static.nn.fc(x, size=1, activation=None)
@@ -270,9 +270,9 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
             train_reader = paddle.batch(
                 paddle.dataset.uci_housing.train(), batch_size=1
             )
-            feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
-            exe = fluid.Executor(place)
-            exe.run(fluid.default_startup_program())
+            feeder = base.DataFeeder(place=place, feed_list=[x, y])
+            exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             for data in train_reader():
                 exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
 

--- a/backends/npu/tests/unittests/test_multinomial_op_npu.py
+++ b/backends/npu/tests/unittests/test_multinomial_op_npu.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 from tests.op_test import OpTest
 import numpy as np
@@ -165,14 +165,14 @@ class TestMultinomialApi(unittest.TestCase):
 
     def test_static(self):
         paddle.set_device("npu:0")
-        startup_program = fluid.Program()
-        train_program = fluid.Program()
-        with fluid.program_guard(train_program, startup_program):
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
             x = paddle.static.data("x", shape=[4], dtype="float32")
             out = paddle.multinomial(x, num_samples=100000, replacement=True)
 
-            place = fluid.CustomPlace("npu", 0)
-            exe = fluid.Executor(place)
+            place = base.CustomPlace("npu", 0)
+            exe = base.Executor(place)
 
         exe.run(startup_program)
         x_np = np.random.rand(4).astype("float32")

--- a/backends/npu/tests/unittests/test_nearest_interp_op_npu.py
+++ b/backends/npu/tests/unittests/test_nearest_interp_op_npu.py
@@ -17,8 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from tests.op_test import OpTest
-import paddle.fluid.core as core
-import paddle.fluid as fluid
+import paddle.base.core as core
+import paddle.base as base
 import paddle
 from paddle.nn.functional import interpolate
 
@@ -450,11 +450,11 @@ class TestNearestInterpOpAPI_dy(unittest.TestCase):
     def test_case(self):
         import paddle
 
-        if "npu" in paddle.fluid.core.get_all_custom_device_type():
+        if "npu" in paddle.base.core.get_all_custom_device_type():
             place = paddle.CustomPlace("npu", 0)
         else:
             place = core.CPUPlace()
-        with fluid.dygraph.guard(place):
+        with base.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
             scale_np = np.array([2, 2]).astype("int64")
             input_x = paddle.to_tensor(input_data)

--- a/backends/npu/tests/unittests/test_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_norm_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest, skip_check_grad_ci
 
 
@@ -107,7 +107,7 @@ class TestNPUNormOp5(TestNPUNormOp):
 class API_NormTest(unittest.TestCase):
     def test_errors(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
 
             def test_norm_x_type():
                 data = paddle.static.data(name="x", shape=[3, 3], dtype="int64")

--- a/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
+import paddle.base as base
+import paddle.base.core as core
 
 paddle.enable_static()
 
@@ -212,9 +212,9 @@ class TestOneHotOpApi(unittest.TestCase):
         label = np.array([np.random.randint(0, depth - 1) for i in range(6)]).reshape(
             [6, 1]
         )
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             one_hot_label = paddle.nn.functional.one_hot(
-                fluid.dygraph.to_variable(label), depth
+                base.dygraph.to_variable(label), depth
             )
             one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
 
@@ -227,8 +227,8 @@ class TestOneHotOpApi(unittest.TestCase):
             [6, 1]
         )
 
-        exe = fluid.Executor(place)
-        exe.run(fluid.default_startup_program())
+        exe = base.Executor(place)
+        exe.run(base.default_startup_program())
         ret = exe.run(
             feed={
                 "label": label_data,

--- a/backends/npu/tests/unittests/test_pad3d_op_npu.py
+++ b/backends/npu/tests/unittests/test_pad3d_op_npu.py
@@ -19,8 +19,8 @@ from tests.op_test import OpTest
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.fluid import Program, program_guard, Executor, default_main_program
-import paddle.fluid as fluid
+from paddle.base import Program, program_guard, Executor, default_main_program
+import paddle.base as base
 
 
 class TestPad3dNPUOp(OpTest):
@@ -152,9 +152,9 @@ class TestPadAPI(unittest.TestCase):
 
     def test_static(self):
         paddle.enable_static()
-        self.place = fluid.CustomPlace(
+        self.place = base.CustomPlace(
             "npu", 0
-        )  # if fluid.core.is_compiled_with_npu() else fluid.CPUPlace()
+        )  # if base.core.is_compiled_with_npu() else base.CPUPlace()
         with program_guard(Program(), Program()):
             input_shape = (1, 2, 3, 4, 5)
             pad = [1, 2, 1, 1, 3, 4]

--- a/backends/npu/tests/unittests/test_pad_op_npu.py
+++ b/backends/npu/tests/unittests/test_pad_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.fluid import Program, program_guard
+from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_pool2d_op_npu.py
+++ b/backends/npu/tests/unittests/test_pool2d_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -489,7 +489,7 @@ class TestPool2D_Op(OpTest):
             self.pool_type,
             self.padding_algorithm,
         ).astype(self.dtype)
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(input)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(input)}
 
         self.attrs = {
             "strides": self.strides,

--- a/backends/npu/tests/unittests/test_prelu_op_npu.py
+++ b/backends/npu/tests/unittests/test_prelu_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 from tests.op_test import OpTest, skip_check_grad_ci
 
@@ -119,14 +119,14 @@ class TestNNPReluAPI(unittest.TestCase):
         np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
         x = paddle.to_tensor(self.x_np)
-        m = paddle.nn.PReLU(weight_attr=fluid.ParamAttr(name="weight"))
+        m = paddle.nn.PReLU(weight_attr=base.ParamAttr(name="weight"))
         out = m(x)
         out_ref = ref_prelu_nn(self.x_np, 1, 0.25)
         np.testing.assert_allclose(out_ref, out.numpy(), rtol=1e-05)
 
         x = paddle.to_tensor(self.x_np)
         m = paddle.nn.PReLU(
-            weight_attr=fluid.ParamAttr(initializer=paddle.nn.initializer.Constant(0.5))
+            weight_attr=base.ParamAttr(initializer=paddle.nn.initializer.Constant(0.5))
         )
         out = m(x)
         out_ref = ref_prelu_nn(self.x_np, 1, 0.5)

--- a/backends/npu/tests/unittests/test_randperm_op_npu.py
+++ b/backends/npu/tests/unittests/test_randperm_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 from paddle.static import program_guard, Program
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_reciprocal_op_npu.py
+++ b/backends/npu/tests/unittests/test_reciprocal_op_npu.py
@@ -34,7 +34,7 @@ class TestReciprocal(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = np.reciprocal(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.outputs = {"Out": out}
 
     def test_check_output(self):

--- a/backends/npu/tests/unittests/test_reduce_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_max_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_reduce_min_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_min_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
+++ b/backends/npu/tests/unittests/test_reduce_prod_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 paddle.enable_static()
 

--- a/backends/npu/tests/unittests/test_roll_op_npu.py
+++ b/backends/npu/tests/unittests/test_roll_op_npu.py
@@ -18,8 +18,8 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
-from paddle.fluid import Program, program_guard
+from paddle import base
+from paddle.base import Program, program_guard
 
 
 class TestRollOp(OpTest):
@@ -144,7 +144,7 @@ class TestRollAPI(unittest.TestCase):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
             x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1)
-            exe = fluid.Executor(paddle.CustomPlace("npu", 0))
+            exe = base.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
             )
@@ -156,7 +156,7 @@ class TestRollAPI(unittest.TestCase):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
             x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1, axis=0)
-            exe = fluid.Executor(paddle.CustomPlace("npu", 0))
+            exe = base.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
             )
@@ -167,16 +167,16 @@ class TestRollAPI(unittest.TestCase):
         paddle.disable_static(paddle.CustomPlace("npu", 0))
         self.input_data()
         # case 1:
-        with fluid.dygraph.guard():
-            x = fluid.dygraph.to_variable(self.data_x)
+        with base.dygraph.guard():
+            x = base.dygraph.to_variable(self.data_x)
             z = paddle.roll(x, shifts=1)
             np_z = z.numpy()
         expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
         np.testing.assert_allclose(expect_out, np_z, rtol=1e-05)
 
         # case 2:
-        with fluid.dygraph.guard():
-            x = fluid.dygraph.to_variable(self.data_x)
+        with base.dygraph.guard():
+            x = base.dygraph.to_variable(self.data_x)
             z = paddle.roll(x, shifts=1, axis=0)
             np_z = z.numpy()
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
@@ -185,7 +185,7 @@ class TestRollAPI(unittest.TestCase):
 
     def test_shifts_as_tensor_dygraph(self):
         paddle.disable_static(paddle.CustomPlace("npu", 0))
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             x = paddle.arange(9).reshape([3, 3])
             shape = paddle.shape(x)
             shifts = shape // 2
@@ -204,7 +204,7 @@ class TestRollAPI(unittest.TestCase):
             out = paddle.roll(x, shifts=shifts, axis=axes)
             expected_out = np.array([[8, 6, 7], [2, 0, 1], [5, 3, 4]])
 
-            exe = fluid.Executor(paddle.CustomPlace("npu", 0))
+            exe = base.Executor(paddle.CustomPlace("npu", 0))
             [out_np] = exe.run(fetch_list=[out])
             np.testing.assert_allclose(out_np, expected_out, rtol=1e-05)
 

--- a/backends/npu/tests/unittests/test_rsqrt_op_npu.py
+++ b/backends/npu/tests/unittests/test_rsqrt_op_npu.py
@@ -35,7 +35,7 @@ class TestRsqrt(OpTest):
         x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
         out = 1.0 / np.sqrt(x)
 
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(x)}
         self.attrs = {}
         self.outputs = {"Out": out}
 

--- a/backends/npu/tests/unittests/test_scale_op_npu.py
+++ b/backends/npu/tests/unittests/test_scale_op_npu.py
@@ -32,7 +32,7 @@ class TestScale(OpTest):
         self.init_dtype()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(
+            "X": OpTest.np_dtype_to_base_dtype(
                 np.random.random((10, 10)).astype(self.dtype)
             )
         }
@@ -81,7 +81,7 @@ class TestBiasAfterScale(OpTest):
         self.init_dtype()
 
         self.inputs = {
-            "X": OpTest.np_dtype_to_fluid_dtype(
+            "X": OpTest.np_dtype_to_base_dtype(
                 np.random.random((10, 10)).astype(self.dtype)
             )
         }

--- a/backends/npu/tests/unittests/test_scatter_nd_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_scatter_nd_add_op_npu.py
@@ -18,8 +18,8 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
-from paddle.fluid.dygraph.base import switch_to_static_graph
+from paddle import base
+from paddle.base.dygraph.base import switch_to_static_graph
 
 
 def numpy_scatter_nd(ref, index, updates, fun):
@@ -216,7 +216,7 @@ class TestScatterNdOpAPI(unittest.TestCase):
         index = np.array([[0, 0, 2], [0, 1, 2]])
         val = np.array([-1, -3])
 
-        with fluid.dygraph.guard():
+        with base.dygraph.guard():
             paddle.set_device("npu")
             npu_value = paddle.scatter_nd_add(
                 paddle.to_tensor(x),
@@ -257,11 +257,11 @@ class TestScatterNdOpAPI(unittest.TestCase):
 
 class TestDygraph(unittest.TestCase):
     def test_dygraph(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             x = paddle.rand(shape=[3, 5, 9, 10], dtype="float32")
             updates = paddle.rand(shape=[3, 9, 10], dtype="float32")
             index_data = np.array([[1, 1], [0, 1], [1, 3]]).astype(np.int64)
-            index = fluid.dygraph.to_variable(index_data)
+            index = base.dygraph.to_variable(index_data)
             output = paddle.scatter_nd_add(x, index, updates)
 
 

--- a/backends/npu/tests/unittests/test_selu_op_npu.py
+++ b/backends/npu/tests/unittests/test_selu_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.nn.functional as F
 
 paddle.enable_static()
@@ -127,12 +127,12 @@ class TestSeluAPI(unittest.TestCase):
             np.testing.assert_allclose(out_ref, r.numpy(), rtol=1e-05)
         paddle.enable_static()
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program()):
+        with base.program_guard(base.Program()):
             x = paddle.static.data("X", self.x_np.shape, self.x_np.dtype)
             out = F.selu(x, self.scale, self.alpha)
-            exe = fluid.Executor(self.place)
+            exe = base.Executor(self.place)
             res = exe.run(feed={"X": self.x_np}, fetch_list=[out])
         out_ref = ref_selu(self.x_np, self.scale, self.alpha)
         np.testing.assert_allclose(out_ref, res[0], rtol=1e-05)

--- a/backends/npu/tests/unittests/test_sequence_mask_op_npu.py
+++ b/backends/npu/tests/unittests/test_sequence_mask_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle.nn.functional as F
 
 paddle.enable_static()

--- a/backends/npu/tests/unittests/test_set_value_op_npu.py
+++ b/backends/npu/tests/unittests/test_set_value_op_npu.py
@@ -168,7 +168,7 @@ class TestSetValueItemSlice4(TestSetValueApi):
 # #             return i, x
 
 # #         i = paddle.zeros(shape=(1, ), dtype='int32')
-# #         i, x = paddle.fluid.layers.while_loop(cond, body, [i, x])
+# #         i, x = paddle.base.layers.while_loop(cond, body, [i, x])
 
 # #     def _get_answer(self):
 # #         self.data[0] = self.value

--- a/backends/npu/tests/unittests/test_sign_op_npu.py
+++ b/backends/npu/tests/unittests/test_sign_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid
+from paddle import base
 
 
 class TestSignOp(OpTest):
@@ -60,7 +60,7 @@ class TestSignFP32Op(TestSignOp):
 
 class TestSignAPI(unittest.TestCase):
     def test_dygraph(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.array([-1.0, 0.0, -0.0, 1.2, 1.5], dtype="float64")
             x = paddle.to_tensor(np_x)
             z = paddle.sign(x)

--- a/backends/npu/tests/unittests/test_slice_op_npu.py
+++ b/backends/npu/tests/unittests/test_slice_op_npu.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
+import paddle.base as base
+import paddle.base.core as core
 from paddle.tensor.manipulation import tensor_array_to_tensor
 
 paddle.enable_static()
@@ -277,7 +277,7 @@ EPOCH = 100
 
 #             prediction = paddle.static.nn.fc(z, size=2, activation="softmax")
 
-#             cost = paddle.fluid.layers.softmax_with_cross_entropy(
+#             cost = paddle.base.layers.softmax_with_cross_entropy(
 #                 logits=prediction, label=label
 #             )
 #             loss = paddle.mean(cost)
@@ -614,10 +614,10 @@ class TestSliceApiWithTensorArray(unittest.TestCase):
 
         self.__class__.use_custom_device = True
         self.place = paddle.CustomPlace("npu", 0)
-        self.exe = fluid.Executor(self.place)
+        self.exe = base.Executor(self.place)
 
     def set_program_and_run(self, main_program, case_num):
-        with fluid.program_guard(main_program):
+        with base.program_guard(main_program):
             x = [
                 paddle.static.data(name="x0", shape=self.shape, dtype="float32"),
                 paddle.static.data(name="x1", shape=self.shape, dtype="float32"),
@@ -649,7 +649,7 @@ class TestSliceApiWithTensorArray(unittest.TestCase):
                 )
 
             loss = paddle.sum(output)
-            fluid.backward.append_backward(loss)
+            base.backward.append_backward(loss)
             g_vars = list(
                 map(
                     main_program.global_block().var,
@@ -663,7 +663,7 @@ class TestSliceApiWithTensorArray(unittest.TestCase):
             )
 
     def test_case_1(self):
-        main_program = fluid.Program()
+        main_program = base.Program()
         self.set_program_and_run(main_program, 1)
 
         self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR)
@@ -674,7 +674,7 @@ class TestSliceApiWithTensorArray(unittest.TestCase):
         np.testing.assert_array_equal(self.g_x2, np.zeros_like(self.data))
 
     def test_case_2(self):
-        main_program = fluid.Program()
+        main_program = base.Program()
         self.set_program_and_run(main_program, 2)
 
         self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY)
@@ -687,7 +687,7 @@ class TestSliceApiWithTensorArray(unittest.TestCase):
         np.testing.assert_array_equal(self.g_x2, np.zeros_like(self.data))
 
     def test_case_3(self):
-        main_program = fluid.Program()
+        main_program = base.Program()
         self.set_program_and_run(main_program, 3)
 
         self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY)

--- a/backends/npu/tests/unittests/test_split_op_npu.py
+++ b/backends/npu/tests/unittests/test_split_op_npu.py
@@ -198,7 +198,7 @@ class TestSplitOp_SectionsTensor(NPUOpTest):
         pass
 
 
-# split_with_num op cannot be called by set op type because it has not been registered in fluid OpProto,
+# split_with_num op cannot be called by set op type because it has not been registered in base OpProto,
 # we call paddle.split() in dygraph mode to test it.
 class TestNPUSplitWithNumOp(unittest.TestCase):
     def initTestCase(self):

--- a/backends/npu/tests/unittests/test_stack_op_npu.py
+++ b/backends/npu/tests/unittests/test_stack_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -131,14 +131,14 @@ class TestStackAPIWithLoDTensorArray(unittest.TestCase):
         self.x = np.random.random(self.input_shape).astype("float32")
         self.place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
         self.set_program()
 
     def set_program(self):
-        self.program = fluid.Program()
-        with fluid.program_guard(self.program):
+        self.program = base.Program()
+        with base.program_guard(self.program):
             input = paddle.assign(self.x)
             tensor_array = paddle.tensor.create_array(dtype="float32")
             zero = paddle.tensor.fill_constant(shape=[1], value=0, dtype="int64")
@@ -150,7 +150,7 @@ class TestStackAPIWithLoDTensorArray(unittest.TestCase):
 
     def test_case(self):
         self.assertTrue(self.out_var.shape[self.axis] == -1)
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         res = exe.run(self.program, fetch_list=self.out_var)
         self.assertTrue(
             np.array_equal(res[0], np.stack([self.x] * self.iter_num, axis=self.axis))
@@ -169,14 +169,14 @@ class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
         self.x = np.random.random(self.input_shape).astype("float32")
         self.place = (
             paddle.CustomPlace("npu", 0)
-            if ("npu" in paddle.fluid.core.get_all_custom_device_type())
+            if ("npu" in paddle.base.core.get_all_custom_device_type())
             else paddle.CPUPlace()
         )
         self.set_program()
 
     def set_program(self):
-        self.program = fluid.Program()
-        with fluid.program_guard(self.program):
+        self.program = base.Program()
+        with base.program_guard(self.program):
             input = paddle.assign(self.x)
             tensor_array = paddle.tensor.create_array(dtype="float32")
             zero = paddle.tensor.fill_constant(shape=[1], value=0, dtype="int64")
@@ -188,7 +188,7 @@ class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
 
     def test_case(self):
         self.assertTrue(self.out_var.shape[self.axis] == -1)
-        exe = fluid.Executor(self.place)
+        exe = base.Executor(self.place)
         res = exe.run(self.program, fetch_list=self.out_var)
         self.assertTrue(
             np.array_equal(res[0], np.stack([self.x] * self.iter_num, axis=self.axis))
@@ -198,13 +198,13 @@ class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
 class API_test(unittest.TestCase):
     def test_out(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             data1 = paddle.static.data("data1", shape=[1, 2], dtype="float32")
             data2 = paddle.static.data("data2", shape=[1, 2], dtype="float32")
             data3 = paddle.static.data("data3", shape=[1, 2], dtype="float32")
             result_stack = paddle.stack([data1, data2, data3], axis=0)
             place = paddle.CustomPlace("npu", 0)
-            exe = fluid.Executor(place)
+            exe = base.Executor(place)
             input1 = np.random.random([1, 2]).astype("float32")
             input2 = np.random.random([1, 2]).astype("float32")
             input3 = np.random.random([1, 2]).astype("float32")
@@ -217,7 +217,7 @@ class API_test(unittest.TestCase):
 
     def test_single_tensor_error(self):
         paddle.enable_static()
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        with base.program_guard(base.Program(), base.Program()):
             x = paddle.rand([2, 3])
             self.assertRaises(TypeError, paddle.stack, x)
 
@@ -228,17 +228,17 @@ class API_DygraphTest(unittest.TestCase):
         data1 = np.array([[1.0, 2.0]])
         data2 = np.array([[3.0, 4.0]])
         data3 = np.array([[5.0, 6.0]])
-        with fluid.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
-            x1 = fluid.dygraph.to_variable(data1)
-            x2 = fluid.dygraph.to_variable(data2)
-            x3 = fluid.dygraph.to_variable(data3)
+        with base.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
+            x1 = base.dygraph.to_variable(data1)
+            x2 = base.dygraph.to_variable(data2)
+            x3 = base.dygraph.to_variable(data3)
             result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
         expected_result = np.stack([data1, data2, data3])
         self.assertTrue(np.allclose(expected_result, result_np))
 
-        with fluid.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
-            y1 = fluid.dygraph.to_variable(data1)
+        with base.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
+            y1 = base.dygraph.to_variable(data1)
             result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
         expected_result_2 = np.stack([data1], axis=0)
@@ -247,7 +247,7 @@ class API_DygraphTest(unittest.TestCase):
 
     def test_single_tensor_error(self):
         paddle.disable_static()
-        with fluid.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
             x = paddle.to_tensor([1, 2, 3])
             self.assertRaises(Exception, paddle.stack, x)
         paddle.enable_static()

--- a/backends/npu/tests/unittests/test_strided_slice_op_npu.py
+++ b/backends/npu/tests/unittests/test_strided_slice_op_npu.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -600,9 +600,9 @@ class TestStridedSliceAPI(unittest.TestCase):
         out_6 = x[minus_3:3:1, 0:100:2, :, minus_1:2:minus_1]
         out_7 = x[minus_1, 0:100:2, :, -1:2:-1]
 
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
         res_1, res_2, res_3, res_4, res_5, res_6, res_7 = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={
                 "x": input,
                 "starts": np.array([-3, 0, 2]).astype("int32"),
@@ -641,10 +641,10 @@ class TestStridedSliceAPI(unittest.TestCase):
 #         self.strides = [1]
 #         self.iter_num = 3
 #         self.place = paddle.CustomPlace("npu", 0)
-#         self.exe = fluid.Executor(self.place)
+#         self.exe = base.Executor(self.place)
 
 #     def set_program_and_run(self, main_program, case_num):
-#         with fluid.program_guard(main_program):
+#         with base.program_guard(main_program):
 #             x = [
 #                 paddle.static.data(name="x0", shape=self.shape, dtype="float32"),
 #                 paddle.static.data(name="x1", shape=self.shape, dtype="float32"),
@@ -664,7 +664,7 @@ class TestStridedSliceAPI(unittest.TestCase):
 
 #             array = paddle.concat(output)
 #             loss = paddle.sum(array)
-#             fluid.backward.append_backward(loss)
+#             base.backward.append_backward(loss)
 #             g_vars = list(
 #                 map(
 #                     main_program.global_block().var,
@@ -684,12 +684,12 @@ class TestStridedSliceAPI(unittest.TestCase):
 #             )
 
 #     def test_case(self):
-#         main_program = fluid.Program()
+#         main_program = base.Program()
 #         self.set_program_and_run(main_program, 1)
 
 #         numeric_output = [self.data, self.data]
 #         self.assertTrue(
-#             self.sliced_arr.type == fluid.core.VarDesc.VarType.LOD_TENSOR_ARRAY
+#             self.sliced_arr.type == base.core.VarDesc.VarType.LOD_TENSOR_ARRAY
 #         )
 #         np.testing.assert_array_equal(self.out, numeric_output)
 #         np.testing.assert_array_equal(self.g_x0, np.zeros_like(self.data))

--- a/backends/npu/tests/unittests/test_tile_op_npu.py
+++ b/backends/npu/tests/unittests/test_tile_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 np.random.seed(10)
@@ -294,7 +294,7 @@ class TestTileOpFloat16(OpTest):
 # Test python API
 class TestTileAPI(unittest.TestCase):
     def test_api(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.random.random([12, 14]).astype("float32")
             x = paddle.to_tensor(np_x)
 

--- a/backends/npu/tests/unittests/test_top_k_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_top_k_v2_op_npu.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 
 
 def numpy_topk(x, k=1, axis=-1, largest=True):

--- a/backends/npu/tests/unittests/test_tril_triu_op_npu.py
+++ b/backends/npu/tests/unittests/test_tril_triu_op_npu.py
@@ -17,9 +17,9 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 import paddle.tensor as tensor
-from paddle.fluid.framework import Program, program_guard
+from paddle.base.framework import Program, program_guard
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -167,9 +167,9 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                 tril_out, triu_out = tensor.tril(x), tensor.triu(x)
 
                 place = paddle.CustomPlace("npu", 0)
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 tril_out, triu_out = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"x": data},
                     fetch_list=[tril_out, triu_out],
                 )
@@ -181,14 +181,14 @@ class TestTrilTriuOpAPI(unittest.TestCase):
 
         dtypes = ["float16", "float32"]
         for dtype in dtypes:
-            with fluid.dygraph.guard():
+            with base.dygraph.guard():
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
-                x = fluid.dygraph.to_variable(data)
+                x = base.dygraph.to_variable(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
                 np.testing.assert_allclose(tril_out, np.tril(data))
                 np.testing.assert_allclose(triu_out, np.triu(data))
 
-    def test_fluid_api(self):
+    def test_base_api(self):
         paddle.enable_static()
 
         dtypes = ["float16", "float32"]
@@ -201,9 +201,9 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                 triu_out = paddle.triu(x)
 
                 place = paddle.CustomPlace("npu", 0)
-                exe = fluid.Executor(place)
+                exe = base.Executor(place)
                 triu_out = exe.run(
-                    fluid.default_main_program(),
+                    base.default_main_program(),
                     feed={"x": data},
                     fetch_list=[triu_out],
                 )

--- a/backends/npu/tests/unittests/test_truncated_gaussian_random_op_npu.py
+++ b/backends/npu/tests/unittests/test_truncated_gaussian_random_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 import unittest
 
 import paddle
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 SEED = 2021
@@ -28,14 +28,14 @@ class TestTruncatedNormal(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()
         startup_prog = paddle.static.Program()
-        scope = paddle.fluid.core.Scope()
+        scope = paddle.base.core.Scope()
 
         main_prog.random_seed = SEED
         startup_prog.random_seed = SEED
         np.random.seed(SEED)
         paddle.seed(SEED)
 
-        with fluid.scope_guard(scope):
+        with base.scope_guard(scope):
             with paddle.static.program_guard(main_prog, startup_prog):
                 weight_attr = paddle.framework.ParamAttr(
                     name="linear_weight",

--- a/backends/npu/tests/unittests/test_unbind_op_npu.py
+++ b/backends/npu/tests/unittests/test_unbind_op_npu.py
@@ -18,7 +18,7 @@ import numpy as np
 from tests.op_test import OpTest
 
 import paddle
-from paddle import fluid, tensor
+from paddle import base, tensor
 
 
 class TestUnbind(unittest.TestCase):
@@ -29,10 +29,10 @@ class TestUnbind(unittest.TestCase):
         [out_0, out_1] = tensor.unbind(input=x_1, axis=0)
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
 
         [res_1, res_2] = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x_1": input_1, "axis": 0},
             fetch_list=[out_0, out_1],
         )
@@ -63,7 +63,7 @@ class TestUnbind(unittest.TestCase):
             assert np.array_equal(res[1], input[1, :])
 
     def test_unbind_dygraph(self):
-        with fluid.dygraph.guard(paddle.CustomPlace("npu", 0)):
+        with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.random.random([2, 3]).astype("float32")
             x = paddle.to_tensor(np_x)
             x.stop_gradient = False
@@ -86,10 +86,10 @@ class TestLayersUnbind(unittest.TestCase):
         [out_0, out_1] = paddle.unbind(input=x_1, axis=0)
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
-        exe = fluid.Executor(place=paddle.CustomPlace("npu", 0))
+        exe = base.Executor(place=paddle.CustomPlace("npu", 0))
 
         [res_1, res_2] = exe.run(
-            fluid.default_main_program(),
+            base.default_main_program(),
             feed={"x_1": input_1, "axis": 0},
             fetch_list=[out_0, out_1],
         )

--- a/backends/npu/tests/unittests/test_uniform_random_op_npu.py
+++ b/backends/npu/tests/unittests/test_uniform_random_op_npu.py
@@ -19,10 +19,10 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
+import paddle.base.core as core
 import paddle
 from tests.op import Operator
-import paddle.fluid as fluid
+import paddle.base as base
 
 paddle.enable_static()
 
@@ -51,7 +51,7 @@ class TestUniformRandomOp(OpTest):
     def test_check_api(self):
         places = self._get_places()
         for place in places:
-            with fluid.dygraph.base.guard(place=place):
+            with base.dygraph.base.guard(place=place):
                 out = self.python_api(
                     self.attrs["shape"],
                     "float32",

--- a/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
+++ b/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
@@ -30,7 +30,7 @@ class TestUnsqueeze2Op(OpTest):
         self.place = paddle.CustomPlace("npu", 0)
         self.init_test_case()
         self.x = np.random.random(self.ori_shape).astype("float32")
-        self.inputs = {"X": OpTest.np_dtype_to_fluid_dtype(self.x)}
+        self.inputs = {"X": OpTest.np_dtype_to_base_dtype(self.x)}
         self.init_attrs()
         self.outputs = {
             "Out": self.x.reshape(self.new_shape),

--- a/backends/npu/tests/unittests/test_update_loss_scaling_op_npu.py
+++ b/backends/npu/tests/unittests/test_update_loss_scaling_op_npu.py
@@ -112,7 +112,7 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
 
 # class TestUpdateLossScalingLayer(unittest.TestCase):
 
-#     def loss_scaling_check(self, use_npu=True, scope=fluid.Scope()):
+#     def loss_scaling_check(self, use_npu=True, scope=base.Scope()):
 #         a = paddle.static.data(name="a", shape=[1024, 1024], dtype='float32')
 #         b = paddle.static.data(name="b", shape=[512, 128], dtype='float32')
 #         x = [a, b]
@@ -150,10 +150,10 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
 #                                             decr_ratio,
 #                                             name="update_loss_scaling")
 
-#         place = fluid.CustomPlace('npu', 0)
-#         exe = fluid.Executor(place)
-#         with fluid.scope_guard(scope):
-#             exe.run(fluid.default_startup_program())
+#         place = base.CustomPlace('npu', 0)
+#         exe = base.Executor(place)
+#         with base.scope_guard(scope):
+#             exe.run(base.default_startup_program())
 #             result_v = exe.run(feed={
 #                 'a': a_v,
 #                 'b': b_v,
@@ -175,7 +175,7 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
 #         assert np.array_equal(result_v[6], np.zeros_like(num_good_steps_v))
 #         assert np.array_equal(result_v[7], np.zeros_like(num_bad_steps_v))
 
-#     def loss_scaling_check_inf(self, use_npu=True, scope=fluid.Scope()):
+#     def loss_scaling_check_inf(self, use_npu=True, scope=base.Scope()):
 #         a = paddle.static.data(name="a", shape=[1024, 1024], dtype='float32')
 #         b = paddle.static.data(name="b", shape=[512, 128], dtype='float32')
 #         x = [a, b]
@@ -216,10 +216,10 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
 #                                             decr_ratio,
 #                                             name="update_loss_scaling")
 
-#         place = fluid.CustomPlace('npu', 0)
-#         exe = fluid.Executor(place)
-#         with fluid.scope_guard(scope):
-#             exe.run(fluid.default_startup_program())
+#         place = base.CustomPlace('npu', 0)
+#         exe = base.Executor(place)
+#         with base.scope_guard(scope):
+#             exe.run(base.default_startup_program())
 #             result_v = exe.run(feed={
 #                 'a': a_v,
 #                 'b': b_v,
@@ -243,18 +243,18 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
 
 #     def test_loss_scaling_gpu(self):
 #         paddle.set_device('npu')
-#         main = fluid.Program()
-#         startup = fluid.Program()
-#         with fluid.unique_name.guard():
-#             with fluid.program_guard(main, startup):
+#         main = base.Program()
+#         startup = base.Program()
+#         with base.unique_name.guard():
+#             with base.program_guard(main, startup):
 #                 self.loss_scaling_check(use_npu=True)
 
 #     def test_loss_scaling_gpu_inf(self):
 #         paddle.set_device('npu')
-#         main = fluid.Program()
-#         startup = fluid.Program()
-#         with fluid.unique_name.guard():
-#             with fluid.program_guard(main, startup):
+#         main = base.Program()
+#         startup = base.Program()
+#         with base.unique_name.guard():
+#             with base.program_guard(main, startup):
 #                 self.loss_scaling_check_inf(use_npu=True)
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_where_index_npu.py
+++ b/backends/npu/tests/unittests/test_where_index_npu.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.base as base
+from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
 paddle.enable_static()
@@ -98,10 +98,10 @@ class TestWhereOpError(unittest.TestCase):
             cond = paddle.static.data(name="cond", shape=[-1, 4], dtype="bool")
             result = paddle.nonzero(cond)
 
-            exe = fluid.Executor(paddle.CustomPlace("npu", 0))
-            exe.run(fluid.default_startup_program())
+            exe = base.Executor(paddle.CustomPlace("npu", 0))
+            exe.run(base.default_startup_program())
             cond_i = np.array([True, False, False, False]).astype("bool")
-            out = exe.run(fluid.default_main_program(), feed={"cond": cond_i})
+            out = exe.run(base.default_main_program(), feed={"cond": cond_i})
 
 
 if __name__ == "__main__":

--- a/python/tests/white_list/new_ir_python_api_grad_white_list.py
+++ b/python/tests/white_list/new_ir_python_api_grad_white_list.py
@@ -1,0 +1,1 @@
+../../../Paddle/test/white_list/new_ir_python_api_grad_white_list.py


### PR DESCRIPTION
主框架已完全移除fluid api，剩余fluid功能转到base下面，因此移除测试文件中fluid api