### PR TITLE
[Cleanup] Replace to_variable with to_tensor

### DIFF
--- a/backends/custom_cpu/tests/unittests/test_matmul_op.py
+++ b/backends/custom_cpu/tests/unittests/test_matmul_op.py
@@ -107,8 +107,8 @@ class API_TestMm(unittest.TestCase):
         with base.dygraph.guard(device):
             input_array1 = np.random.rand(3, 4).astype("float64")
             input_array2 = np.random.rand(4, 3).astype("float64")
-            data1 = base.dygraph.to_variable(input_array1)
-            data2 = base.dygraph.to_variable(input_array2)
+            data1 = paddle.to_tensor(input_array1)
+            data2 = paddle.to_tensor(input_array2)
             out = paddle.mm(data1, data2)
             expected_result = np.matmul(input_array1, input_array2)
         self.assertTrue(np.allclose(expected_result, out.numpy()))
@@ -129,8 +129,8 @@ class Test_API_Matmul2DX2D(unittest.TestCase):
         with base.dygraph.guard(device):
             input_array1 = np.random.random(self.shape_x).astype(self.dtype)
             input_array2 = np.random.random(self.shape_y).astype(self.dtype)
-            data1 = base.dygraph.to_variable(input_array1)
-            data2 = base.dygraph.to_variable(input_array2)
+            data1 = paddle.to_tensor(input_array1)
+            data2 = paddle.to_tensor(input_array2)
             out = paddle.matmul(
                 data1, data2, transpose_x=self.trans_x, transpose_y=self.trans_y
             )

--- a/backends/custom_cpu/tests/unittests/test_reduce_op.py
+++ b/backends/custom_cpu/tests/unittests/test_reduce_op.py
@@ -816,7 +816,7 @@ class API_TestSumOp(unittest.TestCase):
     def test_dygraph(self):
         np_x = np.random.random([2, 3, 4]).astype("int32")
         with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
-            x = base.dygraph.to_variable(np_x)
+            x = paddle.to_tensor(np_x)
             out0 = paddle.sum(x).numpy()
             out1 = paddle.sum(x, axis=0).numpy()
             out2 = paddle.sum(x, axis=(0, 1)).numpy()

--- a/backends/custom_cpu/tests/unittests/test_slice_op.py
+++ b/backends/custom_cpu/tests/unittests/test_slice_op.py
@@ -622,7 +622,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
     def test_getitem_with_long(self):
         with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             data = np.random.random((2, 80, 16128)).astype("float32")
-            var = base.dygraph.to_variable(data)
+            var = paddle.to_tensor(data)
             sliced = var[:, 10:, : var.shape[1]]  # var.shape[1] is 80L here
             self.assertEqual(sliced.shape, [2, 70, 80])
 
@@ -633,7 +633,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_slice_item():
             with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[:, 1.1:, : var.shape[1]]
 
         self.assertRaises(Exception, test_float_in_slice_item)
@@ -641,7 +641,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_index():
             with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[1.1]
 
         self.assertRaises(Exception, test_float_in_index)

--- a/backends/custom_cpu/tests/unittests/test_transpose_op.py
+++ b/backends/custom_cpu/tests/unittests/test_transpose_op.py
@@ -325,7 +325,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([10]).astype("float64")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -333,7 +333,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([10, 5]).astype("float64")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -341,7 +341,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("custom_cpu", 0)):
             np_x = np.random.random([1, 5]).astype("float64")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))

--- a/backends/gcu/tests/unittests/test_activation_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_activation_op_gcu.py
@@ -110,7 +110,7 @@ class TestAtan(TestActivation):
     def test_dygraph(self):
         with base.dygraph.guard(self.place):
             np_x = np.array([0.1])
-            x = base.dygraph.to_variable(np_x)
+            x = paddle.to_tensor(np_x)
             z = paddle.atan(x).numpy().astype(np.float32)
             z_expected = np.arctan(np_x).astype(np.float32)
             self.assertEqual(z, z_expected)

--- a/backends/gcu/tests/unittests/test_elementwise_add_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_elementwise_add_op_gcu.py
@@ -314,8 +314,8 @@ class TestAddApi(unittest.TestCase):
         with base.dygraph.guard():
             np_x = np.array([2, 3, 4]).astype("float32")
             np_y = np.array([1, 5, 2]).astype("float32")
-            x = base.dygraph.to_variable(np_x)
-            y = base.dygraph.to_variable(np_y)
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/backends/gcu/tests/unittests/test_elementwise_sub_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_elementwise_sub_op_gcu.py
@@ -423,8 +423,8 @@ class TestSubtractApi(unittest.TestCase):
         with base.dygraph.guard():
             np_x = np.array([2, 3, 4]).astype("float64")
             np_y = np.array([1, 5, 2]).astype("float64")
