### PR TITLE
[npu] generate custom op api

### DIFF
--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -6,11 +6,23 @@ packages = []
 package_data = {}
 
 def write_custom_op_api_py(filename='python/paddle_custom_device/npu/ops.py', libname='python/paddle_custom_device/libpaddle-custom-npu.so'):
+    import os
+    os.environ['CUSTOM_DEVICE_ROOT']=''
     import sys
     import paddle
     op_names = paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(libname)
     api_content = [paddle.utils.cpp_extension.extension_utils._custom_api_content(op_name) for op_name in op_names]
     with open(filename, 'w') as f:
+        f.write('''# THIS FILE IS GENERATED FROM PADDLEPADDLE SETUP.PY
+#
+import paddle
+import os
+for lib in os.listdir(os.getenv("CUSTOM_DEVICE_ROOT")):
+    if lib.endswith(".so"):
+        paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(
+            lib
+        )
+''')
         f.write('\n\n'.join(api_content))
 
 

--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -5,10 +5,20 @@ from setuptools import setup, Distribution
 packages = []
 package_data = {}
 
+def write_custom_op_api_py(filename='python/paddle_custom_device/npu/ops.py', libname='python/paddle_custom_device/libpaddle-custom-npu.so'):
+    import sys
+    import paddle
+    op_names = paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(libname)
+    api_content = [paddle.utils.cpp_extension.extension_utils._custom_api_content(op_name) for op_name in op_names]
+    with open(filename, 'w') as f:
+        f.write('\n\n'.join(api_content))
+
 
 def write_version_py(filename='python/paddle_custom_device/npu/__init__.py'):
     cnt = '''# THIS FILE IS GENERATED FROM PADDLEPADDLE SETUP.PY
 #
+from .ops import *
+
 full_version  = '@PADDLE_VERSION@'
 cann_version  = '@ASCEND_TOOLKIT_VERSION@'
 git_commit_id = '@GIT_HASH@'
@@ -65,6 +75,7 @@ class BinaryDistribution(Distribution):
 
 
 def main():
+    write_custom_op_api_py()
     write_version_py()
     write_init_py()
 

--- a/cmake/paddle.cmake
+++ b/cmake/paddle.cmake
@@ -21,7 +21,7 @@ if(DEFINED ENV{PADDLE_CUSTOM_PATH})
 else()
   execute_process(
     COMMAND
-      "${Python_EXECUTABLE}" "-c"
+      "env" "CUSTOM_DEVICE_ROOT=\"\"" "${Python_EXECUTABLE}" "-c"
       "import re, paddle; print(re.compile('/__init__.py.*').sub('',paddle.__file__))"
     OUTPUT_VARIABLE PADDLE_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
在 paddle_custom_device.npu 生成自定义 op 的 api

```
>>> import paddle
Hint: Your machine support AVX, but the installed paddlepaddle doesn't have avx core. Hence, no-avx core with worse performance will be imported.
If you like, you could reinstall paddlepaddle by 'python -m pip install --force-reinstall paddlepaddle-gpu[==version]' to get better performance.
I0913 17:51:47.216020 39872 init.cc:237] ENV [CUSTOM_DEVICE_ROOT]=/opt/py39/lib/python3.9/site-packages/paddle_custom_device
I0913 17:51:47.216045 39872 init.cc:146] Try loading custom device libs from: [/opt/py39/lib/python3.9/site-packages/paddle_custom_device]
I0913 17:51:47.454190 39872 custom_device.cc:1108] Successed in loading custom runtime in lib: /opt/py39/lib/python3.9/site-packages/paddle_custom_device/libpaddle-custom-npu.so
I0913 17:51:47.457161 39872 custom_kernel.cc:66] Successed in loading 329 custom kernel(s) from loaded lib(s), will be used like native ones.
I0913 17:51:47.457255 39872 init.cc:158] Finished in LoadCustomDevice with libs_path: [/opt/py39/lib/python3.9/site-packages/paddle_custom_device]
I0913 17:51:47.457273 39872 init.cc:243] CustomDevice: npu, visible devices count: 16
>>> import paddle_custom_device.npu as npu
>>> x = paddle.rand([1])
>>> x
Tensor(shape=[1], dtype=float32, place=Place(npu:0), stop_gradient=True,
       [0.60586190])
>>> npu.my_add_n(x, x, x)
Tensor(shape=[1], dtype=float32, place=Place(npu:0), stop_gradient=True,
       [1.81758571])
>>> 
```