### PR TITLE
[MLU] add kernel flash_attention

### DIFF
--- a/backends/mlu/README.md
+++ b/backends/mlu/README.md
@@ -8,10 +8,11 @@ Please refer to the following steps to compile, install and verify the custom de
 
 | Module    | Version  |
 | --------- | -------- |
-| cntoolkit | 3.4.2-1  |
-| cnnl      | 1.17.0-1 |
-| cncl      | 1.9.3-1  |
-| mluops    | 0.6.0-1  |
+| cntoolkit | 3.6.1-1  |
+| cnnl      | 1.20.4-1 |
+| cnnlextra | 1.4.1-1  |
+| cncl      | 1.11.0-1 |
+| mluops    | 0.8.1-1  |
 
 ## Prepare environment and source code
 
@@ -68,11 +69,12 @@ python -c "import paddle; print(paddle.device.get_all_custom_device_type())"
 python -c "import paddle_custom_device; paddle_custom_device.mlu.version()"
 # expected output
 version: 0.0.0
-commit: 98ae7a84b51e36fc15a1fef7808a82ed8b792fdf
-cntoolkit: 3.4.2
-cnnl: 1.17.0
-cncl: 1.9.3
-mluops: 0.6.0
+commit: 7a45dfc420caa6176c36e89f325f908632c7a739
+cntoolkit: 3.6.1
+cnnl: 1.20.4
+cnnlextra: 1.4.1
+cncl: 1.11.0
+mluops: 0.8.1
 
 # 3. demo for training, evaluation and inference
 python tests/test_LeNet_MNIST.py

--- a/backends/mlu/README_cn.md
+++ b/backends/mlu/README_cn.md
@@ -8,10 +8,11 @@
 
 | 模块名称  | 版本     |
 | --------- | -------- |
-| cntoolkit | 3.4.2-1  |
-| cnnl      | 1.17.0-1 |
-| cncl      | 1.9.3-1  |
-| mluops    | 0.6.0-1  |
+| cntoolkit | 3.6.1-1  |
+| cnnl      | 1.20.4-1 |
+| cnnlextra | 1.4.1-1  |
+| cncl      | 1.11.0-1 |
+| mluops    | 0.8.1-1  |
 
 ## 环境准备与源码同步
 
@@ -68,11 +69,12 @@ python -c "import paddle; print(paddle.device.get_all_custom_device_type())"
 python -c "import paddle_custom_device; paddle_custom_device.mlu.version()"
 # 预期得到如下输出结果
 version: 0.0.0
-commit: 98ae7a84b51e36fc15a1fef7808a82ed8b792fdf
-cntoolkit: 3.4.2
-cnnl: 1.17.0
-cncl: 1.9.3
-mluops: 0.6.0
+commit: 7a45dfc420caa6176c36e89f325f908632c7a739
+cntoolkit: 3.6.1
+cnnl: 1.20.4
+cnnlextra: 1.4.1
+cncl: 1.11.0
+mluops: 0.8.1
 
 # 3) 运行简单模型训练、评估和推理任务
 python tests/test_LeNet_MNIST.py

--- a/backends/mlu/cmake/external/neuware.cmake
+++ b/backends/mlu/cmake/external/neuware.cmake
@@ -25,12 +25,14 @@ set(NEUWARE_LIB_DIR ${NEUWARE_HOME}/lib64)
 include_directories(${NEUWARE_INCLUDE_DIR})
 
 set(CNNL_LIB ${NEUWARE_LIB_DIR}/libcnnl.so)
+set(CNNL_EXTRA_LIB ${NEUWARE_LIB_DIR}/libcnnl_extra.so)
 set(CNRT_LIB ${NEUWARE_LIB_DIR}/libcnrt.so)
 set(CNPAPI_LIB ${NEUWARE_LIB_DIR}/libcnpapi.so)
 set(CNCL_LIB ${NEUWARE_LIB_DIR}/libcncl.so)
 set(MLUOP_LIB ${NEUWARE_LIB_DIR}/libmluops.so)
 