-            x = base.dygraph.to_variable(np_x)
-            y = base.dygraph.to_variable(np_y)
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy(False)
             z_expected = np.array([1.0, -2.0, 2.0])

--- a/backends/gcu/tests/unittests/test_gather_nd_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_gather_nd_op_gcu.py
@@ -16,7 +16,6 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -149,8 +148,8 @@ class TestGatherNdAPI2(unittest.TestCase):
         paddle.set_device("gcu")
         input_1 = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
         index_1 = np.array([[1]]).astype("int32")
-        input = base.dygraph.to_variable(input_1)
-        index = base.dygraph.to_variable(index_1)
+        input = paddle.to_tensor(input_1)
+        index = paddle.to_tensor(index_1)
         output = paddle.gather(input, index)
         output_np = output.numpy()
         expected_output = np.array([3, 4])

--- a/backends/gcu/tests/unittests/test_instance_norm_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_instance_norm_op_gcu.py
@@ -20,7 +20,6 @@ from tests.op_test import OpTest
 import paddle
 from paddle import base
 from paddle.base import Program, core, program_guard
-from paddle.base.dygraph import to_variable
 
 
 def _reference_instance_norm_naive(x, scale, bias, epsilon, mean, var):
@@ -346,7 +345,7 @@ class TestElasticNormOp(unittest.TestCase):
                 instance_norm = paddle.nn.InstanceNorm2D(
                     5, weight_attr=False, bias_attr=False
                 )
-                outputs = instance_norm(to_variable(inputs))
+                outputs = instance_norm(paddle.to_tensor(inputs))
                 np.testing.assert_allclose(
                     outputs.numpy(), out_np, rtol=1e-05, atol=1e-06
                 )
@@ -376,7 +375,7 @@ class TestElasticNormOpCase2(unittest.TestCase):
                 instance_norm = paddle.nn.InstanceNorm2D(
                     3, weight_attr=True, bias_attr=True
                 )
-                outputs = instance_norm(to_variable(inputs))
+                outputs = instance_norm(paddle.to_tensor(inputs))
                 np.testing.assert_allclose(
                     outputs.numpy(), out_np, rtol=1e-05, atol=1e-06
                 )

--- a/backends/gcu/tests/unittests/test_merged_adam_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_merged_adam_op_gcu.py
@@ -47,14 +47,14 @@ def run_adam_op(
     paddle.disable_static()
     paddle.set_device(place)
 
-    param_vars = [paddle.base.dygraph.to_variable(p) for p in params]
-    grad_vars = [paddle.base.dygraph.to_variable(g) for g in grads]
-    lr_vars = [paddle.base.dygraph.to_variable(l) for l in lrs]
-    moment1_vars = [paddle.base.dygraph.to_variable(m) for m in moment1s]
-    moment2_vars = [paddle.base.dygraph.to_variable(m) for m in moment2s]
-    beta1_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta1_pows]
-    beta2_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta2_pows]
-    master_param_vars = [paddle.base.dygraph.to_variable(m_p) for m_p in master_params]
+    param_vars = [paddle.to_tensor(p) for p in params]
+    grad_vars = [paddle.to_tensor(g) for g in grads]
+    lr_vars = [paddle.to_tensor(l) for l in lrs]
+    moment1_vars = [paddle.to_tensor(m) for m in moment1s]
+    moment2_vars = [paddle.to_tensor(m) for m in moment2s]
+    beta1_pow_vars = [paddle.to_tensor(b) for b in beta1_pows]
+    beta2_pow_vars = [paddle.to_tensor(b) for b in beta2_pows]
+    master_param_vars = [paddle.to_tensor(m_p) for m_p in master_params]
 
     if not use_merged:
         for i in range(len(param_vars)):

--- a/backends/gcu/tests/unittests/test_meshgrid_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_meshgrid_op_gcu.py
@@ -302,15 +302,15 @@ class TestMeshgridEager(unittest.TestCase):
         ).astype("int32")
 
         with base.dygraph.guard():
-            tensor_1 = base.dygraph.to_variable(input_1)
-            tensor_2 = base.dygraph.to_variable(input_2)
+            tensor_1 = paddle.to_tensor(input_1)
+            tensor_2 = paddle.to_tensor(input_2)
             tensor_1.stop_gradient = False
             tensor_2.stop_gradient = False
             res_1, res_2 = paddle.tensor.meshgrid((tensor_1, tensor_2))
             sum = paddle.add_n([res_1, res_2])
             sum.backward()
