### PR TITLE
fix layer norm ut

### DIFF
--- a/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
@@ -158,6 +158,8 @@ class TestLayerNormOp(unittest.TestCase):
             x_grad, scale_grad, bias_grad = _reference_layer_norm_grad(
                 x, y_grad, scale, bias, mean, variance, begin_norm_axis
             )
+            mean.shape = x_shape[0:begin_norm_axis]
+            variance.shape = x_shape[0:begin_norm_axis]
 
             var_dict = locals()
             var_dict["y@GRAD"] = y_grad

--- a/backends/npu/tests/unittests/test_layer_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_layer_norm_op_npu.py
@@ -167,6 +167,8 @@ class TestLayerNormOp(unittest.TestCase):
             x_grad, scale_grad, bias_grad = _reference_layer_norm_grad(
                 x, y_grad, scale, bias, mean, variance, begin_norm_axis
             )
+            mean.shape = x_shape[0:begin_norm_axis]
+            variance.shape = x_shape[0:begin_norm_axis]
 
             var_dict = locals()
             var_dict["y@GRAD"] = y_grad


### PR DESCRIPTION
根据主框架改动https://github.com/PaddlePaddle/Paddle/pull/58776 修复layer-norm单测中variance和mean shape不匹配的问题，本地测试结果如下：
<img width="549" alt="image" src="https://github.com/PaddlePaddle/PaddleCustomDevice/assets/50285351/d4c2da60-5d78-4916-8190-f576f6801e5f">
