### PR TITLE
fix npi adamw kernel

### DIFF
--- a/backends/npu/kernels/adam_kernel.cc
+++ b/backends/npu/kernels/adam_kernel.cc
@@ -114,7 +114,8 @@ void AdamImplKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<MPDType>(master_param_out);
     phi::DenseTensor master_param_t;
     auto tmp_master_param = master_param.get();
-    if (tmp_master_param.dtype() == phi::DataType::FLOAT64 || tmp_master_param.dtype() == phi::DataType::FLOAT32) {
+    if (tmp_master_param.dtype() == phi::DataType::FLOAT64 ||
+        tmp_master_param.dtype() == phi::DataType::FLOAT32) {
       phi::DenseTensorMeta master_param_meta = {phi::DataType::FLOAT32,
                                                 tmp_master_param.dims(),
                                                 tmp_master_param.layout()};

--- a/backends/npu/kernels/adam_kernel.cc
+++ b/backends/npu/kernels/adam_kernel.cc
@@ -114,7 +114,7 @@ void AdamImplKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<MPDType>(master_param_out);
     phi::DenseTensor master_param_t;
     auto tmp_master_param = master_param.get();
-    if (tmp_master_param.dtype() == phi::DataType::FLOAT64) {
+    if (tmp_master_param.dtype() == phi::DataType::FLOAT64 || tmp_master_param.dtype() == phi::DataType::FLOAT32) {
       phi::DenseTensorMeta master_param_meta = {phi::DataType::FLOAT32,
                                                 tmp_master_param.dims(),
                                                 tmp_master_param.layout()};


### PR DESCRIPTION
修复tmp_master_param.dtype() == phi::DataType::FLOAT32 时，master_param_t不会被分配内存的bug。