-            tensor_eager_1 = base.dygraph.to_variable(input_1)
-            tensor_eager_2 = base.dygraph.to_variable(input_2)
+            tensor_eager_1 = paddle.to_tensor(input_1)
+            tensor_eager_2 = paddle.to_tensor(input_2)
             tensor_eager_1.stop_gradient = False
             tensor_eager_2.stop_gradient = False
             res_eager_1, res_eager_2 = paddle.tensor.meshgrid(

--- a/backends/gcu/tests/unittests/test_one_hot_v2_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_one_hot_v2_op_gcu.py
@@ -204,9 +204,7 @@ class TestOneHotOpApi(unittest.TestCase):
             [6, 1]
         )
         with base.dygraph.guard(paddle.CustomPlace("gcu", 0)):
-            one_hot_label = paddle.nn.functional.one_hot(
-                base.dygraph.to_variable(label), depth
-            )
+            one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
             one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
 
     def _run(self, depth):

--- a/backends/gcu/tests/unittests/test_slice_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_slice_op_gcu.py
@@ -137,7 +137,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         paddle.set_device("gcu")
         with base.dygraph.guard():
             data = np.random.random((2, 80, 16128)).astype("float32")
-            var = base.dygraph.to_variable(data)
+            var = paddle.to_tensor(data)
             sliced = var[:, 10:, : var.shape[1]]  # var.shape[1] is 80L here
             self.assertEqual(sliced.shape, [2, 70, 80])
 
@@ -149,7 +149,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
             paddle.set_device("gcu")
             with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[:, 1.1:, : var.shape[1]]
 
         self.assertRaises(Exception, test_float_in_slice_item)
@@ -158,7 +158,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
             paddle.set_device("gcu")
             with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[1.1]
 
         self.assertRaises(Exception, test_float_in_index)

--- a/backends/gcu/tests/unittests/test_stack_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_stack_op_gcu.py
@@ -150,16 +150,16 @@ class API_DygraphTest(unittest.TestCase):
         data2 = np.array([[3.0, 4.0]])
         data3 = np.array([[5.0, 6.0]])
         with base.dygraph.guard(place=paddle.CustomPlace("gcu", 0)):
-            x1 = base.dygraph.to_variable(data1)
-            x2 = base.dygraph.to_variable(data2)
-            x3 = base.dygraph.to_variable(data3)
+            x1 = paddle.to_tensor(data1)
+            x2 = paddle.to_tensor(data2)
+            x3 = paddle.to_tensor(data3)
             result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
         expected_result = np.stack([data1, data2, data3])
         self.assertTrue(np.allclose(expected_result, result_np))
 
         with base.dygraph.guard(place=paddle.CustomPlace("gcu", 0)):
-            y1 = base.dygraph.to_variable(data1)
+            y1 = paddle.to_tensor(data1)
             result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
         expected_result_2 = np.stack([data1], axis=0)

