### PR TITLE
[NPU] add tril/bitwise aclnn

### DIFF
--- a/backends/npu/kernels/bitwise_kernel.cc
+++ b/backends/npu/kernels/bitwise_kernel.cc
@@ -65,10 +65,10 @@ void BitwiseAndKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseOrKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     const phi::DenseTensor& y,
-                     phi::DenseTensor* out) {
+void AclopBitwiseOrKernel(const Context& dev_ctx,
+                          const phi::DenseTensor& x,
+                          const phi::DenseTensor& y,
+                          phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -88,6 +88,25 @@ void BitwiseOrKernel(const Context& dev_ctx,
         NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseOrKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& x,
+                     const phi::DenseTensor& y,
+                     phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseOrTensor,
+      (custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out)));
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  if (x.dims().size() == 0 && y.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    y_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseOrTensor, dev_ctx, x_tensor, y_tensor, out_tensor);
 }
 
 template <typename T, typename Context>
@@ -137,9 +156,9 @@ void BitwiseXorKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseNotKernel(const Context& dev_ctx,
-                      const phi::DenseTensor& x,
-                      phi::DenseTensor* out) {
+void AclopBitwiseNotKernel(const Context& dev_ctx,
+                           const phi::DenseTensor& x,
+                           phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -156,6 +175,23 @@ void BitwiseNotKernel(const Context& dev_ctx,
     const auto& runner = NpuOpRunner("Invert", {x_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseNotKernel(const Context& dev_ctx,
+                      const phi::DenseTensor& x,
+                      phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseNot,
+      (custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out)));
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), out_tensor(*out);
+  if (x.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseNot, dev_ctx, x_tensor, out_tensor);
 }
 
 }  // namespace custom_kernel


### PR DESCRIPTION
本次迁移kernel：TrilKernel、TrilGradKernel、TrilTriuKernel、TrilTriuGradKernel、TriuKernel、TriuGradKernel、BitwiseOrKernel、BitwiseNotKernel，对应的测试用例：test_tril_triu_op_npu、test_bitwise_op_npu