### PR TITLE
add bf16 dtype for paddle-npu api

### DIFF
--- a/backends/npu/kernels/activation_kernel.cc
+++ b/backends/npu/kernels/activation_kernel.cc
@@ -1175,7 +1175,8 @@ PD_REGISTER_PLUGIN_KERNEL(sin,
                           custom_kernel::SinKernel,
                           float,
                           double,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(swish,
                           npu,
@@ -1196,14 +1197,16 @@ PD_REGISTER_PLUGIN_KERNEL(silu,
                           ALL_LAYOUT,
                           custom_kernel::SiluKernel,
                           float,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(silu_grad,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::SiluGradKernel,
                           float,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(relu,
                           npu,
@@ -1503,15 +1506,23 @@ PD_REGISTER_PLUGIN_KERNEL(selu_grad,
                           float,
                           phi::dtype::float16) {}
 
-PD_REGISTER_PLUGIN_KERNEL(
-    rsqrt, npu, ALL_LAYOUT, custom_kernel::RsqrtKernel, float, double) {}
+PD_REGISTER_PLUGIN_KERNEL(rsqrt,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::RsqrtKernel,
+                          float,
+                          double,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(rsqrt_grad,
                           npu,
                           ALL_LAYOUT,
                           custom_kernel::RsqrtGradKernel,
                           float,
-                          double) {}
+                          double,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(elu,
                           npu,

--- a/backends/npu/kernels/compare_kernel.cc
+++ b/backends/npu/kernels/compare_kernel.cc
@@ -295,6 +295,7 @@ void GreaterThanKernel(const Context& dev_ctx,
                             int64_t,                        \
                             float,                          \
                             phi::dtype::float16,            \
+                            phi::dtype::bfloat16,           \
                             double) {                       \
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);   \
   }                                                         \
@@ -308,6 +309,7 @@ void GreaterThanKernel(const Context& dev_ctx,
                             int64_t,                        \
                             float,                          \
                             phi::dtype::float16,            \
+                            phi::dtype::bfloat16,           \
                             double) {                       \
     kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);   \
   }

--- a/backends/npu/kernels/elementwise_mul_kernel.cc
+++ b/backends/npu/kernels/elementwise_mul_kernel.cc
@@ -147,6 +147,7 @@ PD_REGISTER_PLUGIN_KERNEL(multiply_raw,
                           int64_t,
                           float,
                           phi::dtype::float16,
+                          phi::dtype::bfloat16,
                           double) {}
 
 PD_REGISTER_PLUGIN_KERNEL(multiply,
@@ -158,6 +159,7 @@ PD_REGISTER_PLUGIN_KERNEL(multiply,
                           int64_t,
                           float,
                           phi::dtype::float16,
+                          phi::dtype::bfloat16,
                           double) {}
 
 PD_REGISTER_PLUGIN_KERNEL(multiply_grad,
@@ -168,4 +170,5 @@ PD_REGISTER_PLUGIN_KERNEL(multiply_grad,
                           int64_t,
                           float,
                           phi::dtype::float16,
+                          phi::dtype::bfloat16,
                           double) {}

--- a/backends/npu/kernels/multinomial_kernel.cc
+++ b/backends/npu/kernels/multinomial_kernel.cc
@@ -55,6 +55,7 @@ PD_REGISTER_PLUGIN_KERNEL(multinomial,
                           custom_kernel::MultinomialKernel,
                           float,
                           double,
-                          phi::dtype::float16) {
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {
   kernel->OutputAt(0).SetDataType(phi::DataType::INT64);
 }

--- a/backends/npu/kernels/tril_triu_kernel.cc
+++ b/backends/npu/kernels/tril_triu_kernel.cc
@@ -126,7 +126,8 @@ PD_REGISTER_PLUGIN_KERNEL(tril_triu,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(tril,
                           npu,
@@ -136,7 +137,8 @@ PD_REGISTER_PLUGIN_KERNEL(tril,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(triu,
                           npu,
@@ -147,7 +149,8 @@ PD_REGISTER_PLUGIN_KERNEL(triu,
                           double,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(tril_triu_grad,
                           npu,
@@ -158,7 +161,8 @@ PD_REGISTER_PLUGIN_KERNEL(tril_triu_grad,
                           double,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(tril_grad,
                           npu,
@@ -169,7 +173,8 @@ PD_REGISTER_PLUGIN_KERNEL(tril_grad,
                           double,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(triu_grad,
                           npu,
@@ -180,4 +185,5 @@ PD_REGISTER_PLUGIN_KERNEL(triu_grad,
                           double,
                           int,
                           int64_t,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}

--- a/backends/npu/kernels/unsqueeze_kernel.cc
+++ b/backends/npu/kernels/unsqueeze_kernel.cc
@@ -121,7 +121,8 @@ PD_REGISTER_PLUGIN_KERNEL(unsqueeze_infer,
                           int8_t,
                           int64_t,
                           phi::dtype::complex<float>,
-                          phi::dtype::complex<double>) {}
+                          phi::dtype::complex<double>,
+                          phi::dtype::float16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(unsqueeze,
                           npu,

--- a/backends/npu/kernels/where_kernel.cc
+++ b/backends/npu/kernels/where_kernel.cc
@@ -77,7 +77,8 @@ PD_REGISTER_PLUGIN_KERNEL(where,
                           int64_t,
                           double,
                           float,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(where_grad,
                           npu,
@@ -87,4 +88,5 @@ PD_REGISTER_PLUGIN_KERNEL(where_grad,
                           int64_t,
                           double,
                           float,
-                          phi::dtype::float16) {}
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}

--- a/backends/npu/tests/unittests/test_activation_op.py
+++ b/backends/npu/tests/unittests/test_activation_op.py
@@ -22,7 +22,7 @@ from scipy.special import erf, expit
 import paddle
 import paddle.base as base
 import paddle.nn.functional as F
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 from tests.utils import static_guard
 
 paddle.enable_static()
@@ -1117,6 +1117,21 @@ class TestSin_ZeroDim(TestSin):
         self.shape = []
 
 
+class TestSinBF16(TestSin):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "sin"
+        self.init_dtype()
+        self.init_shape()
+
+        np.random.seed(1024)
+        x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        out = np.sin(convert_uint16_to_float(convert_float_to_uint16(x)))
+
+        self.inputs = {"X": convert_float_to_uint16(OpTest.np_dtype_to_base_dtype(x))}
+        self.outputs = {"Out": out}
+
+
 def ref_swish(x):
     out = x * expit(x)
     return out
@@ -1232,6 +1247,20 @@ class TestSilu(TestActivation):
 class TestSilu_ZeroDim(TestSilu):
     def init_shape(self):
         self.shape = []
+
+
+class TestSiluBF16(TestSilu):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "silu"
+        self.init_dtype()
+        self.init_shape()
+
+        np.random.seed(1024)
+        x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        out = x / (np.exp(-convert_uint16_to_float(convert_float_to_uint16(x))) + 1)
+        self.inputs = {"X": convert_float_to_uint16(OpTest.np_dtype_to_base_dtype(x))}
+        self.outputs = {"Out": out}
 
 
 class TestSiluAPI(unittest.TestCase):

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.base as base
 from paddle.base import Program, program_guard
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16
 
 
 def create_test_class(op_type, typename, callback):
@@ -28,10 +28,18 @@ def create_test_class(op_type, typename, callback):
         def setUp(self):
             self.set_npu()
             self.place = paddle.CustomPlace("npu", 0)
-            x = np.random.random(size=(10, 7)).astype(typename)
-            y = np.random.random(size=(10, 7)).astype(typename)
+            if typename == "bfloat16":
+                x = np.random.random(size=(10, 7)).astype("float32")
+                y = np.random.random(size=(10, 7)).astype("float32")
+                self.inputs = {
+                    "X": convert_float_to_uint16(x),
+                    "Y": convert_float_to_uint16(y),
+                }
+            else:
+                x = np.random.random(size=(10, 7)).astype(typename)
+                y = np.random.random(size=(10, 7)).astype(typename)
+                self.inputs = {"X": x, "Y": y}
             out = callback(x, y)
-            self.inputs = {"X": x, "Y": y}
             self.outputs = {"Out": out}
             self.op_type = op_type
 
@@ -62,8 +70,12 @@ def create_test_class(op_type, typename, callback):
         def test_dynamic_api(self):
             paddle.disable_static()
             paddle.set_device("npu:0")
-            x = np.random.random(size=(10, 7)).astype(typename)
-            y = np.random.random(size=(10, 7)).astype(typename)
+            if typename == "bfloat16":
+                x = np.random.random(size=(10, 7)).astype("float32")
+                y = np.random.random(size=(10, 7)).astype("float32")
+            else:
+                x = np.random.random(size=(10, 7)).astype(typename)
+                y = np.random.random(size=(10, 7)).astype(typename)
             real_result = callback(x, y)
             x = paddle.to_tensor(x, dtype=typename)
             y = paddle.to_tensor(y, dtype=typename)
@@ -76,8 +88,11 @@ def create_test_class(op_type, typename, callback):
                 return
             paddle.disable_static()
             paddle.set_device("npu:0")
-            x = np.random.random(size=(10, 7)).astype(typename)
             y = np.random.random(size=(10, 7)).astype("int32")
+            if typename == "bfloat16":
+                x = np.random.random(size=(10, 7)).astype("float32")
+            else:
+                x = np.random.random(size=(10, 7)).astype(typename)
             real_result = callback(x, y)
             x = paddle.to_tensor(x, dtype=typename)
             y = paddle.to_tensor(y, dtype="float32")
@@ -85,7 +100,6 @@ def create_test_class(op_type, typename, callback):
             out = op(x, y)
             self.assertEqual((out.numpy() == real_result).all(), True)
 
-        @unittest.skipIf(typename == "float16", "float16 is not supported now")
         def test_broadcast_api_1(self):
             paddle.enable_static()
             with program_guard(Program(), Program()):
@@ -94,13 +108,26 @@ def create_test_class(op_type, typename, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.arange(1, 7).reshape((1, 2, 1, 3)).astype(typename)
-                input_y = np.arange(0, 6).reshape((1, 2, 3)).astype(typename)
+                if typename == "bfloat16":
+                    input_x = np.arange(1, 7).reshape((1, 2, 1, 3)).astype("float32")
+                    input_y = np.arange(0, 6).reshape((1, 2, 3)).astype("float32")
+                    (res,) = exe.run(
+                        feed={
+                            "x": convert_float_to_uint16(input_x),
+                            "y": convert_float_to_uint16(input_y),
+                        },
+                        fetch_list=[out],
+                    )
+                else:
+                    input_x = np.arange(1, 7).reshape((1, 2, 1, 3)).astype(typename)
+                    input_y = np.arange(0, 6).reshape((1, 2, 3)).astype(typename)
+                    (res,) = exe.run(
+                        feed={"x": input_x, "y": input_y}, fetch_list=[out]
+                    )
                 real_result = callback(input_x, input_y)
-                (res,) = exe.run(feed={"x": input_x, "y": input_y}, fetch_list=[out])
+
             self.assertEqual((res == real_result).all(), True)
 
-        @unittest.skipIf(typename == "float16", "float16 is not supported now")
         def test_broadcast_api_2(self):
             paddle.enable_static()
             with program_guard(Program(), Program()):
@@ -109,13 +136,25 @@ def create_test_class(op_type, typename, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.arange(0, 6).reshape((1, 2, 3)).astype(typename)
-                input_y = np.arange(1, 7).reshape((1, 2, 1, 3)).astype(typename)
+                if typename == "bfloat16":
+                    input_x = np.arange(0, 6).reshape((1, 2, 3)).astype("float32")
+                    input_y = np.arange(1, 7).reshape((1, 2, 1, 3)).astype("float32")
+                    (res,) = exe.run(
+                        feed={
+                            "x": convert_float_to_uint16(input_x),
+                            "y": convert_float_to_uint16(input_y),
+                        },
+                        fetch_list=[out],
+                    )
+                else:
+                    input_x = np.arange(0, 6).reshape((1, 2, 3)).astype(typename)
+                    input_y = np.arange(1, 7).reshape((1, 2, 1, 3)).astype(typename)
+                    (res,) = exe.run(
+                        feed={"x": input_x, "y": input_y}, fetch_list=[out]
+                    )
                 real_result = callback(input_x, input_y)
-                (res,) = exe.run(feed={"x": input_x, "y": input_y}, fetch_list=[out])
             self.assertEqual((res == real_result).all(), True)
 
-        @unittest.skipIf(typename == "float16", "float16 is not supported now")
         def test_broadcast_api_3(self):
             paddle.enable_static()
             with program_guard(Program(), Program()):
@@ -124,13 +163,25 @@ def create_test_class(op_type, typename, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.arange(0, 5).reshape((5)).astype(typename)
-                input_y = np.array([5, 3, 2]).reshape((3, 1)).astype(typename)
+                if typename == "bfloat16":
+                    input_x = np.arange(0, 5).reshape((5)).astype("float32")
+                    input_y = np.array([5, 3, 2]).reshape((3, 1)).astype("float32")
+                    (res,) = exe.run(
+                        feed={
+                            "x": convert_float_to_uint16(input_x),
+                            "y": convert_float_to_uint16(input_y),
+                        },
+                        fetch_list=[out],
+                    )
+                else:
+                    input_x = np.arange(0, 5).reshape((5)).astype(typename)
+                    input_y = np.array([5, 3, 2]).reshape((3, 1)).astype(typename)
+                    (res,) = exe.run(
+                        feed={"x": input_x, "y": input_y}, fetch_list=[out]
+                    )
                 real_result = callback(input_x, input_y)
-                (res,) = exe.run(feed={"x": input_x, "y": input_y}, fetch_list=[out])
             self.assertEqual((res == real_result).all(), True)
 
-        @unittest.skipIf(typename == "float16", "float16 is not supported now")
         def test_attr_name(self):
             paddle.enable_static()
             with program_guard(Program(), Program()):
@@ -145,7 +196,7 @@ def create_test_class(op_type, typename, callback):
     globals()[cls_name] = Cls
 
 
-for _type_name in {"float16", "float32", "int32", "int64", "bool"}:
+for _type_name in {"bfloat16", "float16", "float32", "int32", "int64", "bool"}:
     create_test_class("equal", _type_name, lambda _a, _b: _a == _b)
     create_test_class("not_equal", _type_name, lambda _a, _b: _a != _b)
     create_test_class("less_than", _type_name, lambda _a, _b: _a < _b)

--- a/backends/npu/tests/unittests/test_rsqrt_op_npu.py
+++ b/backends/npu/tests/unittests/test_rsqrt_op_npu.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 
 paddle.enable_static()
 SEED = 2021
@@ -61,6 +61,30 @@ class TestRsqrt(OpTest):
 class TestRsqrtDouble(TestRsqrt):
     def init_dtype(self):
         self.dtype = np.double
+
+
+class TestRsqrtFP16(TestRsqrt):
+    def init_dtype(self):
+        self.dtype = np.float16
+
+
+class TestRsqrtBF16(TestRsqrt):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "rsqrt"
+        self.place = paddle.CustomPlace("npu", 0)
+
+        self.init_dtype()
+        np.random.seed(SEED)
+        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
+        out = 1.0 / np.sqrt(convert_uint16_to_float(convert_float_to_uint16(x)))
+
+        self.inputs = {"X": convert_float_to_uint16(OpTest.np_dtype_to_base_dtype(x))}
+        self.attrs = {}
+        self.outputs = {"Out": out}
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_tril_triu_op_npu.py
+++ b/backends/npu/tests/unittests/test_tril_triu_op_npu.py
@@ -20,7 +20,7 @@ import paddle
 import paddle.base as base
 import paddle.tensor as tensor
 from paddle.base.framework import Program, program_guard
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 
 paddle.enable_static()
 
@@ -75,6 +75,30 @@ class TestNPUTrilTriu(OpTest):
 class TestNPUTrilTriuFP16(TestNPUTrilTriu):
     def init_dtype(self):
         self.dtype = np.float16
+
+
+class TestNPUTrilTriuBF16(TestNPUTrilTriu):
+    def setUp(self):
+        self.op_type = "tril_triu"
+        self.set_npu()
+        self.init_dtype()
+        self.initTestCase()
+        self.place = paddle.CustomPlace("npu", 0)
+        self.real_np_op = getattr(np, self.real_op_type)
+
+        self.inputs = {"X": convert_float_to_uint16(self.X)}
+        self.attrs = {
+            "diagonal": self.diagonal,
+            "lower": True if self.real_op_type == "tril" else False,
+        }
+        self.outputs = {
+            "Out": self.real_np_op(convert_uint16_to_float(self.X), self.diagonal)
+            if self.diagonal
+            else self.real_np_op(convert_uint16_to_float(self.X))
+        }
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 
 class TestNPUTrilTriuFP64(TestNPUTrilTriu):
@@ -157,12 +181,17 @@ class TestTrilTriuOpAPI(unittest.TestCase):
     def test_api(self):
         paddle.enable_static()
 
-        dtypes = ["float16", "float32"]
+        dtypes = ["float16", "float32", "bfloat16"]
         for dtype in dtypes:
             prog = Program()
             startup_prog = Program()
             with program_guard(prog, startup_prog):
-                data = np.random.random([1, 9, 9, 4]).astype(dtype)
+                if dtype == "bfloat16":
+                    data = convert_float_to_uint16(
+                        np.random.random([1, 9, 9, 4]).astype("float32")
+                    )
+                else:
+                    data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = paddle.static.data(shape=[1, 9, -1, 4], dtype=dtype, name="x")
                 tril_out, triu_out = tensor.tril(x), tensor.triu(x)
 
@@ -173,30 +202,52 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     feed={"x": data},
                     fetch_list=[tril_out, triu_out],
                 )
-                np.testing.assert_allclose(tril_out, np.tril(data))
-                np.testing.assert_allclose(triu_out, np.triu(data))
+                np.testing.assert_allclose(
+                    convert_uint16_to_float(tril_out),
+                    np.tril(convert_uint16_to_float(data)),
+                )
+                np.testing.assert_allclose(
+                    convert_uint16_to_float(triu_out),
+                    np.triu(convert_uint16_to_float(data)),
+                )
 
     def test_api_with_dygraph(self):
         paddle.disable_static(paddle.CustomPlace("npu", 0))
 
-        dtypes = ["float16", "float32"]
+        dtypes = ["float16", "float32", "bfloat16"]
         for dtype in dtypes:
             with base.dygraph.guard():
-                data = np.random.random([1, 9, 9, 4]).astype(dtype)
+                if dtype == "bfloat16":
+                    data = convert_float_to_uint16(
+                        np.random.random([1, 9, 9, 4]).astype("float32")
+                    )
+                else:
+                    data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = base.dygraph.to_variable(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
-                np.testing.assert_allclose(tril_out, np.tril(data))
-                np.testing.assert_allclose(triu_out, np.triu(data))
+                np.testing.assert_allclose(
+                    convert_uint16_to_float(tril_out),
+                    np.tril(convert_uint16_to_float(data)),
+                )
+                np.testing.assert_allclose(
+                    convert_uint16_to_float(triu_out),
+                    np.triu(convert_uint16_to_float(data)),
+                )
 
     def test_base_api(self):
         paddle.enable_static()
 
-        dtypes = ["float16", "float32"]
+        dtypes = ["float16", "float32", "bfloat16"]
         for dtype in dtypes:
             prog = Program()
             startup_prog = Program()
             with program_guard(prog, startup_prog):
-                data = np.random.random([1, 9, 9, 4]).astype(dtype)
+                if dtype == "bfloat16":
+                    data = convert_float_to_uint16(
+                        np.random.random([1, 9, 9, 4]).astype("float32")
+                    )
+                else:
+                    data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = paddle.static.data(shape=[1, 9, -1, 4], dtype=dtype, name="x")
                 triu_out = paddle.triu(x)
 

--- a/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
+++ b/backends/npu/tests/unittests/test_unsqueeze_op_npu.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 
 paddle.enable_static()
@@ -29,7 +29,8 @@ class TestUnsqueeze2Op(OpTest):
         self.op_type = "unsqueeze2"
         self.place = paddle.CustomPlace("npu", 0)
         self.init_test_case()
-        self.x = np.random.random(self.ori_shape).astype("float32")
+        self.init_dtype()
+        self.x = np.random.random(self.ori_shape).astype(self.dtype)
         self.inputs = {"X": OpTest.np_dtype_to_base_dtype(self.x)}
         self.init_attrs()
         self.outputs = {
@@ -43,9 +44,11 @@ class TestUnsqueeze2Op(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, no_check_set=["XShape"])
 
-    @unittest.skip("skip check_grad because unstable.")
     def test_check_grad(self):
         self.check_grad_with_place(self.place, ["X"], "Out")
+
+    def init_dtype(self):
+        self.dtype = "float32"
 
     def init_test_case(self):
         self.ori_shape = (3, 40)
@@ -78,6 +81,31 @@ class TestUnsqueeze2Op3(TestUnsqueeze2Op):
         self.ori_shape = (6, 5, 1, 4)
         self.axes = (1, -1)
         self.new_shape = (6, 1, 5, 1, 4, 1)
+
+
+class TestUnsqueeze2BF16(TestUnsqueeze2Op):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "unsqueeze2"
+        self.place = paddle.CustomPlace("npu", 0)
+        self.init_test_case()
+        self.init_dtype()
+        self.x = np.random.random(self.ori_shape).astype(self.dtype)
+        self.inputs = {
+            "X": convert_float_to_uint16(OpTest.np_dtype_to_base_dtype(self.x))
+        }
+        self.init_attrs()
+        self.outputs = {
+            "Out": convert_uint16_to_float(
+                convert_float_to_uint16(self.x.reshape(self.new_shape))
+            ),
+            "XShape": np.random.random(self.ori_shape).astype("float32"),
+        }
+
+
+class TestUnsqueeze2FP16(TestUnsqueeze2Op):
+    def init_dtype(self):
+        self.dtype = "float16"
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_where_op_npu.py
+++ b/backends/npu/tests/unittests/test_where_op_npu.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.base as base
 from paddle.base.backward import append_backward
-from tests.op_test import OpTest
+from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 
 paddle.enable_static()
 
@@ -67,6 +67,30 @@ class TestNPUWhereFp16(TestNPUWhereOp):
     def init_config(self):
         self.x = np.random.uniform(-5, 5, (60, 2)).astype("float16")
         self.y = np.random.uniform(-5, 5, (60, 2)).astype("float16")
+        self.cond = np.ones((60, 2)).astype("bool")
+
+
+class TestNPUWhereBF16(TestNPUWhereOp):
+    def setUp(self):
+        self.op_type = "where"
+        self.set_npu()
+        self.init_config()
+        self.inputs = {"Condition": self.cond, "X": self.x, "Y": self.y}
+        self.outputs = {
+            "Out": np.where(
+                self.cond,
+                convert_uint16_to_float(self.x),
+                convert_uint16_to_float(self.y),
+            )
+        }
+
+    def init_config(self):
+        self.x = convert_float_to_uint16(
+            np.random.uniform(-5, 5, (60, 2)).astype("float16")
+        )
+        self.y = convert_float_to_uint16(
+            np.random.uniform(-5, 5, (60, 2)).astype("float16")
+        )
         self.cond = np.ones((60, 2)).astype("bool")
 
 


### PR DESCRIPTION
add  bf16 dtype for paddle-npu api:
rqual, rsqrt, silu, sin, tril, triu, unsqueeze, where