### PR TITLE
[NPU] support aclnn for multiply_raw multiply_grad

### DIFF
--- a/backends/npu/kernels/elementwise_mul_kernel.cc
+++ b/backends/npu/kernels/elementwise_mul_kernel.cc
@@ -45,11 +45,11 @@ static void ReduceDims(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MultiplyRawKernel(const Context& dev_ctx,
-                       const phi::DenseTensor& x,
-                       const phi::DenseTensor& y,
-                       int axis,
-                       phi::DenseTensor* out) {
+void AclopMultiplyRawKernel(const Context& dev_ctx,
+                            const phi::DenseTensor& x,
+                            const phi::DenseTensor& y,
+                            int axis,
+                            phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -75,6 +75,36 @@ void MultiplyRawKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
+void MultiplyRawKernel(const Context& dev_ctx,
+                       const phi::DenseTensor& x,
+                       const phi::DenseTensor& y,
+                       int axis,
+                       phi::DenseTensor* out) {
+  DO_COMPATIBILITY(aclnnMul,
+                   (custom_kernel::AclopMultiplyRawKernel<T, Context>(
+                       dev_ctx, x, y, axis, out)));
+  dev_ctx.template Alloc<T>(out);
+
+  bool direct_compute = false;
+  auto x_dims = x.dims();
+  auto y_dims = y.dims();
+  axis = (axis == -1 ? std::abs(x_dims.size() - y_dims.size()) : axis);
+  if (x_dims.size() >= y_dims.size()) {
+    direct_compute = x_dims.size() == (y_dims.size() + axis);
+  } else {
+    direct_compute = y_dims.size() == (x_dims.size() + axis);
+  }
+
+  if (direct_compute) {
+    EXEC_NPU_CMD(aclnnMul, dev_ctx, x, y, *out);
+  } else {
+    phi::DenseTensor trans_x, trans_y;
+    NpuElementWiseOpBroadcast<T>(dev_ctx, &x, &y, axis, &trans_x, &trans_y);
+    EXEC_NPU_CMD(aclnnMul, dev_ctx, trans_x, trans_y, *out);
+  }
+}
+
+template <typename T, typename Context>
 void AclopMultiplyKernel(const Context& dev_ctx,
                          const phi::DenseTensor& x,
                          const phi::DenseTensor& y,
@@ -96,13 +126,13 @@ void MultiplyKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MultiplyGradKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& x,
-                        const phi::DenseTensor& y,
-                        const phi::DenseTensor& dout,
-                        int axis,
-                        phi::DenseTensor* dx,
-                        phi::DenseTensor* dy) {
+void AclopMultiplyGradKernel(const Context& dev_ctx,
+                             const phi::DenseTensor& x,
+                             const phi::DenseTensor& y,
+                             const phi::DenseTensor& dout,
+                             int axis,
+                             phi::DenseTensor* dx,
+                             phi::DenseTensor* dy) {
   auto stream = dev_ctx.stream();
 
   axis = (axis == -1 ? std::abs(x.dims().size() - y.dims().size()) : axis);
@@ -148,6 +178,63 @@ void MultiplyGradKernel(const Context& dev_ctx,
       const auto& runner_dy =
           NpuOpRunner("Mul", {trans_x, dout}, {dy_temp}, {});
       runner_dy.Run(stream);
+      ReduceDims<T>(
+          dev_ctx, stream, axis, dy->dims(), trans_x.dims(), dy_temp, dy);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void MultiplyGradKernel(const Context& dev_ctx,
+                        const phi::DenseTensor& x,
+                        const phi::DenseTensor& y,
+                        const phi::DenseTensor& dout,
+                        int axis,
+                        phi::DenseTensor* dx,
+                        phi::DenseTensor* dy) {
+  DO_COMPATIBILITY(aclnnMul,
+                   (custom_kernel::AclopMultiplyGradKernel<T, Context>(
+                       dev_ctx, x, y, dout, axis, dx, dy)));
+
+  auto stream = dev_ctx.stream();
+
+  axis = (axis == -1 ? std::abs(x.dims().size() - y.dims().size()) : axis);
+
+  int x_axis;
+  int y_axis;
+  phi::DDim dst_dims;
+  NpuElementWiseHelper(&x, &y, axis, &x_axis, &y_axis, &dst_dims);
+
+  if (dx) {
+    phi::DenseTensor trans_y;
+    NpuBroadcast<T>(dev_ctx, &y, y_axis, dst_dims, &trans_y);
+    if (dx->dims() == dout.dims()) {
+      dev_ctx.template Alloc<T>(dx);
+      EXEC_NPU_CMD(aclnnMul, dev_ctx, dout, trans_y, *dx);
+    } else {
+      phi::DenseTensor dx_temp;
+      phi::DenseTensorMeta dx_temp_meta = {x.dtype(), trans_y.dims()};
+      dx_temp.set_meta(dx_temp_meta);
+      dev_ctx.template Alloc<T>(&dx_temp);
+
+      EXEC_NPU_CMD(aclnnMul, dev_ctx, dout, trans_y, dx_temp);
+      ReduceDims<T>(
+          dev_ctx, stream, axis, dx->dims(), trans_y.dims(), dx_temp, dx);
+    }
+  }
+  if (dy) {
+    phi::DenseTensor trans_x;
+    NpuBroadcast<T>(dev_ctx, &x, x_axis, dst_dims, &trans_x);
+    if (dy->dims() == dout.dims()) {
+      dev_ctx.template Alloc<T>(dy);
+      EXEC_NPU_CMD(aclnnMul, dev_ctx, trans_x, dout, *dy);
+    } else {
+      phi::DenseTensor dy_temp;
+      phi::DenseTensorMeta dy_temp_meta = {y.dtype(), trans_x.dims()};
+      dy_temp.set_meta(dy_temp_meta);
+      dev_ctx.template Alloc<T>(&dy_temp);
+
+      EXEC_NPU_CMD(aclnnMul, dev_ctx, trans_x, dout, dy_temp);
       ReduceDims<T>(
           dev_ctx, stream, axis, dy->dims(), trans_x.dims(), dy_temp, dy);
     }

--- a/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mul_op_npu.py
@@ -162,8 +162,6 @@ class TestElementwiseMulOp_broadcast_5(ElementwiseMulOp):
         self.outputs = {"Out": self.inputs["X"] * self.inputs["Y"]}
 
 
-# TODO
-@unittest.skipIf(True, "Not support")
 class TestElementwiseMulOpFp16(ElementwiseMulOp):
     def init_dtype(self):
         self.dtype = np.float16

--- a/backends/npu/tests/unittests/test_elementwise_mul_op_npu_eager.py
+++ b/backends/npu/tests/unittests/test_elementwise_mul_op_npu_eager.py
@@ -38,6 +38,7 @@ class ElementwiseMulOpBF16(OpTest):
         self.dtype = np.float32
         self.axis = -1
         self.init_input_output()
+        self.init_axis()
 
         self.inputs = {
             "X": OpTest.np_dtype_to_base_dtype(self.x),
@@ -72,6 +73,102 @@ class ElementwiseMulOpBF16(OpTest):
         self.out = np.multiply(
             convert_uint16_to_float(self.x), convert_uint16_to_float(self.y)
         )
+
+    def init_axis(self):
+        pass
+
+
+class TestElementwiseMulOp_BF16_broadcast_0(ElementwiseMulOpBF16):
+    def init_input_output(self):
+        self.x = convert_float_to_uint16(np.random.rand(100, 2, 3).astype(self.dtype))
+        self.y = convert_float_to_uint16(np.random.rand(100).astype(self.dtype))
+        self.out = convert_uint16_to_float(self.x) * convert_uint16_to_float(
+            self.y
+        ).reshape(100, 1, 1)
+
+    def init_axis(self):
+        self.axis = 0
+
+
+class TestElementwiseMulOp_BF16_broadcast_1(ElementwiseMulOpBF16):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "elementwise_mul"
+        self.inputs = {
+            "X": convert_float_to_uint16(np.random.rand(2, 100, 3).astype(np.float32)),
+            "Y": convert_float_to_uint16(np.random.rand(100).astype(np.float32)),
+        }
+
+        self.attrs = {"axis": 1}
+        self.outputs = {
+            "Out": convert_uint16_to_float(self.inputs["X"])
+            * convert_uint16_to_float(self.inputs["Y"]).reshape(1, 100, 1)
+        }
+
+
+class TestElementwiseMulOp_BF16_broadcast_2(ElementwiseMulOpBF16):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "elementwise_mul"
+        self.inputs = {
+            "X": convert_float_to_uint16(np.random.rand(2, 3, 100).astype(np.float32)),
+            "Y": convert_float_to_uint16(np.random.rand(100).astype(np.float32)),
+        }
+
+        self.outputs = {
+            "Out": convert_uint16_to_float(self.inputs["X"])
+            * convert_uint16_to_float(self.inputs["Y"]).reshape(1, 1, 100)
+        }
+
+
+class TestElementwiseMulOp_BF16_broadcast_3(ElementwiseMulOpBF16):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "elementwise_mul"
+        self.inputs = {
+            "X": convert_float_to_uint16(
+                np.random.rand(2, 10, 12, 3).astype(np.float32)
+            ),
+            "Y": convert_float_to_uint16(np.random.rand(10, 12).astype(np.float32)),
+        }
+
+        self.attrs = {"axis": 1}
+        self.outputs = {
+            "Out": convert_uint16_to_float(self.inputs["X"])
+            * convert_uint16_to_float(self.inputs["Y"]).reshape(1, 10, 12, 1)
+        }
+
+
+class TestElementwiseMulOp_BF16_broadcast_4(ElementwiseMulOpBF16):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "elementwise_mul"
+        self.inputs = {
+            "X": convert_float_to_uint16(np.random.rand(10, 2, 11).astype(np.float32)),
+            "Y": convert_float_to_uint16(np.random.rand(10, 1, 11).astype(np.float32)),
+        }
+        self.outputs = {
+            "Out": convert_uint16_to_float(self.inputs["X"])
+            * convert_uint16_to_float(self.inputs["Y"])
+        }
+
+
+class TestElementwiseMulOp_BF16_broadcast_5(ElementwiseMulOpBF16):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "elementwise_mul"
+        self.inputs = {
+            "X": convert_float_to_uint16(
+                np.random.rand(10, 4, 2, 3).astype(np.float32)
+            ),
+            "Y": convert_float_to_uint16(
+                np.random.rand(10, 4, 1, 3).astype(np.float32)
+            ),
+        }
+        self.outputs = {
+            "Out": convert_uint16_to_float(self.inputs["X"])
+            * convert_uint16_to_float(self.inputs["Y"])
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[NPU] support aclnn for multiply_raw multiply_grad
ut用例test_elementwise_mul_op_npu.py
补充bf16用例test_elementwise_mul_op_npu_eager.py