-set(NEUWARE_LIBS ${CNNL_LIB} ${CNRT_LIB} ${CNPAPI_LIB} ${CNCL_LIB} ${MLUOP_LIB})
+set(NEUWARE_LIBS ${CNNL_LIB} ${CNNL_EXTRA_LIB} ${CNRT_LIB} ${CNPAPI_LIB}
+                 ${CNCL_LIB} ${MLUOP_LIB})
 
 function(find_neuware_lib_version LIBNAME OUTPUT)
   execute_process(
@@ -53,6 +55,9 @@ message(STATUS "cntoolkit version is ${CNTOOLKIT_VERSION}")
 
 find_neuware_lib_version(libcnnl CNNL_VERSION)
 message(STATUS "cnnl version is ${CNNL_VERSION}")
+
+find_neuware_lib_version(libcnnl_extra CNNL_EXTRA_VERSION)
+message(STATUS "cnnl_extra version is ${CNNL_EXTRA_VERSION}")
 
 find_neuware_lib_version(libcncl CNCL_VERSION)
 message(STATUS "cncl version is ${CNCL_VERSION}")

--- a/backends/mlu/kernels/flash_attn_kernel.cc
+++ b/backends/mlu/kernels/flash_attn_kernel.cc
@@ -1,0 +1,486 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/mlu_baseop.h"
+#include "kernels/funcs/mlu_funcs.h"
+
+namespace custom_kernel {
+
+template <typename T, typename Context>
+void FlashAttnUnpaddedMLUKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& q,
+    const phi::DenseTensor& k,
+    const phi::DenseTensor& v,
+    const phi::DenseTensor& cu_seqlens_q,
+    const phi::DenseTensor& cu_seqlens_k,
+    const paddle::optional<phi::DenseTensor>& fixed_seed_offset,
+    const paddle::optional<phi::DenseTensor>& attn_mask,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_k,
+    float scale,
+    float dropout,
+    bool causal,
+    bool return_softmax,
+    bool is_test,
+    const std::string& rng_name,
+    phi::DenseTensor* out,
+    phi::DenseTensor* softmax,
+    phi::DenseTensor* softmax_lse,
+    phi::DenseTensor* seed_offset) {
+  dev_ctx.template Alloc<T>(out);
+  // q,k,v [total_*, num_heads, head_dim]
+  auto dims = q.dims();
+  PADDLE_ENFORCE_EQ(
+      dims.size(),
+      3,
+      phi::errors::InvalidArgument("flash_attn_raw receive input with dim "
+                                   "[total_seq_len, num_heads, head_dim]"));
+
+  const int32_t total_q = dims[0];
+  const int32_t num_heads = dims[1];
+  const int32_t head_size = dims[2];
+
+  const int32_t total_k = k.dims()[0];
+  const int32_t num_heads_k = k.dims()[1];
+  const int32_t batch_size = cu_seqlens_q.numel() - 1;
+
+  PADDLE_ENFORCE_GT(
+      batch_size,
+      0,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input with batch_size should > 0"));
+
+  PADDLE_ENFORCE_EQ(
+      head_size % 8,
+      0,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input with head_size should divisible by 8"));
+
+  PADDLE_ENFORCE_LE(
+      head_size,
+      128,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input with head_size should <= 128"));
+
+  PADDLE_ENFORCE_EQ(
+      return_softmax,
+      false,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input with return_softmax should be false"));
+
+  phi::DenseTensor dropout_mask;
+  void* dropout_mask_ptr = nullptr;
+  if (return_softmax) {
+    phi::DenseTensorMeta dropout_mask_meta = {
+        phi::DataType::INT32, {num_heads, total_q, max_seqlen_k}};
+    dropout_mask.set_meta(dropout_mask_meta);
+    dropout_mask_ptr = dev_ctx.template Alloc<int32_t>(&dropout_mask);
+  }
+
+  // Generate random state for dropout and save for recompute in grad.
+  uint64_t seed = 0;
+  uint64_t offset = 0;
+  if (fixed_seed_offset.get_ptr()) {
+    const int64_t* fixed_seed_offset_data =
+        fixed_seed_offset.get_ptr()->data<int64_t>();
+    seed = static_cast<uint64_t>(fixed_seed_offset_data[0]);
+    offset = static_cast<uint64_t>(fixed_seed_offset_data[1]);
+  } else {
+    seed = static_cast<uint64_t>(dev_ctx.GetGenerator()->Random64());
+    offset = static_cast<uint64_t>(dev_ctx.GetGenerator()->Random64());
+  }
+
+  seed_offset->Resize({2});
+  int64_t* seed_offset_data = dev_ctx.template HostAlloc<int64_t>(seed_offset);
+  seed_offset_data[0] = seed;
+  seed_offset_data[1] = offset;
+  size_t* rng_state = reinterpret_cast<uint64_t*>(seed_offset_data);
+
+  cnnlFlashAttentionDescriptor_t desc_;
+  cnnlCreateFlashAttentionDescriptor(&desc_);
+  auto compute_dtype = CNNL_DTYPE_FLOAT;
+  auto prefer = CNNL_ACTIVATION_HIGH_PRECISION;
+  auto attn_mask_mode = causal ? CNNL_ATTN_MASK_CAUSAL : CNNL_ATTN_MASK_NONE;
+  cnnlSetFlashAttentionDescriptor(desc_,
+                                  compute_dtype,
+                                  prefer,
+                                  attn_mask_mode,
+                                  /*is_pack_mode = */ true,
+                                  /*is_out_zero = */ false,
+                                  return_softmax,
+                                  max_seqlen_q,
+                                  max_seqlen_k,
+                                  dropout,
+                                  scale);
+
+  MLUCnnlTensorDesc query_desc(q, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc key_desc(k, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc value_desc(v, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+
+  MLUCnnlTensorDesc csq_desc(cu_seqlens_q);
+  MLUCnnlTensorDesc csk_desc(cu_seqlens_k);
+
+  softmax_lse->Resize({num_heads, total_q});
+  dev_ctx.template Alloc<float>(softmax_lse);
+  MLUCnnlTensorDesc softmax_lse_desc(*softmax_lse);
+
+  out->Resize({total_q, num_heads, head_size});
+  MLUCnnlTensorDesc out_desc(
+      *out, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+
+  // TODO(cifar10): Only equal-length input is supported. Variable lengths need
+  // to be split and processed.
+  MLUCnnl::FlashAttentionForward(dev_ctx,
+                                 desc_,
+                                 query_desc.get(),
+                                 GetBasePtr(&q),
+                                 key_desc.get(),
+                                 GetBasePtr(&k),
+                                 value_desc.get(),
+                                 GetBasePtr(&v),
+                                 csq_desc.get(),
+                                 GetBasePtr(&cu_seqlens_q),
+                                 csk_desc.get(),
+                                 GetBasePtr(&cu_seqlens_k),
+                                 rng_state,
+                                 nullptr,  // dropout_mask_desc.desc()
+                                 nullptr,  // dropout_mask_ptr
+                                 softmax_lse_desc.get(),
+                                 GetBasePtr(softmax_lse),
+                                 out_desc.get(),
+                                 GetBasePtr(out));
+  out->Resize({batch_size, total_q / batch_size, num_heads, head_size});
+}
+
+template <typename T, typename Context>
+void FlashAttnKernel(
+    const Context& ctx,
+    const phi::DenseTensor& q,
+    const phi::DenseTensor& k,
+    const phi::DenseTensor& v,
+    const paddle::optional<phi::DenseTensor>& fixed_seed_offset,
+    const paddle::optional<phi::DenseTensor>& attn_mask,
+    float dropout,
+    bool causal,
+    bool return_softmax,
+    bool is_test,
+    const std::string& rng_name,
+    phi::DenseTensor* out,
+    phi::DenseTensor* softmax,
+    phi::DenseTensor* softmax_lse,
+    phi::DenseTensor* seed_offset) {
+  // q,k,v [batch_size, seq_len, num_heads, head_dim]
+  const auto& dims = q.dims();
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    4,
+                    phi::errors::InvalidArgument(
+                        "flash_attn receive input with dim "
+                        "[batch_size, seq_len, num_heads, head_dim]"));
+
+  const int32_t batch_size = dims[0];
+  const int32_t seqlen_q = dims[1];
+  const int32_t num_heads = dims[2];
+  const int32_t head_size = dims[3];
+  const int32_t seqlen_k = k.dims()[1];
+  const int32_t num_heads_k = k.dims()[2];
+  const int32_t total_q = batch_size * seqlen_q;
+  const int32_t total_k = batch_size * seqlen_k;
+  const float scale = 1.0f / std::sqrt(head_size);
+
+  phi::DenseTensor q_t_s, k_t_s, v_t_s;
+  q_t_s = q;
+  k_t_s = k;
+  v_t_s = v;
+
+  q_t_s.Resize({total_q, num_heads, head_size});
+  k_t_s.Resize({total_k, num_heads, head_size});
+  v_t_s.Resize({total_k, num_heads, head_size});
+
+  phi::DenseTensor cu_seqlens_q;
+  phi::DenseTensor cu_seqlens_k;
+  ArangeNullKernel<int32_t, Context>(
+      ctx, 0, (batch_size + 1) * seqlen_q, seqlen_q, &cu_seqlens_q);
+  ArangeNullKernel<int32_t, Context>(
+      ctx, 0, (batch_size + 1) * seqlen_k, seqlen_k, &cu_seqlens_k);
+
+  FlashAttnUnpaddedMLUKernel<T, Context>(ctx,
+                                         q_t_s,
+                                         k_t_s,
+                                         v_t_s,
+                                         cu_seqlens_q,
+                                         cu_seqlens_k,
+                                         fixed_seed_offset,
+                                         attn_mask,
+                                         seqlen_q,
+                                         seqlen_k,
+                                         scale,
+                                         dropout,
+                                         causal,
+                                         return_softmax,
+                                         is_test,
+                                         rng_name,
+                                         out,
+                                         softmax,
+                                         softmax_lse,
+                                         seed_offset);
+}
+
+template <typename T, typename Context>
+void FlashAttnUnpaddedGradKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& q,
+    const phi::DenseTensor& k,
+    const phi::DenseTensor& v,
+    const phi::DenseTensor& cu_seqlens_q,
+    const phi::DenseTensor& cu_seqlens_k,
+    const phi::DenseTensor& out,
+    const phi::DenseTensor& softmax_lse,
+    const phi::DenseTensor& seed_offset,
+    const paddle::optional<phi::DenseTensor>& attn_mask,
+    const phi::DenseTensor& dout,
+    int64_t max_seqlen_q,
+    int64_t max_seqlen_k,
+    float scale,
+    float dropout,
+    bool causal,
+    phi::DenseTensor* dq,
+    phi::DenseTensor* dk,
+    phi::DenseTensor* dv) {
+  dev_ctx.template Alloc<T>(dq);
+  dev_ctx.template Alloc<T>(dk);
+  dev_ctx.template Alloc<T>(dv);
+
+  // q,k,v [total_*, num_heads, head_dim]
+  auto dims = q.dims();
+  const int32_t total_q = dims[0];
+  const int32_t batch_size = cu_seqlens_q.numel() - 1;
+  const int32_t num_heads = dims[1];
+  const int32_t head_size = dims[2];
+  const int32_t total_k = k.dims()[0];
+  const int32_t num_heads_k = k.dims()[1];
+
+  // const dout and out cannot be modified
+  Tensor dout_tensor = dout;
+  dout_tensor.Resize({total_q, num_heads, head_size});
+  const int32_t head_size_og = dout_tensor.dims()[2];
+  MLUCnnlTensorDesc diff_out_desc(dout_tensor);
+
+  Tensor out_tensor = out;
+  out_tensor.Resize({total_q, num_heads, head_size});
+  MLUCnnlTensorDesc fwd_out_desc(
+      out_tensor, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+
+  PADDLE_ENFORCE_EQ(
+      head_size_og,
+      head_size,
+      phi::errors::InvalidArgument(
+          "flash_attn_bwd receive input with head_size_og == head_size"));
+
+  PADDLE_ENFORCE_GT(
+      batch_size,
+      0,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input with batch_size should > 0"));
+
+  PADDLE_ENFORCE_EQ(
+      head_size % 8,
+      0,
+      phi::errors::InvalidArgument(
+          "flash_attn_raw receive input head_size should divisible by 8"));
+
+  PADDLE_ENFORCE_LE(head_size,
+                    128,
+                    phi::errors::InvalidArgument(
+                        "flash_attn_raw receive input head_size should <=128"));
+
+  cnnlFlashAttentionDescriptor_t desc_;
+  cnnlCreateFlashAttentionDescriptor(&desc_);
+  auto compute_dtype = CNNL_DTYPE_FLOAT;
+  auto prefer = CNNL_ACTIVATION_HIGH_PRECISION;
+  auto attn_mask_mode = causal ? CNNL_ATTN_MASK_CAUSAL : CNNL_ATTN_MASK_NONE;
+  cnnlSetFlashAttentionBackwardDescriptor(desc_,
+                                          compute_dtype,
+                                          prefer,
+                                          attn_mask_mode,
+                                          /*is_pack_mode = */ true,
+                                          /*is_out_zero = */ false,
+                                          /*is_store_softmax_d = */ false,
+                                          max_seqlen_q,
+                                          max_seqlen_k,
+                                          dropout,
+                                          scale);
+
+  MLUCnnlTensorDesc query_desc(q, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc key_desc(k, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc value_desc(v, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+
+  MLUCnnlTensorDesc csq_desc(cu_seqlens_q);
+  MLUCnnlTensorDesc csk_desc(cu_seqlens_k);
+  MLUCnnlTensorDesc softmax_lse_desc(softmax_lse);
+
+  dq->Resize({total_q, num_heads, head_size});
+  dk->Resize({total_k, num_heads, head_size});
+  dv->Resize({total_k, num_heads, head_size});
+
+  MLUCnnlTensorDesc diff_query_desc(
+      *dq, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc diff_key_desc(
+      *dk, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+  MLUCnnlTensorDesc diff_value_desc(
+      *dv, CNNL_LAYOUT_ARRAY, ToCnnlDataType(q.dtype()));
+
+  int64_t* seed_offset_data = const_cast<int64_t*>(seed_offset.data<int64_t>());
+  size_t* rng_state = reinterpret_cast<uint64_t*>(seed_offset_data);
+
+  MLUCnnl::FlashAttentionBackward(dev_ctx,
+                                  desc_,
+                                  diff_out_desc.get(),
+                                  GetBasePtr(&dout_tensor),
+                                  query_desc.get(),
+                                  GetBasePtr(&q),
+                                  key_desc.get(),
+                                  GetBasePtr(&k),
+                                  value_desc.get(),
+                                  GetBasePtr(&v),
+                                  fwd_out_desc.get(),
+                                  GetBasePtr(&out_tensor),
+                                  softmax_lse_desc.get(),
+                                  GetBasePtr(&softmax_lse),
+                                  csq_desc.get(),
+                                  GetBasePtr(&cu_seqlens_q),
+                                  csk_desc.get(),
+                                  GetBasePtr(&cu_seqlens_k),
+                                  rng_state,
+                                  diff_query_desc.get(),
+                                  GetBasePtr(dq),
+                                  diff_key_desc.get(),
+                                  GetBasePtr(dk),
+                                  diff_value_desc.get(),
+                                  GetBasePtr(dv));
+  dq->Resize({batch_size, total_q / batch_size, num_heads, head_size});
+  dk->Resize({batch_size, total_k / batch_size, num_heads, head_size});
+  dv->Resize({batch_size, total_k / batch_size, num_heads, head_size});
+}
+
+template <typename T, typename Context>
+void FlashAttnGradKernel(const Context& ctx,
+                         const phi::DenseTensor& q,
+                         const phi::DenseTensor& k,
+                         const phi::DenseTensor& v,
+                         const phi::DenseTensor& out,
+                         const phi::DenseTensor& softmax_lse,
+                         const phi::DenseTensor& seed_offset,
+                         const paddle::optional<phi::DenseTensor>& attn_mask,
+                         const phi::DenseTensor& dout,
+                         float dropout,
+                         bool causal,
+                         phi::DenseTensor* dq,
+                         phi::DenseTensor* dk,
+                         phi::DenseTensor* dv) {
+  // q,k,v [batch_size, seq_len, num_heads, head_dim]
+  const auto& dims = q.dims();
+  const int32_t batch_size = dims[0];
+  const int32_t seqlen_q = dims[1];
+  const int32_t num_heads = dims[2];
+  const int32_t head_size_og = dout.dims()[3];
+  const int32_t head_size = dims[3];
+  const int32_t seqlen_k = k.dims()[1];
+  const int32_t num_heads_k = k.dims()[2];
+
+  const int32_t total_q = batch_size * seqlen_q;
+  const int32_t total_k = batch_size * seqlen_k;
+
+  PADDLE_ENFORCE_EQ(
+      head_size_og,
+      head_size,
+      phi::errors::InvalidArgument(
+          "flash_attn_bwd receive input with head_size_og == head_size"));
+
+  VLOG(10) << "FlashAttn bwd dims q[" << q.dims() << "], k[" << k.dims()
+           << "], v[" << v.dims() << "]";
+
+  const float scale = 1.0f / std::sqrt(head_size);
+  phi::DenseTensor q_t_s, k_t_s, v_t_s;
+  q_t_s = q;
+  k_t_s = k;
+  v_t_s = v;
+
+  q_t_s.Resize({total_q, num_heads, head_size});
+  k_t_s.Resize({total_k, num_heads, head_size});
+  v_t_s.Resize({total_k, num_heads, head_size});
+
+  phi::DenseTensor cu_seqlens_q;
+  phi::DenseTensor cu_seqlens_k;
+  ArangeNullKernel<int32_t, Context>(
+      ctx, 0, (batch_size + 1) * seqlen_q, seqlen_q, &cu_seqlens_q);
+  ArangeNullKernel<int32_t, Context>(
+      ctx, 0, (batch_size + 1) * seqlen_k, seqlen_k, &cu_seqlens_k);
+
+  FlashAttnUnpaddedGradKernel<T, Context>(ctx,
+                                          q_t_s,
+                                          k_t_s,
+                                          v_t_s,
+                                          cu_seqlens_q,
+                                          cu_seqlens_k,
+                                          out,
+                                          softmax_lse,
+                                          seed_offset,
+                                          attn_mask,
+                                          dout,
+                                          seqlen_q,
+                                          seqlen_k,
+                                          scale,
+                                          dropout,
+                                          causal,
+                                          dq,
+                                          dk,
+                                          dv);
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(flash_attn_unpadded,
+                          mlu,
+                          ALL_LAYOUT,
+                          custom_kernel::FlashAttnUnpaddedMLUKernel,
+                          phi::dtype::float16) {
+  kernel->InputAt(5).SetBackend(
+      phi::Backend::ALL_BACKEND);  // fixed_seed_offset
+}
+
+PD_REGISTER_PLUGIN_KERNEL(flash_attn,
+                          mlu,
+                          ALL_LAYOUT,
+                          custom_kernel::FlashAttnKernel,
+                          phi::dtype::float16) {
+  kernel->InputAt(3).SetBackend(
+      phi::Backend::ALL_BACKEND);  // fixed_seed_offset
+}
+
+PD_REGISTER_PLUGIN_KERNEL(flash_attn_unpadded_grad,
+                          mlu,
+                          ALL_LAYOUT,
+                          custom_kernel::FlashAttnUnpaddedGradKernel,
+                          phi::dtype::float16) {
+  kernel->InputAt(7).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+}
+
+PD_REGISTER_PLUGIN_KERNEL(flash_attn_grad,
+                          mlu,
+                          ALL_LAYOUT,
+                          custom_kernel::FlashAttnGradKernel,
+                          phi::dtype::float16) {
+  kernel->InputAt(5).SetBackend(phi::Backend::ALL_BACKEND);  // seed_offset
+}

--- a/backends/mlu/kernels/funcs/mlu_baseop.h
+++ b/backends/mlu/kernels/funcs/mlu_baseop.h
@@ -1535,6 +1535,54 @@ class MLUCnnl {
                   const cnnlTensorDescriptor_t output_desc,
                   void* output);
 
+  static void FlashAttentionForward(
+      const Context& ctx,
+      const cnnlFlashAttentionDescriptor_t flash_atten_desc,
+      const cnnlTensorDescriptor_t q_desc,  // [total_q, head_num, head_size]
+      const void* q,
+      const cnnlTensorDescriptor_t k_desc,  // [total_k, head_num, head_size]
+      const void* k,
+      const cnnlTensorDescriptor_t v_desc,  // [total_k, head_num, head_size]
+      const void* v,
+      const cnnlTensorDescriptor_t seqlens_q_desc,  // b+1
+      const void* seqlens_q,
+      const cnnlTensorDescriptor_t seqlens_k_desc,  // b+1
+      const void* seqlens_k,
+      const size_t rng_state[],
+      const cnnlTensorDescriptor_t dropout_mask_desc,
+      void* dropout_mask,
+      const cnnlTensorDescriptor_t softmax_lse_desc,  // [total_q, head_num]
+      void* softmax_lse,
+      const cnnlTensorDescriptor_t output_desc,
+      void* output);
+
+  static void FlashAttentionBackward(
+      const Context& ctx,
+      const cnnlFlashAttentionDescriptor_t flash_atten_desc,
+      const cnnlTensorDescriptor_t diff_out_desc,
+      const void* diff_out,
+      const cnnlTensorDescriptor_t q_desc,
+      const void* q,
+      const cnnlTensorDescriptor_t k_desc,
+      const void* k,
+      const cnnlTensorDescriptor_t v_desc,
+      const void* v,
+      const cnnlTensorDescriptor_t fwd_out_desc,
+      const void* out,
+      const cnnlTensorDescriptor_t softmax_lse_desc,
+      const void* softmax_lse,
+      const cnnlTensorDescriptor_t csq_desc,
+      const void* cu_seqlens_q,
+      const cnnlTensorDescriptor_t csk_desc,
+      const void* cu_seqlens_k,
+      const size_t rng_state[],
+      const cnnlTensorDescriptor_t diff_query_desc,
+      void* dq,
+      const cnnlTensorDescriptor_t diff_key_desc,
+      void* dk,
+      const cnnlTensorDescriptor_t diff_value_desc,
+      void* dv);
+
   static void Neg(const Context& ctx,
                   const cnnlTensorDescriptor_t input_desc,
                   const void* input,

--- a/backends/mlu/kernels/funcs/mlu_funcs.h
+++ b/backends/mlu/kernels/funcs/mlu_funcs.h
@@ -409,4 +409,54 @@ class MPTypeTrait<phi::dtype::bfloat16> {
   using Type = float;
 };
 
+template <typename T>
+void GetSize(T start, T end, T step, int64_t* size) {
+  PADDLE_ENFORCE_NE(
+      step,
+      0,
+      phi::errors::InvalidArgument("The step of range op should not be 0."));
+
+  if (start < end) {
+    PADDLE_ENFORCE_GT(
+        step,
+        0,
+        phi::errors::InvalidArgument(
+            "The step should be greater than 0 while start < end."));
+  }
+
+  if (start > end) {
+    PADDLE_ENFORCE_LT(step,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The step should be less than 0 while start > end."));
+  }
+
+  *size = std::is_integral<T>::value
+              ? ((std::abs(end - start) + std::abs(step) - 1) / std::abs(step))
+              : std::ceil(std::abs((end - start) / step));
+}
+
+template <typename T, typename Context>
+void ArangeNullKernel(const Context& dev_ctx,
+                      const T start_value,
+                      const T end_value,
+                      const T step_value,
+                      phi::DenseTensor* out) {
+  int64_t size = 0;
+  GetSize(start_value, end_value, step_value, &size);
+  out->Resize(phi::make_ddim({size}));
+
+  dev_ctx.template Alloc<T>(out);
+
+  std::vector<T> odata;
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    odata.push_back(value);
+    value += step_value;
+  }
+
+  TensorFromVector(dev_ctx, odata, dev_ctx, out);
+  dev_ctx.Wait();
+}
+
 }  // namespace custom_kernel

--- a/backends/mlu/kernels/range_kernel.cc
+++ b/backends/mlu/kernels/range_kernel.cc
@@ -17,33 +17,6 @@
 
 namespace custom_kernel {
 
-template <typename T>
-void GetSize(T start, T end, T step, int64_t* size) {
-  PADDLE_ENFORCE_NE(
-      step,
-      0,
-      phi::errors::InvalidArgument("The step of range op should not be 0."));
-
-  if (start < end) {
-    PADDLE_ENFORCE_GT(
-        step,
-        0,
-        phi::errors::InvalidArgument(
-            "The step should be greater than 0 while start < end."));
-  }
-
-  if (start > end) {
-    PADDLE_ENFORCE_LT(step,
-                      0,
-                      phi::errors::InvalidArgument(
-                          "The step should be less than 0 while start > end."));
-  }
-
-  *size = std::is_integral<T>::value
-              ? ((std::abs(end - start) + std::abs(step) - 1) / std::abs(step))
-              : std::ceil(std::abs((end - start) / step));
-}
-
 template <typename T, typename Context>
 void ArangeKernel(const Context& dev_ctx,
                   const phi::DenseTensor& start_t,

--- a/backends/mlu/runtime/runtime.h
+++ b/backends/mlu/runtime/runtime.h
@@ -16,6 +16,7 @@
 
 #include <cncl.h>
 #include <cnnl.h>
+#include <cnnl_extra.h>
 #include <cnpapi.h>
 #include <cnrt.h>
 #include <mlu_op.h>

--- a/backends/mlu/tests/unittests/test_flash_attention_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_flash_attention_op_mlu.py
@@ -1,0 +1,406 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.nn.functional as F
+from paddle import base
+from paddle.nn.functional.flash_attention import (
+    flash_attention,
+    flash_attn_unpadded,
+    scaled_dot_product_attention,
+)
+
+
+def attention_naive(q, k, v, causal=False):
+    qt = paddle.transpose(q, [0, 2, 1, 3])
+    kt = paddle.transpose(k, [0, 2, 1, 3])
+    vt = paddle.transpose(v, [0, 2, 1, 3])
+    scale = 1.0 / np.sqrt(q.shape[-1])
+    s = paddle.matmul(qt, paddle.transpose(kt, [0, 1, 3, 2]))
+    s = paddle.scale(s, scale)
+    p = paddle.incubate.softmax_mask_fuse_upper_triangle(s) if causal else F.softmax(s)
+    o = paddle.matmul(p, vt)
+    return paddle.transpose(o, [0, 2, 1, 3])
+
+
+def attention_naive_with_mask(q, k, v, attn_bias):
+    qt = paddle.transpose(q, [0, 2, 1, 3])
+    kt = paddle.transpose(k, [0, 2, 1, 3])
+    vt = paddle.transpose(v, [0, 2, 1, 3])
+    scale = 1.0 / np.sqrt(q.shape[-1])
+    s = paddle.matmul(qt, paddle.transpose(kt, [0, 1, 3, 2]))
+    s = paddle.scale(s, scale)
+    p = F.softmax(s + attn_bias)
+    o = paddle.matmul(p, vt)
+    return paddle.transpose(o, [0, 2, 1, 3])
+
+
+class TestFlashAttentionAPI(unittest.TestCase):
+    def setUp(self):
+        self.set_mlu()
+        self.shape = (2, 128, 8, 16)
+        self.dtype = "float16"
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+        self.use_sdp_api = False
+
+    def set_mlu(self):
+        self.__class__.use_custom_device = True
+        self.place = paddle.CustomPlace("mlu", 0)
+
+    def test_unpadded(self):
+        print(
+            f"Test unpadded case shape {self.shape} dtype {self.dtype} causal {self.causal}"
+        )
+
+        paddle.disable_static()
+
+        query = np.random.random(self.shape)
+        q = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        q_ = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+
+        out_ = attention_naive(q_, q_, q_, self.causal)
+
+        scale = 1.0 / np.sqrt(q.shape[-1])
+
+        bs = self.shape[0]
+        ms = self.shape[1]
+        nh = self.shape[2]
+        hd = self.shape[3]
+        cu_q = paddle.arange(0, (bs + 1) * ms, ms, dtype="int32")
+
+        qq = paddle.reshape(q, [bs * ms, nh, hd])
+        out, _ = flash_attn_unpadded(
+            qq,
+            qq,
+            qq,
+            cu_q,
+            cu_q,
+            ms,
+            ms,
+            scale,
+            self.dropout,
+            self.causal,
+            self.return_softmax,
+        )
+        out_ = paddle.reshape(out_, [bs, ms, nh, hd])
+
+        np.testing.assert_allclose(out.numpy(), out_, rtol=5e-03, atol=1e-03)
+
+        out.backward()
+        out_.backward()
+
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_.grad.numpy(), rtol=5e-03, atol=1e-03
+        )
+
+        # test static
+        paddle.enable_static()
+
+        with paddle.static.program_guard(paddle.static.Program()):
+            qs = paddle.static.data(name="q", shape=self.shape, dtype=self.dtype)
+
+            cu_q = paddle.arange(0, (bs + 1) * ms, ms, dtype="int32")
+            qs = paddle.reshape(qs, [bs * ms, nh, hd])
+
+            outs, softmax = flash_attn_unpadded(
+                qs,
+                qs,
+                qs,
+                cu_q,
+                cu_q,
+                ms,
+                ms,
+                scale,
+                self.dropout,
+                self.causal,
+                self.return_softmax,
+            )
+
+            exe = base.Executor(self.place)
+            fetches_result = exe.run(
+                feed={
+                    "q": query.astype("float16"),
+                    "k": query.astype("float16"),
+                    "v": query.astype("float16"),
+                },
+                fetch_list=[outs],
+            )
+
+            np.testing.assert_allclose(fetches_result[0], out_, rtol=5e-03, atol=1e-03)
+
+    def test_all(self):
+        print(f"Test case shape {self.shape} dtype {self.dtype} causal {self.causal}")
+        # test dynamic
+        paddle.disable_static()
+
+        query = np.random.random(self.shape)
+        key = np.random.random(self.shape)
+        value = np.random.random(self.shape)
+
+        q = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        k = paddle.to_tensor(
+            key, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        v = paddle.to_tensor(
+            value, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+
+        q_ = paddle.to_tensor(
+            query, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        k_ = paddle.to_tensor(
+            key, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+        v_ = paddle.to_tensor(
+            value, place=self.place, dtype=self.dtype, stop_gradient=False
+        )
+
+        if self.use_sdp_kernel:
+            with paddle.nn.functional.sdp_kernel(
+                enable_math=self.enable_math,
+                enable_flash=self.enable_flash,
+                enable_mem_efficient=self.enable_mem_efficient,
+            ):
+                if self.use_sdp_api:
+                    out = scaled_dot_product_attention(
+                        q, k, v, None, self.dropout, self.causal
+                    )
+                else:
+                    out, _ = flash_attention(
+                        q, k, v, self.dropout, self.causal, self.return_softmax
+                    )
+
+        else:
+            out, _ = flash_attention(
+                q, k, v, self.dropout, self.causal, self.return_softmax
+            )
+        out_ = attention_naive(q_, k_, v_, self.causal)
+
+        out.backward()
+        out_.backward()
+
+        np.testing.assert_allclose(out.numpy(), out_, rtol=5e-03, atol=1e-03)
+
+        self.assertEqual(q.grad.shape, q.shape)
+        self.assertEqual(q_.grad.shape, q.shape)
+
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_.grad.numpy(), rtol=5e-03, atol=1e-03
+        )
+
+        # test static
+        paddle.enable_static()
+
+        with paddle.static.program_guard(paddle.static.Program()):
+            qs = paddle.static.data(name="q", shape=self.shape, dtype=self.dtype)
+            ks = paddle.static.data(name="k", shape=self.shape, dtype=self.dtype)
+            vs = paddle.static.data(name="v", shape=self.shape, dtype=self.dtype)
+
+            if self.use_sdp_kernel:
+                with paddle.nn.functional.sdp_kernel(
+                    enable_math=self.enable_math,
+                    enable_flash=self.enable_flash,
+                    enable_mem_efficient=self.enable_mem_efficient,
+                ):
+                    if self.use_sdp_api:
+                        outs = scaled_dot_product_attention(
+                            qs, ks, vs, None, self.dropout, self.causal
+                        )
+                    else:
+                        outs, softmax = flash_attention(
+                            qs,
+                            ks,
+                            vs,
+                            self.dropout,
+                            self.causal,
+                            self.return_softmax,
+                        )
+            else:
+                outs, softmax = flash_attention(
+                    qs, ks, vs, self.dropout, self.causal, self.return_softmax
+                )
+
+            exe = base.Executor(self.place)
+            fetches_result = exe.run(
+                feed={
+                    "q": query.astype("float16"),
+                    "k": key.astype("float16"),
+                    "v": value.astype("float16"),
+                },
+                fetch_list=[outs],
+            )
+
+            np.testing.assert_allclose(fetches_result[0], out_, rtol=5e-03, atol=1e-03)
+
+
+# class TestFlashAttentionWithMaskAPI(unittest.TestCase):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (2, 128, 8, 32)
+#         self.dtype = 'float16'
+#         self.dropout = 0.0
+#         self.causal = False
+
+#     def test_dot_scale_product(self):
+#         # test dynamic
+#         paddle.disable_static()
+
+#         query = np.random.random(self.shape)
+#         key = np.random.random(self.shape)
+#         value = np.random.random(self.shape)
+
+#         q = paddle.to_tensor(
+#             query, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+#         k = paddle.to_tensor(
+#             key, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+#         v = paddle.to_tensor(
+#             value, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+
+#         q_ = paddle.to_tensor(
+#             query, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+#         k_ = paddle.to_tensor(
+#             key, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+#         v_ = paddle.to_tensor(
+#             value, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+
+#         mask_shape = (self.shape[0], 1, self.shape[1], self.shape[1])
+#         mask = np.random.random(mask_shape)
+#         m = paddle.to_tensor(
+#             mask, place=self.place, dtype=self.dtype, stop_gradient=False
+#         )
+
+#         out = scaled_dot_product_attention(
+#             q, k, v, m, self.dropout, self.causal
+#         )
+#         out_ = attention_naive_with_mask(q_, k_, v_, m)
+#         out.backward()
+#         out_.backward()
+#         np.testing.assert_allclose(out.numpy(), out_, rtol=5e-03, atol=1e-03)
+
+
+class TestFlashAttentionAPITest1(TestFlashAttentionAPI):
+    def setUp(self):
+        self.set_mlu()
+        self.shape = (2, 128, 8, 16)
+        self.dtype = paddle.float16
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+
+
+# class TestFlashAttentionAPITest2(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (2, 256, 8, 16)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = False
+#         self.return_softmax = True
+#         self.use_sdp_kernel = False
+
+
+# class TestFlashAttentionAPITest3(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (2, 512, 8, 16)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = True
+#         self.return_softmax = False
+#         self.use_sdp_kernel = False
+
+
+class TestFlashAttentionAPITest4(TestFlashAttentionAPI):
+    def setUp(self):
+        self.set_mlu()
+        self.shape = (8, 1024, 16, 128)
+        self.dtype = paddle.float16
+        self.dropout = 0.0
+        self.causal = False
+        self.return_softmax = False
+        self.use_sdp_kernel = False
+
+
+# class TestFlashAttentionAPITest5(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (8, 1024, 16, 256)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = False
+#         self.return_softmax = False
+#         self.use_sdp_kernel = False
+
+
+# class TestMathAttentionAPITest(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (8, 1024, 16, 128)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = False
+#         self.return_softmax = False
+#         self.use_sdp_kernel = True
+#         self.use_sdp_api = False
+#         self.enable_math = True
+#         self.enable_flash = False
+#         self.enable_mem_efficient = False
+
+
+# class TestSDPAttentionAPITest(TestFlashAttentionAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (8, 1024, 16, 128)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = False
+#         self.return_softmax = False
+#         self.use_sdp_kernel = True
+#         self.use_sdp_api = True
+#         self.enable_math = True
+#         self.enable_flash = False
+#         self.enable_mem_efficient = False
+
+
+# class TestFlashAttrnionWithMaskAPI(TestFlashAttentionWithMaskAPI):
+#     def setUp(self):
+#         self.set_mlu()
+#         self.shape = (8, 1024, 16, 128)
+#         self.dtype = paddle.float16
+#         self.dropout = 0.0
+#         self.causal = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/mlu/tools/dockerfile/Dockerfile.mlu.ubuntu18.x86_64.gcc82
+++ b/backends/mlu/tools/dockerfile/Dockerfile.mlu.ubuntu18.x86_64.gcc82
@@ -6,6 +6,7 @@ LABEL maintainer="PaddlePaddle Authors <paddle-dev@baidu.com>"
 # version for mlu packages
 ARG CNTOOLKIT_VERSION
 ARG CNNL_VERSION
+ARG CNNL_EXTRA_VERSION
 ARG CNCL_VERSION
 ARG MLUOPS_VERSION
 
@@ -18,7 +19,7 @@ RUN apt update && \
 
 # install cntoolkit
 RUN cd /tmp && \
-    wget -O cntoolkit_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.9.0/cntoolkit_${CNTOOLKIT_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
+    wget -O cntoolkit_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.11.0/cntoolkit_${CNTOOLKIT_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
     dpkg -i cntoolkit_install_pkg.deb && \
     apt update && \
     apt-get install -y cnrt cnperf cnpapi cnlicense cngdb cndrv cndev cncodec cncc cnas cnbin cnstudio cnrtc cnvs && \
@@ -30,19 +31,25 @@ RUN cd /tmp && \
 
 # install cnnl
 RUN cd /tmp && \
-    wget -O cnnl_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.9.0/cnnl_${CNNL_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
+    wget -O cnnl_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.11.0/cnnl_${CNNL_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
     dpkg -i cnnl_install_pkg.deb && \
     rm -f cnnl_install_pkg.deb
 
+# install cnnl_extra
+RUN cd /tmp && \
+    wget -O cnnlextra_install_pkg.deb ftp://download.cambricon.com:8821/tmp/cnnlextra/cnnlextra_${CNNL_EXTRA_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
+    dpkg -i cnnlextra_install_pkg.deb && \
+    rm -f cnnlextra_install_pkg.deb
+
 # install cncl
 RUN cd /tmp && \
-    wget -O cncl_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.9.0/cncl_${CNCL_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
+    wget -O cncl_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.11.0/cncl_${CNCL_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
     dpkg -i cncl_install_pkg.deb && \
     rm -f cncl_install_pkg.deb
 
 # install mluops
 RUN cd /tmp && \
-    wget -O mluops_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.9.0/mluops_${MLUOPS_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
+    wget -O mluops_install_pkg.deb ftp://download.cambricon.com:8821/tmp/CTR2.11.0/mluops_${MLUOPS_VERSION}.ubuntu18.04_amd64.deb --ftp-user=${FTP_USER} --ftp-password=${FTP_PASSWORD} && \
     dpkg -i mluops_install_pkg.deb && \
     rm -f mluops_install_pkg.deb
 

--- a/backends/mlu/tools/dockerfile/build-image.sh
+++ b/backends/mlu/tools/dockerfile/build-image.sh
@@ -17,15 +17,16 @@
 set -ex
 
 # Usage:
-# export ${FTP_USER} ${FTP_PASSWORD} ${CNTOOLKIT_VERSION} ${CNNL_VERSION} ${CNCL_VERSION} ${MLUOPS_VERSION}
-# bash build-image.sh ${FTP_USER} ${FTP_PASSWORD} ${CNTOOLKIT_VERSION} ${CNNL_VERSION} ${CNCL_VERSION} ${MLUOPS_VERSION}
+# export ${FTP_USER} ${FTP_PASSWORD} ${CNTOOLKIT_VERSION} ${CNNL_VERSION} ${CNNL_EXTRA_VERSION} ${CNCL_VERSION} ${MLUOPS_VERSION}
+# bash build-image.sh ${FTP_USER} ${FTP_PASSWORD} ${CNTOOLKIT_VERSION} ${CNNL_VERSION} ${CNNL_EXTRA_VERSION} ${CNCL_VERSION} ${MLUOPS_VERSION}
 
 FTP_USER=${1} # Please contact Cambricon technicians to obtain username and password
 FTP_PASSWORD=${2}
-CNTOOLKIT_VERSION=${3:-3.4.2-1} # default 3.4.2
-CNNL_VERSION=${4:-1.17.0-1} # default 1.17.0
-CNCL_VERSION=${5:-1.9.3-1} # default 1.9.3
-MLUOPS_VERSION=${6:-0.6.0-1} # default 0.6.0
+CNTOOLKIT_VERSION=${3:-3.6.1-1} # default 3.6.1
+CNNL_VERSION=${4:-1.20.4-1} # default 1.20.4
+CNCL_VERSION=${5:-1.11.0-1} # default 1.11.0
+MLUOPS_VERSION=${6:-0.8.1-1} # default 0.8.1
+CNNL_EXTRA_VERSION=${7:-1.4.1-1} # default 1.4.1-1
 
 if [ $(uname -i) == 'x86_64' ]; then
   # ubuntu18-$(uname -m)-gcc82
@@ -33,6 +34,7 @@ if [ $(uname -i) == 'x86_64' ]; then
   docker build --network=host -f Dockerfile.mlu.ubuntu18.$(uname -m).gcc82 \
        --build-arg CNTOOLKIT_VERSION=${CNTOOLKIT_VERSION} \
        --build-arg CNNL_VERSION=${CNNL_VERSION} \
+       --build-arg CNNL_EXTRA_VERSION=${CNNL_EXTRA_VERSION} \
        --build-arg CNCL_VERSION=${CNCL_VERSION} \
        --build-arg MLUOPS_VERSION=${MLUOPS_VERSION} \
        --build-arg FTP_USER=${FTP_USER} \
@@ -56,4 +58,3 @@ else
        -t registry.baidubce.com/device/paddle-mlu:kylinv10-$(uname -m)-gcc82 .
   docker push registry.baidubce.com/device/paddle-mlu:kylinv10-$(uname -m)-gcc82
 fi
-


### PR DESCRIPTION
1、添加flash attention前项算子。
2、第一阶段验证方法：
（1）从gpu处保存输入到_C_ops.flash_attn( ) 中的query、key、value值；保存经过_C_ops.flash_attn( )后输出的result_attention值。
（2）将gpu的输入值传入mlu的_C_ops.flash_attn( ) 处，mlu输出结果与gpu的diff如下。
![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/41565156/fcd6ef97-7d50-4354-a8de-db4fab90ca3d)
3、添加flash attention反向算子。
4、参考gpu测例，添加mlu正反向测例。
5、添加的测例pass，但是整网训练，反向loss出现nan。
6、重新修改softmax_lse、rng_state接入，loss中的nan消失。
7、启动脚本中开关 --use_flash_attention ，单卡训练小网络tiny-random-llama，分别对比迭代后的loss，loss基本一致。