### PR TITLE
fix arg_max ut

### DIFF
--- a/backends/mlu/tests/unittests/test_arg_max_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_arg_max_op_mlu.py
@@ -356,7 +356,7 @@ class TestArgMaxAPI_3(unittest.TestCase):
             np.random.seed(2022)
             numpy_input = (np.random.random(self.dims)).astype(self.dtype)
             tensor_input = paddle.to_tensor(numpy_input)
-            numpy_output = np.argmax(numpy_input).reshape([1])
+            numpy_output = np.argmax(numpy_input)
             paddle_output = paddle.argmax(tensor_input)
             np.testing.assert_allclose(numpy_output, paddle_output.numpy(), rtol=1e-05)
             self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)

--- a/backends/npu/tests/unittests/test_arg_max_op_npu.py
+++ b/backends/npu/tests/unittests/test_arg_max_op_npu.py
@@ -501,7 +501,7 @@ class TestArgMaxAPI_3(unittest.TestCase):
             np.random.seed(2021)
             numpy_input = (np.random.random(self.dims)).astype(self.dtype)
             tensor_input = paddle.to_tensor(numpy_input)
-            numpy_output = np.argmax(numpy_input).reshape([1])
+            numpy_output = np.argmax(numpy_input)
             paddle_output = paddle.argmax(tensor_input)
             self.assertEqual(np.allclose(numpy_output, paddle_output.numpy()), True)
             self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)


### PR DESCRIPTION
修复npu和mlu中arg_max的单测，本地测试结果如下：
![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/50285351/6350b5f7-dce8-406c-8278-ea7ce2511524)
