### PR TITLE
[NPU]fix BroadCastTo input error in set_value kernel

### DIFF
--- a/backends/npu/kernels/set_value_kernel.cc
+++ b/backends/npu/kernels/set_value_kernel.cc
@@ -131,7 +131,8 @@ void SetTensorValueNPUImplKernel(const Context& dev_ctx,
     }
   }
   phi::DenseTensor value_temp;
-  if (slice_dims_for_assign == value.dims()) {
+  if (slice_dims_for_assign == value.dims() ||
+      slice_dims_for_assign.size() == 0) {
     value_temp = value;
   } else {
     value_temp.Resize(slice_dims_for_assign);


### PR DESCRIPTION
当slice_dims_for_assign为空时，不需要做broadcast，且slice_dims_for_assign作为broadcast的输入为空，会导致set_value ACL ERROR 10000的问题，本PR修复此问题，且test_zero_dim_tensor_npu中test_setitem的单测可测试通过