### PR TITLE
[NPU] Fix bug in setup.py

### DIFF
--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -6,9 +6,6 @@ packages = []
 package_data = {}
 
 def write_custom_op_api_py(filename='python/paddle_custom_device/npu/ops.py', libname='python/paddle_custom_device/libpaddle-custom-npu.so'):
-    import os
-    os.environ['CUSTOM_DEVICE_ROOT']=''
-    import sys
     import paddle
     op_names = paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(libname)
     api_content = [paddle.utils.cpp_extension.extension_utils._custom_api_content(op_name) for op_name in op_names]
@@ -87,9 +84,9 @@ class BinaryDistribution(Distribution):
 
 
 def main():
-    write_custom_op_api_py()
     write_version_py()
     write_init_py()
+    write_custom_op_api_py()
 
     setup(
         name = '@CMAKE_PROJECT_NAME@',

--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -9,6 +9,9 @@ def write_custom_op_api_py(filename='python/paddle_custom_device/npu/ops.py', li
     import paddle
     op_names = paddle.utils.cpp_extension.extension_utils.load_op_meta_info_and_register_op(libname)
     api_content = [paddle.utils.cpp_extension.extension_utils._custom_api_content(op_name) for op_name in op_names]
+    dirname = os.path.dirname(filename)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
     with open(filename, 'w') as f:
         f.write('''# THIS FILE IS GENERATED FROM PADDLEPADDLE SETUP.PY
 #
@@ -56,9 +59,6 @@ def version():
     print('commit:', git_commit_id)
     print('cann:', cann_version)
 '''
-    dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
 
     with open(filename, 'w') as f:
         f.write(cnt)
@@ -84,9 +84,9 @@ class BinaryDistribution(Distribution):
 
 
 def main():
+    write_custom_op_api_py()
     write_version_py()
     write_init_py()
-    write_custom_op_api_py()
 
     setup(
         name = '@CMAKE_PROJECT_NAME@',


### PR DESCRIPTION
如图：
![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/65210872/6d107974-fc1b-4baa-89f9-b5529ce2bb89)

之前测试没有发现这个问题是因为`build`目录中有缓存，已经通过`write_version_py()`创建好了`python/paddle_custom_device/npu/`这个路径，否则会报上图的错误。该将创建文件夹提到`write_custom_op_api_py()`执行，从而避免了这个问题。

相关PR：#794