--- a/backends/gcu/tests/unittests/test_tril_triu_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_tril_triu_op_gcu.py
@@ -182,7 +182,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
         for dtype in dtypes:
             with base.dygraph.guard():
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
-                x = base.dygraph.to_variable(data)
+                x = paddle.to_tensor(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
                 np.testing.assert_allclose(tril_out, np.tril(data))
                 np.testing.assert_allclose(triu_out, np.triu(data))

--- a/backends/gcu/tests/unittests/test_where_op_gcu.py
+++ b/backends/gcu/tests/unittests/test_where_op_gcu.py
@@ -205,9 +205,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype("float32")
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype("float32")
             cond_i = np.array([False, False, True, True]).astype("bool")
-            x = base.dygraph.to_variable(x_i)
-            y = base.dygraph.to_variable(y_i)
-            cond = base.dygraph.to_variable(cond_i)
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             assert np.array_equal(out.numpy(), np.where(cond_i, x_i, y_i))
 

--- a/backends/intel_gpu/tests/unittests/test_reduce_op.py
+++ b/backends/intel_gpu/tests/unittests/test_reduce_op.py
@@ -423,7 +423,7 @@ class API_TestSumOp(unittest.TestCase):
     def test_dygraph(self):
         np_x = np.random.random([2, 3, 4]).astype("float32")
         with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
-            x = base.dygraph.to_variable(np_x)
+            x = paddle.to_tensor(np_x)
             out0 = paddle.sum(x).numpy()
             out1 = paddle.sum(x, axis=0).numpy()
             out2 = paddle.sum(x, axis=(0, 1)).numpy()

--- a/backends/intel_gpu/tests/unittests/test_slice_op.py
+++ b/backends/intel_gpu/tests/unittests/test_slice_op.py
@@ -625,7 +625,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
     def test_getitem_with_long(self):
         with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             data = np.random.random((2, 80, 16128)).astype("float32")
-            var = base.dygraph.to_variable(data)
+            var = paddle.to_tensor(data)
             sliced = var[:, 10:, : var.shape[1]]  # var.shape[1] is 80L here
             self.assertEqual(sliced.shape, [2, 70, 80])
 
@@ -636,7 +636,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_slice_item():
             with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[:, 1.1:, : var.shape[1]]
 
         self.assertRaises(Exception, test_float_in_slice_item)
@@ -644,7 +644,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_index():
             with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[1.1]
 
         self.assertRaises(Exception, test_float_in_index)

--- a/backends/intel_gpu/tests/unittests/test_transpose_op.py
+++ b/backends/intel_gpu/tests/unittests/test_transpose_op.py
@@ -290,7 +290,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([10]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -298,7 +298,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([10, 5]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -306,7 +306,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard(paddle.CustomPlace("intel_gpu", 0)):
             np_x = np.random.random([1, 5]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))

--- a/backends/mlu/tests/unittests/parallel_dygraph_sync_batch_norm.py
+++ b/backends/mlu/tests/unittests/parallel_dygraph_sync_batch_norm.py
@@ -17,7 +17,6 @@ from test_dist_base import TestParallelDyGraphRunnerBase, runtime_main
 
 import paddle
 from paddle import base
-from paddle.base.dygraph.base import to_variable
 from paddle.nn import Conv2D, SyncBatchNorm
 
 
@@ -82,7 +81,7 @@ class TestSyncBatchNorm(TestParallelDyGraphRunnerBase):
     def run_one_loop(self, model, opt, data):
         batch_size = len(data)
         dy_x_data = np.array([x[0].reshape(1, 28, 28) for x in data]).astype("float32")
-        img = to_variable(dy_x_data)
+        img = paddle.to_tensor(dy_x_data)
         img.stop_gradient = False
 
         out = model(img)

--- a/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
@@ -729,7 +729,7 @@ class TestDygraphBatchNormTrainableStats(unittest.TestCase):
                         is_test=is_test,
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(base.dygraph.to_variable(x))
+                    y = bn(paddle.to_tensor(x))
                 return y.numpy()
 
             x = np.random.randn(*shape).astype("float32")

--- a/backends/mlu/tests/unittests/test_batch_norm_op_mlu_v2.py
+++ b/backends/mlu/tests/unittests/test_batch_norm_op_mlu_v2.py
@@ -39,32 +39,32 @@ class TestBatchNorm(unittest.TestCase):
             def error1d_dataformat():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm1d = paddle.nn.BatchNorm1D(1, data_format="NCDHW")
-                batch_norm1d(base.dygraph.to_variable(x_data_4))
+                batch_norm1d(paddle.to_tensor(x_data_4))
 
             def error2d_dataformat():
                 x_data_3 = np.random.random(size=(2, 1, 3)).astype("float32")
                 batch_norm2d = paddle.nn.BatchNorm2D(1, data_format="NCDHW")
-                batch_norm2d(base.dygraph.to_variable(x_data_3))
+                batch_norm2d(paddle.to_tensor(x_data_3))
 
             def error3d_dataformat():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm3d = paddle.nn.BatchNorm3D(1, data_format="NCL")
-                batch_norm3d(base.dygraph.to_variable(x_data_4))
+                batch_norm3d(paddle.to_tensor(x_data_4))
 
             def error1d():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm1d = paddle.nn.BatchNorm1D(1)
-                batch_norm1d(base.dygraph.to_variable(x_data_4))
+                batch_norm1d(paddle.to_tensor(x_data_4))
 
             def error2d():
                 x_data_3 = np.random.random(size=(2, 1, 3)).astype("float32")
                 batch_norm2d = paddle.nn.BatchNorm2D(1)
-                batch_norm2d(base.dygraph.to_variable(x_data_3))
+                batch_norm2d(paddle.to_tensor(x_data_3))
 
             def error3d():
                 x_data_4 = np.random.random(size=(2, 1, 3, 3)).astype("float32")
                 batch_norm3d = paddle.nn.BatchNorm3D(1)
-                batch_norm3d(base.dygraph.to_variable(x_data_4))
+                batch_norm3d(paddle.to_tensor(x_data_4))
 
             with base.dygraph.guard(p):
                 self.assertRaises(ValueError, error1d)
@@ -86,13 +86,13 @@ class TestBatchNorm(unittest.TestCase):
                         is_test=is_test,
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(base.dygraph.to_variable(x))
+                    y = bn(paddle.to_tensor(x))
                 return y.numpy()
 
             def compute_v2(x):
                 with base.dygraph.guard(p):
                     bn = paddle.nn.BatchNorm2D(shape[1])
-                    y = bn(base.dygraph.to_variable(x))
+                    y = bn(paddle.to_tensor(x))
                 return y.numpy()
 
             def compute_v3(x, is_test, trainable_statistics):
@@ -110,7 +110,7 @@ class TestBatchNorm(unittest.TestCase):
                         ),
                         trainable_statistics=trainable_statistics,
                     )
