### PR TITLE
0d slice error 

### DIFF
--- a/backends/npu/kernels/funcs/slice_utils.h
+++ b/backends/npu/kernels/funcs/slice_utils.h
@@ -161,12 +161,6 @@ inline phi::DDim GetDecreasedDims(const phi::DDim slice_dims,
       }
     }
 
-    if (FLAGS_set_to_1d && new_shape.size() == 0) {
-      // NOTE(zoooo0820): Hack procssing to 1-D, when axes decrease to 0-D in
-      // slice. This will remove in release 2.6.
-      new_shape.push_back(1);
-    }
-
     decreased_dims = phi::make_ddim(new_shape);
   }
   return decreased_dims;


### PR DESCRIPTION
调用paddle.slice实际应输出为0D时，paddlenpu输出是1d的。
testcase:tensor([5,6,7,8]).slice([1,2,3,4])应输出一个tensor([])，实际输出tensor([1])