### PR TITLE
fix dtype warning and cannversion bug

### DIFF
--- a/backends/npu/cmake/external/ascend.cmake
+++ b/backends/npu/cmake/external/ascend.cmake
@@ -67,7 +67,7 @@ macro(find_ascend_toolkit_version ascend_toolkit_version_info)
                        ASCEND_TOOLKIT_VERSION "${ASCEND_TOOLKIT_VERSION}")
   string(REGEX REPLACE "[A-Z]|[a-z|\.]" "" CANN_VERSION
                        "${ASCEND_TOOLKIT_VERSION}")
-  string(SUBSTRING "${CANN_VERSION}000" 0 6 CANN_VERSION)
+  string(SUBSTRING "${CANN_VERSION}00000" 0 6 CANN_VERSION)
   add_definitions("-DCANN_VERSION_CODE=${CANN_VERSION}")
   if(NOT ASCEND_TOOLKIT_VERSION)
     set(ASCEND_TOOLKIT_VERSION "???")

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -233,6 +233,11 @@ inline aclTensor* ConvertType(const phi::DenseTensor& at_tensor) {
     return nullptr;
   }
   auto at_tensor_dtype = at_tensor.dtype();
+
+  if (at_tensor_dtype == phi::DataType::FLOAT64) {
+    VLOG(2) << "Kernel is running on the AICPU."
+            << "For better performance. use other dtypes.";
+  }
   auto acl_data_type = ConvertToNpuDtype(at_tensor_dtype);
   std::vector<int64_t> storageDims(5);
   if (acl_data_type != ACL_STRING) {
@@ -335,6 +340,7 @@ auto ConvertToOpApiFunc(const Tuple& params, void* opApiAddr) {
 
 #define EXEC_NPU_CMD(aclnn_api, dev_ctx, ...)                             \
   do {                                                                    \
+    VLOG(1) << "NpuAclnnOpRunner: " << #aclnn_api;                        \
     static const auto getWorkspaceSizeFuncAddr =                          \
     GetOpApiFuncAddr(#aclnn_api "GetWorkspaceSize");                      \
     static const auto opApiFuncAddr = GetOpApiFuncAddr(#aclnn_api);       \

--- a/backends/npu/tools/disable_ut_npu_910b
+++ b/backends/npu/tools/disable_ut_npu_910b
@@ -26,3 +26,4 @@ test_softmax_with_cross_entropy_op_npu
 test_squared_l2_norm_op_npu
 test_stack_op_npu
 test_zero_dim_tensor_npu
+test_rmsprop_op_npu


### PR DESCRIPTION
1. dtype warning 提示
2. cann version 生成问题修复
3. rmsprop ut 偶现精度问题 先加入disable中待修复