### PR TITLE
[NPU] add aclnn of tril/bitwise/swiglu/maskedselect/all/fill_diagonal

### DIFF
--- a/backends/npu/kernels/bitwise_kernel.cc
+++ b/backends/npu/kernels/bitwise_kernel.cc
@@ -65,10 +65,10 @@ void BitwiseAndKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseOrKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     const phi::DenseTensor& y,
-                     phi::DenseTensor* out) {
+void AclopBitwiseOrKernel(const Context& dev_ctx,
+                          const phi::DenseTensor& x,
+                          const phi::DenseTensor& y,
+                          phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -88,6 +88,29 @@ void BitwiseOrKernel(const Context& dev_ctx,
         NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseOrKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& x,
+                     const phi::DenseTensor& y,
+                     phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseOrTensor,
+      (custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out);
+    return;
+  }
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  if (x.dims().size() == 0 && y.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    y_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseOrTensor, dev_ctx, x_tensor, y_tensor, out_tensor);
 }
 
 template <typename T, typename Context>
@@ -137,9 +160,9 @@ void BitwiseXorKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseNotKernel(const Context& dev_ctx,
-                      const phi::DenseTensor& x,
-                      phi::DenseTensor* out) {
+void AclopBitwiseNotKernel(const Context& dev_ctx,
+                           const phi::DenseTensor& x,
+                           phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -156,6 +179,27 @@ void BitwiseNotKernel(const Context& dev_ctx,
     const auto& runner = NpuOpRunner("Invert", {x_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseNotKernel(const Context& dev_ctx,
+                      const phi::DenseTensor& x,
+                      phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseNot,
+      (custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out);
+    return;
+  }
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), out_tensor(*out);
+  if (x.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseNot, dev_ctx, x_tensor, out_tensor);
 }
 
 }  // namespace custom_kernel

--- a/backends/npu/kernels/reduce_all_kernel.cc
+++ b/backends/npu/kernels/reduce_all_kernel.cc
@@ -18,12 +18,12 @@
 namespace custom_kernel {
 
 template <typename T, typename Context>
-void AllRawKernel(const Context& dev_ctx,
-                  const phi::DenseTensor& x,
-                  const std::vector<int64_t>& dims,
-                  bool keep_dim,
-                  bool reduce_all,
-                  phi::DenseTensor* out) {
+void AclopAllRawKernel(const Context& dev_ctx,
+                       const phi::DenseTensor& x,
+                       const std::vector<int64_t>& dims,
+                       bool keep_dim,
+                       bool reduce_all,
+                       phi::DenseTensor* out) {
   bool reduce_all_f = dims.size() == 0 ||
                       static_cast<int>(dims.size()) == x.dims().size() ||
                       reduce_all;
@@ -47,6 +47,39 @@ void AllRawKernel(const Context& dev_ctx,
       .AddOutput(*out)
       .AddAttr("keep_dims", keep_dim);
   runner.Run(stream);
+}
+
+template <typename T, typename Context>
+void AllRawKernel(const Context& dev_ctx,
+                  const phi::DenseTensor& x,
+                  const std::vector<int64_t>& dims,
+                  bool keep_dim,
+                  bool reduce_all,
+                  phi::DenseTensor* out) {
+  DO_COMPATIBILITY(aclnnAll,
+                   (custom_kernel::AclopAllRawKernel<T, Context>(
+                       dev_ctx, x, dims, keep_dim, reduce_all, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopAllRawKernel<T, Context>(
+        dev_ctx, x, dims, keep_dim, reduce_all, out);
+    return;
+  }
+  bool reduce_all_f = dims.size() == 0 ||
+                      static_cast<int>(dims.size()) == x.dims().size() ||
+                      reduce_all;
+  std::vector<int64_t> dims_vec = dims;
+  dev_ctx.template Alloc<T>(out);
+  if (x.dims().size() == 0) {
+    TensorCopy(dev_ctx, x, true, out);
+    return;
+  }
+  if (reduce_all_f) {
+    dims_vec.clear();
+    for (size_t i = 0; i < x.dims().size(); ++i) {
+      dims_vec.push_back(static_cast<int64_t>(i));
+    }
+  }
+  EXEC_NPU_CMD(aclnnAll, dev_ctx, x, dims_vec, keep_dim, *out);
 }
 
 template <typename T, typename Context>

--- a/backends/npu/kernels/swiglu_kernel.cc
+++ b/backends/npu/kernels/swiglu_kernel.cc
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "kernels/funcs/npu_funcs.h"
+#include "kernels/funcs/npu_op_runner.h"
+
+namespace custom_kernel {
+
+template <typename T, typename Context>
+void ConcatKernel(const Context& dev_ctx,
+                  const std::vector<const phi::DenseTensor*>& x,
+                  const phi::Scalar& axis_scalar,
+                  phi::DenseTensor* out);
+
+template <typename T, typename Context>
+void SwiGluKernel(const Context& dev_ctx,
+                  const phi::DenseTensor& x,
+                  const paddle::optional<phi::DenseTensor>& y,
+                  phi::DenseTensor* out) {
+  dev_ctx.template Alloc<T>(out);
+  const auto& dims = x.dims();
+  int64_t axis = -1;
+
+  if (y) {
+    const auto& y_tensor = y.get();
+    const auto& y_dims = y_tensor.dims();
+    PADDLE_ENFORCE_EQ(
+        y_dims,
+        dims,
+        phi::errors::InvalidArgument("The shape of Input(Y):[%s] must be equal "
+                                     "to the shape of Input(X):[%s].",
+                                     y_dims,
+                                     dims));
+    // Concatenate x and y in the - 1 dimension
+    phi::DenseTensor concat_xy;
+    auto dst_dims = y_dims;
+    phi::Scalar concat_dim = -1;
+    dst_dims[y_dims.size() - 1] = y_dims[y_dims.size() - 1] * 2;
+    concat_xy.Resize(dst_dims);
+    dev_ctx.template Alloc<T>(&concat_xy);
+
+    std::vector<const phi::DenseTensor*> in_tensors{&x, &y_tensor};
+    custom_kernel::ConcatKernel<T, Context>(
+        dev_ctx, in_tensors, &concat_dim, &concat_xy);
+    EXEC_NPU_CMD(aclnnSwiGlu, dev_ctx, concat_xy, axis, *out);
+
+  } else {
+    // check dims, divide x into two equal parts
+    auto dims_2d = flatten_to_2d(dims, dims.size() - 1);
+    int64_t n = dims_2d[1];
+    PADDLE_ENFORCE_EQ(n % 2,
+                      0,
+                      phi::errors::InvalidArgument(
+                          "The last dim of Input(X) should be exactly divided "
+                          "by 2 when Input(Y) is None, but got %d",
+                          n));
+    EXEC_NPU_CMD(aclnnSwiGlu, dev_ctx, x, axis, *out);
+  }
+}
+
+}  // namespace custom_kernel
+
+PD_REGISTER_PLUGIN_KERNEL(swiglu,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::SwiGluKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}

--- a/backends/npu/kernels/tril_triu_kernel.cc
+++ b/backends/npu/kernels/tril_triu_kernel.cc
@@ -18,11 +18,11 @@
 namespace custom_kernel {
 
 template <typename T, typename Context>
-void TrilTriuKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    int diagonal,
-                    bool lower,
-                    phi::DenseTensor* out) {
+void AclopTrilTriuKernel(const Context& dev_ctx,
+                         const phi::DenseTensor& x,
+                         int diagonal,
+                         bool lower,
+                         phi::DenseTensor* out) {
   const auto* x_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -69,6 +69,33 @@ void TrilTriuKernel(const Context& dev_ctx,
   } else {
     const auto& runner = NpuOpRunner(op_type, {x}, {*out}, attr_input);
     runner.Run(dev_ctx.stream());
+  }
+}
+
+template <typename T, typename Context>
+void TrilTriuKernel(const Context& dev_ctx,
+                    const phi::DenseTensor& x,
+                    int diagonal,
+                    bool lower,
+                    phi::DenseTensor* out) {
+  DO_COMPATIBILITY(aclnnTril,
+                   (custom_kernel::AclopTrilTriuKernel<T, Context>(
+                       dev_ctx, x, diagonal, lower, out)));
+  DO_COMPATIBILITY(aclnnTriu,
+                   (custom_kernel::AclopTrilTriuKernel<T, Context>(
+                       dev_ctx, x, diagonal, lower, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopTrilTriuKernel<T, Context>(
+        dev_ctx, x, diagonal, lower, out);
+    return;
+  }
+
+  int64_t dia = diagonal;
+  dev_ctx.template Alloc<T>(out);
+  if (lower) {
+    EXEC_NPU_CMD(aclnnTril, dev_ctx, x, dia, *out);
+  } else {
+    EXEC_NPU_CMD(aclnnTriu, dev_ctx, x, dia, *out);
   }
 }
 

--- a/backends/npu/tests/unittests/test_swiglu_op_npu.py
+++ b/backends/npu/tests/unittests/test_swiglu_op_npu.py
@@ -1,0 +1,97 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+from tests.op_test import OpTest
+import paddle
+from scipy.special import expit
+from npu_utils import check_soc_version
+
+SEED = 2021
+
+
+def swish(x):
+    out = x.astype("float32") * expit(x.astype("float32"))
+    return out.astype(x.dtype)
+
+
+class TestSwiGluFP32_1(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.init_dtype()
+        self.op_type = "swiglu"
+        self.place = paddle.CustomPlace("npu", 0)
+
+        rows = 20
+        cols = 512
+        x = (np.random.rand(rows, cols) * 16).astype(self.dtype)
+        bias = np.random.rand(cols).astype(self.dtype)
+        res_tmp = (x + bias).astype(self.dtype)
+        res_tmp_head = res_tmp[:, : cols // 2]
+        res_tmp_tail = res_tmp[:, cols // 2 :]
+        res_tmp_head_act = swish(res_tmp_head)
+        y = res_tmp_head_act * res_tmp_tail
+
+        self.inputs = {"x": res_tmp_head, "y": res_tmp_tail}
+        self.outputs = {"out": y}
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    @check_soc_version
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
+class TestSwiGluFP32_2(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.init_dtype()
+        self.op_type = "swiglu"
+        self.place = paddle.CustomPlace("npu", 0)
+
+        rows = 20
+        cols = 512
+        x = (np.random.rand(rows, cols) * 16).astype(self.dtype)
+        bias = np.random.rand(cols).astype(self.dtype)
+        res_tmp = (x + bias).astype(self.dtype)
+        res_tmp_head = res_tmp[:, : cols // 2]
+        res_tmp_tail = res_tmp[:, cols // 2 :]
+        res_tmp_head_act = swish(res_tmp_head)
+        y = res_tmp_head_act * res_tmp_tail
+
+        inputx = np.concatenate((res_tmp_head, res_tmp_tail), axis=-1)
+
+        self.inputs = {"x": inputx}
+        self.outputs = {"out": y}
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def set_npu(self):
+        self.__class__.use_custom_device = True
+
+    @check_soc_version
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
本次迁移kernel：TrilKernel、TrilGradKernel、TrilTriuKernel、TrilTriuGradKernel、TriuKernel、TriuGradKernel、BitwiseOrKernel、BitwiseNotKernel、SwiGluKernel、MaskedSelectKernel、AllRawKernel、AllKernel、FillDiagonalKernel、FillDiagonalGradKernel，对应的测试用例：test_tril_triu_op_npu、test_bitwise_op_npu、test_swiglu_op_npu、test_masked_select_op_npu、test_reduce_all_op_npu、test_fill_diagonal_op_npu