### PR TITLE
[NPU]Fix compare ut

### DIFF
--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -18,6 +18,7 @@ import unittest
 
 import numpy as np
 import paddle
+import paddle.base as base
 from paddle.base import Program, program_guard
 from tests.op_test import OpTest
 
@@ -43,44 +44,33 @@ def create_test_class(op_type, typename, callback):
         def test_errors(self):
             paddle.enable_static()
             with program_guard(Program(), Program()):
+                a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
+                b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
+                c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
+                d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
+
                 op = eval("paddle.%s" % self.op_type)
+                self.assertRaises(TypeError, op, x=a, y=b, axis=True)
+                self.assertRaises(TypeError, op, x=a, y=b, force_cpu=1)
+                self.assertRaises(TypeError, op, x=a, y=b, cond=1)
 
-                dtype_list = [
-                    "float",
-                    "float32",
-                    "float64",
-                    "int8",
-                    "int16",
-                    "int32",
-                    "int64",
-                    "uint8",
-                ]
-
-                n = len(dtype_list)
-
-                for i in range(n):
-                    a = paddle.static.data(
-                        name=f"a_{i}", shape=[-1, 2], dtype=dtype_list[i]
+                try:
+                    result = op(x=a, y=c)
+                except TypeError:
+                    self.fail(
+                        "TypeError should not raised for float32 and int16 inputs"
                     )
-                    b = paddle.static.data(
-                        name=f"b_{i}", shape=[-1, 2], dtype=dtype_list[i]
+
+                try:
+                    result = op(x=c, y=a)
+                except TypeError:
+                    self.fail(
+                        "TypeError should not raised for int16 and float32 inputs"
                     )
-                    try:
-                        result = op(x=a, y=b)
-                    except TypeError:
-                        self.fail(
-                            f"TypeError should not raised for {dtype_list[i]} inputs"
-                        )
-                    for j in range(i + 1, n):
-                        c = paddle.static.data(
-                            name=f"c{i}_{j}", shape=[-1, 2], dtype=dtype_list[j]
-                        )
-                        try:
-                            result = op(x=a, y=c)
-                        except TypeError:
-                            self.fail(
-                                f"TypeError should not raised for {dtype_list[i]} and {dtype_list[j]} inputs"
-                            )
+
+                self.assertRaises(TypeError, op, x=a, y=d)
+                self.assertRaises(TypeError, op, x=d, y=a)
+                self.assertRaises(TypeError, op, x=c, y=d)
 
         def test_dynamic_api(self):
             paddle.disable_static()

--- a/backends/npu/tools/disable_ut_npu
+++ b/backends/npu/tools/disable_ut_npu
@@ -9,6 +9,5 @@ test_zero_dim_tensor_npu
 test_momentum_op_npu
 test_matmul_op_npu
 test_linear_op_npu
-test_compare_op_npu
 test_elementwise_sub_op_npu
 test_index_sample_op_npu


### PR DESCRIPTION
不同dtype的paddle.static.data不会引发paddle.equal(以及其他compare方法)的TypeError。

单测通过：
![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/104260574/1ced41d3-0b42-473e-9316-e8853bfa2771)