-                    y = bn(base.dygraph.to_variable(x))
+                    y = bn(paddle.to_tensor(x))
                 return y.numpy()
 
             def compute_v4(x):
@@ -118,7 +118,7 @@ class TestBatchNorm(unittest.TestCase):
                     bn = paddle.nn.BatchNorm2D(
                         shape[1], weight_attr=False, bias_attr=False
                     )
-                    y = bn(base.dygraph.to_variable(x))
+                    y = bn(paddle.to_tensor(x))
                 return y.numpy()
 
             x = np.random.randn(*shape).astype("float32")

--- a/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
@@ -432,8 +432,8 @@ class TestAddApi(unittest.TestCase):
         with base.dygraph.guard():
             np_x = np.array([2, 3, 4]).astype("float32")
             np_y = np.array([1, 5, 2]).astype("float32")
-            x = base.dygraph.to_variable(np_x)
-            y = base.dygraph.to_variable(np_y)
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/backends/mlu/tests/unittests/test_flip_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_flip_op_mlu.py
@@ -53,7 +53,7 @@ class TestFlipOp_API(unittest.TestCase):
         paddle.disable_static(paddle.CustomPlace("mlu", 0))
         img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
         with base.dygraph.guard():
-            inputs = base.dygraph.to_variable(img)
+            inputs = paddle.to_tensor(img)
             ret = paddle.flip(inputs, [0])
             ret = ret.flip(0)
             ret = paddle.flip(ret, 1)

--- a/backends/mlu/tests/unittests/test_gather_nd_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_gather_nd_op_mlu.py
@@ -17,7 +17,6 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -262,8 +261,8 @@ class TestGatherNdAPI2(unittest.TestCase):
         paddle.set_device("mlu")
         input_1 = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
         index_1 = np.array([[1]]).astype("int32")
-        input = base.dygraph.to_variable(input_1)
-        index = base.dygraph.to_variable(index_1)
+        input = paddle.to_tensor(input_1)
+        index = paddle.to_tensor(index_1)
         output = paddle.gather(input, index)
         output_np = output.numpy()
         expected_output = np.array([3, 4])

--- a/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
@@ -44,14 +44,14 @@ def run_adam_op(
     paddle.disable_static()
     paddle.set_device("mlu")
 
-    param_vars = [paddle.base.dygraph.to_variable(p) for p in params]
-    grad_vars = [paddle.base.dygraph.to_variable(g) for g in grads]
-    lr_vars = [paddle.base.dygraph.to_variable(l) for l in lrs]
-    moment1_vars = [paddle.base.dygraph.to_variable(m) for m in moment1s]
-    moment2_vars = [paddle.base.dygraph.to_variable(m) for m in moment2s]
-    beta1_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta1_pows]
-    beta2_pow_vars = [paddle.base.dygraph.to_variable(b) for b in beta2_pows]
-    master_param_vars = [paddle.base.dygraph.to_variable(m_p) for m_p in master_params]
+    param_vars = [paddle.to_tensor(p) for p in params]
+    grad_vars = [paddle.to_tensor(g) for g in grads]
+    lr_vars = [paddle.to_tensor(l) for l in lrs]
+    moment1_vars = [paddle.to_tensor(m) for m in moment1s]
+    moment2_vars = [paddle.to_tensor(m) for m in moment2s]
+    beta1_pow_vars = [paddle.to_tensor(b) for b in beta1_pows]
+    beta2_pow_vars = [paddle.to_tensor(b) for b in beta2_pows]
+    master_param_vars = [paddle.to_tensor(m_p) for m_p in master_params]
 
     if not use_merged:
         for i in range(len(param_vars)):

--- a/backends/mlu/tests/unittests/test_meshgrid_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_meshgrid_op_mlu.py
@@ -190,8 +190,8 @@ class TestMeshgridOp7(unittest.TestCase):
         ).astype("int32")
 
         with base.dygraph.guard():
-            tensor_3 = base.dygraph.to_variable(input_3)
-            tensor_4 = base.dygraph.to_variable(input_4)
+            tensor_3 = paddle.to_tensor(input_3)
+            tensor_4 = paddle.to_tensor(input_4)
             res_3, res_4 = paddle.tensor.meshgrid([tensor_3, tensor_4])
 
             assert np.array_equal(res_3.shape, [100, 200])
@@ -217,8 +217,8 @@ class TestMeshgridOp8(unittest.TestCase):
 
         paddle.set_device("mlu")
         with base.dygraph.guard():
-            tensor_3 = base.dygraph.to_variable(input_3)
-            tensor_4 = base.dygraph.to_variable(input_4)
+            tensor_3 = paddle.to_tensor(input_3)
+            tensor_4 = paddle.to_tensor(input_4)
             res_3, res_4 = paddle.tensor.meshgrid((tensor_3, tensor_4))
 
             assert np.array_equal(res_3.shape, [100, 200])

