### PR TITLE
[NPU] add tril/bitwise/swiglu/maskedselect aclnn

### DIFF
--- a/backends/npu/kernels/bitwise_kernel.cc
+++ b/backends/npu/kernels/bitwise_kernel.cc
@@ -65,10 +65,10 @@ void BitwiseAndKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseOrKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     const phi::DenseTensor& y,
-                     phi::DenseTensor* out) {
+void AclopBitwiseOrKernel(const Context& dev_ctx,
+                          const phi::DenseTensor& x,
+                          const phi::DenseTensor& y,
+                          phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -88,6 +88,25 @@ void BitwiseOrKernel(const Context& dev_ctx,
         NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseOrKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& x,
+                     const phi::DenseTensor& y,
+                     phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseOrTensor,
+      (custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out)));
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  if (x.dims().size() == 0 && y.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    y_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseOrTensor, dev_ctx, x_tensor, y_tensor, out_tensor);
 }
 
 template <typename T, typename Context>
@@ -137,9 +156,9 @@ void BitwiseXorKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseNotKernel(const Context& dev_ctx,
-                      const phi::DenseTensor& x,
-                      phi::DenseTensor* out) {
+void AclopBitwiseNotKernel(const Context& dev_ctx,
+                           const phi::DenseTensor& x,
+                           phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -156,6 +175,23 @@ void BitwiseNotKernel(const Context& dev_ctx,
     const auto& runner = NpuOpRunner("Invert", {x_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseNotKernel(const Context& dev_ctx,
+                      const phi::DenseTensor& x,
+                      phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseNot,
+      (custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out)));
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), out_tensor(*out);
+  if (x.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseNot, dev_ctx, x_tensor, out_tensor);
 }
 
 }  // namespace custom_kernel

--- a/backends/npu/kernels/masked_select_kernel.cc
+++ b/backends/npu/kernels/masked_select_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
+#include "kernels/funcs/slice_utils.h"
 
 namespace custom_kernel {
 
@@ -24,10 +25,10 @@ void CastKernel(const Context& dev_ctx,
                 phi::DenseTensor* out);
 
 template <typename T, typename Context>
-void MaskedSelectKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& x,
-                        const phi::DenseTensor& mask,
-                        phi::DenseTensor* out) {
+void AclopMaskedSelectKernel(const Context& dev_ctx,
+                             const phi::DenseTensor& x,
+                             const phi::DenseTensor& mask,
+                             phi::DenseTensor* out) {
   auto input_dim = x.dims();
   auto mask_dim = mask.dims();
   PADDLE_ENFORCE_EQ(input_dim,
@@ -80,6 +81,70 @@ void MaskedSelectKernel(const Context& dev_ctx,
   const auto& runner =
       NpuOpRunner("MaskedSelect", {x_tmp, mask_tmp}, {*out}, {});
   runner.Run(stream);
+}
+
+template <typename T, typename Context>
+void MaskedSelectKernel(const Context& dev_ctx,
+                        const phi::DenseTensor& x,
+                        const phi::DenseTensor& mask,
+                        phi::DenseTensor* out) {
+  auto input_dim = x.dims();
+  auto mask_dim = mask.dims();
+  PADDLE_ENFORCE_EQ(input_dim,
+                    mask_dim,
+                    phi::errors::InvalidArgument(
+                        "The dim size of input and mask in OP(masked_selected) "
+                        "must be equal, but got input dim:(%ld), mask dim: "
+                        "(%ld). Please check input "
+                        "value.",
+                        input_dim,
+                        mask_dim));
+
+  auto stream = dev_ctx.stream();
+
+  phi::DenseTensor x_tmp(x), mask_tmp(mask);
+  if (x.dims().size() == 0 && mask.dims().size() == 0) {
+    x_tmp.Resize({1});
+    mask_tmp.Resize({1});
+  }
+
+  phi::DenseTensor middle_out;
+  phi::DenseTensorMeta out_meta = {x.dtype(), phi::make_ddim({x.numel()})};
+  middle_out.set_meta(out_meta);
+  dev_ctx.Alloc(&middle_out, middle_out.dtype());
+
+  EXEC_NPU_CMD(aclnnMaskedSelect, dev_ctx, x_tmp, mask_tmp, middle_out);
+
+  phi::DenseTensor mask_int32;
+  phi::DenseTensor out_size;
+  mask_int32.Resize(mask_dim);
+  out_size.Resize({1});
+  dev_ctx.template Alloc<int32_t>(&mask_int32);
+  dev_ctx.template Alloc<int32_t>(&out_size);
+  std::vector<int32_t> out_size_vec;
+  {
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, mask, phi::DataType::INT32, &mask_int32);
+    mask_int32.Resize({mask_int32.numel()});
+
+    NpuOpRunner sum_runner;
+    sum_runner.SetType("ReduceSum");
+    sum_runner.AddInput(mask_int32);
+    sum_runner.AddInput(dev_ctx, std::vector<int32_t>(1, 0));
+    sum_runner.AddOutput(out_size);
+    sum_runner.AddAttr("keep_dims", false);
+    sum_runner.Run(stream);
+
+    // wait for ReduceSum complete
+    dev_ctx.Wait();
+    TensorToVector(dev_ctx, out_size, dev_ctx, &out_size_vec);
+    // wait for copy complete
+    dev_ctx.Wait();
+  }
+
+  *out = custom_kernel::Slice(middle_out,
+                              static_cast<int64_t>(0),
+                              static_cast<int64_t>(out_size_vec[0]));
 }
 
 template <typename T, typename Context>

--- a/backends/npu/kernels/swiglu_kernel.cc
+++ b/backends/npu/kernels/swiglu_kernel.cc
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/npu_funcs.h"
+#include "kernels/funcs/npu_op_runner.h"
+
+namespace custom_kernel {
+
+template <typename T, typename Context>
+void ConcatKernel(const Context& dev_ctx,
+                  const std::vector<const phi::DenseTensor*>& x,
+                  const phi::Scalar& axis_scalar,
+                  phi::DenseTensor* out);
+
+template <typename T, typename Context>
+void SwiGluKernel(const Context& dev_ctx,
+                  const phi::DenseTensor& x,
+                  const paddle::optional<phi::DenseTensor>& y,
+                  phi::DenseTensor* out) {
+  dev_ctx.template Alloc<T>(out);
+  const auto& dims = x.dims();
+  int64_t axis = -1;
+
+  if (y) {
+    const auto& y_tensor = y.get();
+    const auto& y_dims = y_tensor.dims();
+    PADDLE_ENFORCE_EQ(
+        y_dims,
+        dims,
+        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
+                                     "to the shape of Input(X):[%s].",
+                                     y_dims,
+                                     dims));
+    // Concatenate x and y in the - 1 dimension
+    phi::DenseTensor concat_xy;
+    auto dst_dims = y_dims;
+    phi::Scalar concat_dim = -1;
+    dst_dims[y_dims.size() - 1] = y_dims[y_dims.size() - 1] * 2;
+    concat_xy.Resize(dst_dims);
+    dev_ctx.template Alloc<T>(&concat_xy);
+
+    std::vector<const phi::DenseTensor*> in_tensors{&x, &y_tensor};
+    custom_kernel::ConcatKernel<T, Context>(
+        dev_ctx, in_tensors, &concat_dim, &concat_xy);
+    EXEC_NPU_CMD(aclnnSwiGlu, dev_ctx, concat_xy, axis, *out);
+
+  } else {
+    // check dims, divide x into two equal parts
+    auto dims_2d = flatten_to_2d(dims, dims.size() - 1);
+    int64_t n = dims_2d[1];
+    PADDLE_ENFORCE_EQ(n % 2,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The last dim of Input(X) should be exactly divided "
+                          "by 2 when Input(Y) is None, but got %d",
+                          n));
+    EXEC_NPU_CMD(aclnnSwiGlu, dev_ctx, x, axis, *out);
+  }
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(swiglu,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::SwiGluKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}

--- a/backends/npu/tests/unittests/test_swiglu_op_npu.py
+++ b/backends/npu/tests/unittests/test_swiglu_op_npu.py
@@ -1,0 +1,94 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+from tests.op_test import OpTest
+import paddle
+from scipy.special import expit
+
+SEED = 2021
+
+
+def swish(x):
+    out = x.astype("float32") * expit(x.astype("float32"))
+    return out.astype(x.dtype)
+
+
+class TestSwiGluFP32_1(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.init_dtype()
+        self.op_type = "swiglu"
+        self.place = paddle.CustomPlace("npu", 0)
+
+        rows = 20
+        cols = 512
+        x = (np.random.rand(rows, cols) * 16).astype(self.dtype)
+        bias = np.random.rand(cols).astype(self.dtype)
+        res_tmp = (x + bias).astype(self.dtype)
+        res_tmp_head = res_tmp[:, : cols // 2]
+        res_tmp_tail = res_tmp[:, cols // 2 :]
+        res_tmp_head_act = swish(res_tmp_head)
+        y = res_tmp_head_act * res_tmp_tail
+
+        self.inputs = {"x": res_tmp_head, "y": res_tmp_tail}
+        self.outputs = {"out": y}
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
+class TestSwiGluFP32_2(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.init_dtype()
+        self.op_type = "swiglu"
+        self.place = paddle.CustomPlace("npu", 0)
+
+        rows = 20
+        cols = 512
+        x = (np.random.rand(rows, cols) * 16).astype(self.dtype)
+        bias = np.random.rand(cols).astype(self.dtype)
+        res_tmp = (x + bias).astype(self.dtype)
+        res_tmp_head = res_tmp[:, : cols // 2]
+        res_tmp_tail = res_tmp[:, cols // 2 :]
+        res_tmp_head_act = swish(res_tmp_head)
+        y = res_tmp_head_act * res_tmp_tail
+
+        inputx = np.concatenate((res_tmp_head, res_tmp_tail), axis=-1)
+
+        self.inputs = {"x": inputx}
+        self.outputs = {"out": y}
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
本次迁移kernel：TrilKernel、TrilGradKernel、TrilTriuKernel、TrilTriuGradKernel、TriuKernel、TriuGradKernel、BitwiseOrKernel、BitwiseNotKernel、SwiGluKernel、MaskedSelectKernel，对应的测试用例：test_tril_triu_op_npu、test_bitwise_op_npu、test_swiglu_op_npu、test_masked_select_op_npu