### PR TITLE
[MLU] fix assign blocking D2D, which may cause weight invalid in some…

### DIFF
--- a/backends/mlu/kernels/assign_kernel.cc
+++ b/backends/mlu/kernels/assign_kernel.cc
@@ -21,7 +21,7 @@ void AssignKernel(const Context& dev_ctx,
                   const phi::DenseTensor& x,
                   phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
-  TensorCopy(dev_ctx, x, true, out);
+  TensorCopy(dev_ctx, x, false, out);
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
Now we use blocking assign, so that copy is processed asynchronizely on the default stream. It may cause weight invalid in `conv2d` cases shown below. Non-blocking here invokes the copy process on the computing stream so that weight is valid while doing `conv2d` computation. 
<img width="1434" alt="image" src="https://github.com/PaddlePaddle/PaddleCustomDevice/assets/21559339/304b0998-3523-49e8-91a9-53cec42a9f3d">

After this change, the timechart looks like below
<img width="1205" alt="image" src="https://github.com/PaddlePaddle/PaddleCustomDevice/assets/21559339/67dea028-be29-47a6-89f4-1e20645f5ded">