--- a/backends/mlu/tests/unittests/test_one_hot_v2_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_one_hot_v2_op_mlu.py
@@ -141,13 +141,9 @@ class TestOneHotOpApi(unittest.TestCase):
             [6, 1]
         )
         with base.dygraph.guard():
-            one_hot_label = paddle.nn.functional.one_hot(
-                base.dygraph.to_variable(label), depth
-            )
+            one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
 
-            one_hot_label = paddle.nn.functional.one_hot(
-                base.dygraph.to_variable(label), depth
-            )
+            one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
             # with _test_eager_guard():
             #     one_hot_label = paddle.nn.functional.one_hot(
             #         paddle.to_tensor(label), depth)

--- a/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
@@ -1249,7 +1249,7 @@ class TestDygraphPool2DAPI(unittest.TestCase):
     def test_nhwc(self):
         with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = base.dygraph.to_variable(data)
+            x = paddle.to_tensor(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,
@@ -1270,7 +1270,7 @@ class TestDygraphPool2DAPI(unittest.TestCase):
     def test_lower_case(self):
         with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = base.dygraph.to_variable(data)
+            x = paddle.to_tensor(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,
@@ -1291,7 +1291,7 @@ class TestDygraphPool2DAPI(unittest.TestCase):
     def test_upper_case(self):
         with base.dygraph.guard():
             data = np.random.random((3, 32, 32, 5)).astype("float32")
-            x = base.dygraph.to_variable(data)
+            x = paddle.to_tensor(data)
             pool2d = paddle.nn.MaxPool2D(
                 kernel_size=2,
                 stride=1,

--- a/backends/mlu/tests/unittests/test_roll_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_roll_op_mlu.py
@@ -168,7 +168,7 @@ class TestRollAPI(unittest.TestCase):
         self.input_data()
         # case 1:
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(self.data_x)
+            x = paddle.to_tensor(self.data_x)
             z = paddle.roll(x, shifts=1)
             np_z = z.numpy()
         expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
@@ -176,7 +176,7 @@ class TestRollAPI(unittest.TestCase):
 
         # case 2:
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(self.data_x)
+            x = paddle.to_tensor(self.data_x)
             z = paddle.roll(x, shifts=1, axis=0)
             np_z = z.numpy()
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])

--- a/backends/mlu/tests/unittests/test_slice_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_slice_op_mlu.py
@@ -551,7 +551,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
     def test_getitem_with_long(self):
         with base.dygraph.guard():
             data = np.random.random((2, 80, 16128)).astype("float32")
-            var = base.dygraph.to_variable(data)
+            var = paddle.to_tensor(data)
             sliced = var[:, 10:, : var.shape[1]]  # var.shape[1] is 80L here
             self.assertEqual(sliced.shape, [2, 70, 80])
 
@@ -562,7 +562,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_slice_item():
             with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[:, 1.1:, : var.shape[1]]
 
         self.assertRaises(Exception, test_float_in_slice_item)
@@ -570,7 +570,7 @@ class TestImperativeVarBaseGetItem(unittest.TestCase):
         def test_float_in_index():
             with base.dygraph.guard():
                 data = np.random.random((2, 80, 16128)).astype("float32")
-                var = base.dygraph.to_variable(data)
+                var = paddle.to_tensor(data)
                 sliced = var[1.1]
 
         self.assertRaises(Exception, test_float_in_index)

--- a/backends/mlu/tests/unittests/test_stack_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_stack_op_mlu.py
@@ -145,16 +145,16 @@ class API_DygraphTest(unittest.TestCase):
         data2 = np.array([[3.0, 4.0]]).astype("float32")
         data3 = np.array([[5.0, 6.0]]).astype("float32")
         with base.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
-            x1 = base.dygraph.to_variable(data1)
-            x2 = base.dygraph.to_variable(data2)
-            x3 = base.dygraph.to_variable(data3)
+            x1 = paddle.to_tensor(data1)
+            x2 = paddle.to_tensor(data2)
+            x3 = paddle.to_tensor(data3)
             result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
         expected_result = np.stack([data1, data2, data3])
         np.testing.assert_allclose(expected_result, result_np)
 
         with base.dygraph.guard(place=paddle.CustomPlace("mlu", 0)):
-            y1 = base.dygraph.to_variable(data1)
+            y1 = paddle.to_tensor(data1)
             result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
         expected_result_2 = np.stack([data1], axis=0)

--- a/backends/mlu/tests/unittests/test_strided_slice_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_strided_slice_op_mlu.py
@@ -632,7 +632,7 @@ class TestStridedSliceTensorArray(unittest.TestCase):
     def test(self):
         with base.dygraph.guard():
             data = np.random.rand(2, 10).astype("float32")
-            var = base.dygraph.to_variable(data)
+            var = paddle.to_tensor(data)
             out = var[:, ::-1]
             assert np.array_equal(out, data[:, ::-1])
 

--- a/backends/mlu/tests/unittests/test_transpose_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_transpose_op_mlu.py
@@ -285,7 +285,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard():
             np_x = np.random.random([10]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -293,7 +293,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard():
             np_x = np.random.random([10, 5]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))
@@ -301,7 +301,7 @@ class TestTAPI(unittest.TestCase):
 
         with base.dygraph.guard():
             np_x = np.random.random([1, 5]).astype("float32")
-            data = base.dygraph.to_variable(np_x)
+            data = paddle.to_tensor(np_x)
             z = paddle.t(data)
             np_z = z.numpy()
             z_expected = np.array(np.transpose(np_x))

--- a/backends/mlu/tests/unittests/test_tril_triu_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_tril_triu_op_mlu.py
@@ -157,7 +157,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
         for dtype in dtypes:
             with base.dygraph.guard():
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
-                x = base.dygraph.to_variable(data)
+                x = paddle.to_tensor(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
                 np.testing.assert_allclose(tril_out, np.tril(data))
                 np.testing.assert_allclose(triu_out, np.triu(data))

--- a/backends/mlu/tests/unittests/test_where_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_where_op_mlu.py
@@ -228,9 +228,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype("float32")
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype("float32")
             cond_i = np.array([False, False, True, True]).astype("bool")
-            x = base.dygraph.to_variable(x_i)
-            y = base.dygraph.to_variable(y_i)
-            cond = base.dygraph.to_variable(cond_i)
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             assert np.array_equal(out.numpy(), np.where(cond_i, x_i, y_i))
 

--- a/backends/npu/tests/unittests/test_activation_op.py
+++ b/backends/npu/tests/unittests/test_activation_op.py
@@ -113,7 +113,7 @@ class TestAtan(TestActivation):
     def test_dygraph(self):
         with base.dygraph.guard(self.place):
             np_x = np.array([0.1])
-            x = base.dygraph.to_variable(np_x)
+            x = paddle.to_tensor(np_x)
             z = paddle.atan(x).numpy()
             z_expected = np.arctan(np_x)
             self.assertEqual(z, z_expected)

--- a/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
@@ -520,8 +520,8 @@ class TestAddApi(unittest.TestCase):
         with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
             np_x = np.array([2, 3, 4]).astype("float32")
             np_y = np.array([1, 5, 2]).astype("float32")
-            x = base.dygraph.to_variable(np_x)
-            y = base.dygraph.to_variable(np_y)
+            x = paddle.to_tensor(np_x)
+            y = paddle.to_tensor(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
             z_expected = np.array([3.0, 8.0, 6.0])

--- a/backends/npu/tests/unittests/test_flip_op_npu.py
+++ b/backends/npu/tests/unittests/test_flip_op_npu.py
@@ -53,7 +53,7 @@ class TestFlipOp_API(unittest.TestCase):
         paddle.disable_static(paddle.CustomPlace("npu", 0))
         img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
         with base.dygraph.guard():
-            inputs = base.dygraph.to_variable(img)
+            inputs = paddle.to_tensor(img)
             ret = paddle.flip(inputs, [0])
             ret = ret.flip(0)
             ret = paddle.flip(ret, 1)

--- a/backends/npu/tests/unittests/test_gather_nd_op_npu.py
+++ b/backends/npu/tests/unittests/test_gather_nd_op_npu.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 
 from tests.op_test import OpTest
-import paddle.base as base
 import paddle
 
 
@@ -259,8 +258,8 @@ class TestGatherNdAPI(unittest.TestCase):
         paddle.disable_static()
         input_1 = np.array([[1, 2], [3, 4], [5, 6]])
         index_1 = np.array([[1]])
-        input = base.dygraph.to_variable(input_1)
-        index = base.dygraph.to_variable(index_1)
+        input = paddle.to_tensor(input_1)
+        index = paddle.to_tensor(index_1)
         output = paddle.gather(input, index)
         output_np = output.numpy()
         expected_output = np.array([3, 4])

--- a/backends/npu/tests/unittests/test_inverse_op_npu.py
+++ b/backends/npu/tests/unittests/test_inverse_op_npu.py
@@ -117,7 +117,7 @@ class TestInverseAPI(unittest.TestCase):
         for place in self.places:
             with base.dygraph.guard(place):
                 input_np = np.random.random([4, 4]).astype("float64")
-                input = base.dygraph.to_variable(input_np)
+                input = paddle.to_tensor(input_np)
                 result = paddle.inverse(input)
                 np.testing.assert_allclose(
                     result.numpy(), np.linalg.inv(input_np), rtol=1e-05

--- a/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_one_hot_v2_op_npu.py
@@ -213,9 +213,7 @@ class TestOneHotOpApi(unittest.TestCase):
             [6, 1]
         )
         with base.dygraph.guard(paddle.CustomPlace("npu", 0)):
-            one_hot_label = paddle.nn.functional.one_hot(
-                base.dygraph.to_variable(label), depth
-            )
+            one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
             one_hot_label = paddle.nn.functional.one_hot(paddle.to_tensor(label), depth)
 
     def _run(self, depth):

--- a/backends/npu/tests/unittests/test_roll_op_npu.py
+++ b/backends/npu/tests/unittests/test_roll_op_npu.py
@@ -168,7 +168,7 @@ class TestRollAPI(unittest.TestCase):
         self.input_data()
         # case 1:
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(self.data_x)
+            x = paddle.to_tensor(self.data_x)
             z = paddle.roll(x, shifts=1)
             np_z = z.numpy()
         expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
@@ -176,7 +176,7 @@ class TestRollAPI(unittest.TestCase):
 
         # case 2:
         with base.dygraph.guard():
-            x = base.dygraph.to_variable(self.data_x)
+            x = paddle.to_tensor(self.data_x)
             z = paddle.roll(x, shifts=1, axis=0)
             np_z = z.numpy()
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])

--- a/backends/npu/tests/unittests/test_scatter_nd_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_scatter_nd_add_op_npu.py
@@ -261,7 +261,7 @@ class TestDygraph(unittest.TestCase):
             x = paddle.rand(shape=[3, 5, 9, 10], dtype="float32")
             updates = paddle.rand(shape=[3, 9, 10], dtype="float32")
             index_data = np.array([[1, 1], [0, 1], [1, 3]]).astype(np.int64)
-            index = base.dygraph.to_variable(index_data)
+            index = paddle.to_tensor(index_data)
             output = paddle.scatter_nd_add(x, index, updates)
 
 

--- a/backends/npu/tests/unittests/test_stack_op_npu.py
+++ b/backends/npu/tests/unittests/test_stack_op_npu.py
@@ -229,16 +229,16 @@ class API_DygraphTest(unittest.TestCase):
         data2 = np.array([[3.0, 4.0]])
         data3 = np.array([[5.0, 6.0]])
         with base.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
-            x1 = base.dygraph.to_variable(data1)
-            x2 = base.dygraph.to_variable(data2)
-            x3 = base.dygraph.to_variable(data3)
+            x1 = paddle.to_tensor(data1)
+            x2 = paddle.to_tensor(data2)
+            x3 = paddle.to_tensor(data3)
             result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
         expected_result = np.stack([data1, data2, data3])
         self.assertTrue(np.allclose(expected_result, result_np))
 
         with base.dygraph.guard(place=paddle.CustomPlace("npu", 0)):
-            y1 = base.dygraph.to_variable(data1)
+            y1 = paddle.to_tensor(data1)
             result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
         expected_result_2 = np.stack([data1], axis=0)

--- a/backends/npu/tests/unittests/test_tril_triu_op_npu.py
+++ b/backends/npu/tests/unittests/test_tril_triu_op_npu.py
@@ -245,7 +245,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
                     )
                 else:
                     data = np.random.random([1, 9, 9, 4]).astype(dtype)
-                x = base.dygraph.to_variable(data)
+                x = paddle.to_tensor(data)
                 tril_out, triu_out = tensor.tril(x).numpy(), tensor.triu(x).numpy()
                 np.testing.assert_allclose(
                     convert_uint16_to_float(tril_out),

--- a/backends/npu/tests/unittests/test_where_op_npu.py
+++ b/backends/npu/tests/unittests/test_where_op_npu.py
@@ -157,9 +157,9 @@ class TestWhereDygraphAPI(unittest.TestCase):
             x_i = np.array([0.9383, 0.1983, 3.2, 1.2]).astype("float64")
             y_i = np.array([1.0, 1.0, 1.0, 1.0]).astype("float64")
             cond_i = np.array([False, False, True, True]).astype("bool")
-            x = base.dygraph.to_variable(x_i)
-            y = base.dygraph.to_variable(y_i)
-            cond = base.dygraph.to_variable(cond_i)
+            x = paddle.to_tensor(x_i)
+            y = paddle.to_tensor(y_i)
+            cond = paddle.to_tensor(cond_i)
             out = paddle.where(cond, x, y)
             assert np.array_equal(out.numpy(), np.where(cond_i, x_i, y_i))
 


### PR DESCRIPTION
`to_variable` 已移除： https://github.com/PaddlePaddle/Paddle/pull/61952 。
少数动转静场景需要使用 `paddle.assign`，其余场景都直接替换成 `paddle.to_tensor` 即可。