### PR TITLE
[NPU] support aclnn for layer_norm layer_norm_grad sum_grad

### DIFF
--- a/backends/npu/kernels/layer_norm_kernel.cc
+++ b/backends/npu/kernels/layer_norm_kernel.cc
@@ -54,15 +54,27 @@ template <typename T>
 using LayerNormParamType = typename NormDataType<T>::BatchNormParamType;
 
 template <typename T, typename Context>
-void LayerNormNPUKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& x,
-                        const paddle::optional<phi::DenseTensor>& scale_opt,
-                        const paddle::optional<phi::DenseTensor>& bias_opt,
-                        float epsilon,
-                        int begin_norm_axis,
-                        phi::DenseTensor* out,
-                        phi::DenseTensor* mean,
-                        phi::DenseTensor* variance) {
+void FillKernel(const Context& dev_ctx,
+                const phi::DenseTensor& x,
+                const phi::Scalar& val);
+
+template <typename T, typename Context>
+void CastKernel(const Context& dev_ctx,
+                const phi::DenseTensor& x,
+                phi::DataType dtype,
+                phi::DenseTensor* out);
+
+template <typename T, typename Context>
+void AclopLayerNormNPUKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& x,
+    const paddle::optional<phi::DenseTensor>& scale_opt,
+    const paddle::optional<phi::DenseTensor>& bias_opt,
+    float epsilon,
+    int begin_norm_axis,
+    phi::DenseTensor* out,
+    phi::DenseTensor* mean,
+    phi::DenseTensor* variance) {
   using U = LayerNormParamType<T>;
   auto* scale = scale_opt.get_ptr();
   auto* bias = bias_opt.get_ptr();
@@ -243,18 +255,133 @@ void LayerNormNPUKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void LayerNormGradNPUKernel(const Context& dev_ctx,
-                            const phi::DenseTensor& x,
-                            const paddle::optional<phi::DenseTensor>& scale_opt,
-                            const paddle::optional<phi::DenseTensor>& bias,
-                            const phi::DenseTensor& mean,
-                            const phi::DenseTensor& variance,
-                            const phi::DenseTensor& out_grad,
-                            float epsilon,
-                            int begin_norm_axis,
-                            phi::DenseTensor* x_grad,
-                            phi::DenseTensor* scale_grad,
-                            phi::DenseTensor* bias_grad) {
+void LayerNormNPUKernel(const Context& dev_ctx,
+                        const phi::DenseTensor& x,
+                        const paddle::optional<phi::DenseTensor>& scale_opt,
+                        const paddle::optional<phi::DenseTensor>& bias_opt,
+                        float epsilon,
+                        int begin_norm_axis,
+                        phi::DenseTensor* out,
+                        phi::DenseTensor* mean,
+                        phi::DenseTensor* variance) {
+  DO_COMPATIBILITY(
+      aclnnLayerNorm,
+      (custom_kernel::AclopLayerNormNPUKernel<T, Context>(dev_ctx,
+                                                          x,
+                                                          scale_opt,
+                                                          bias_opt,
+                                                          epsilon,
+                                                          begin_norm_axis,
+                                                          out,
+                                                          mean,
+                                                          variance)));
+  dev_ctx.template Alloc<T>(out);
+  std::vector<int64_t> axes;
+  std::vector<int64_t> mean_shape;
+  auto mean_dims = mean->dims();
+  const auto& x_dims = x.dims();
+  auto matrix_dim = phi::flatten_to_2d(x_dims, begin_norm_axis);
+  int right = static_cast<int>(matrix_dim[1]);
+
+  for (auto i = 0; i < x_dims.size(); ++i) {
+    if (i >= begin_norm_axis) {
+      axes.push_back(x_dims[i]);
+      mean_shape.push_back(1);
+
+    } else {
+      mean_shape.push_back(x_dims[i]);
+    }
+  }
+
+  auto* scale = scale_opt.get_ptr();
+  auto* bias = bias_opt.get_ptr();
+
+  phi::Scalar scale_val = 1.0f;
+  phi::Scalar bias_val = 0.0f;
+
+  phi::DenseTensor default_scale;
+  if (!scale) {
+    phi::DenseTensorMeta default_scale_meta = {x.dtype(), phi::make_ddim(axes)};
+    default_scale.set_meta(default_scale_meta);
+    dev_ctx.template Alloc<T>(&default_scale);
+    custom_kernel::FillKernel<T, Context>(dev_ctx, default_scale, scale_val);
+    scale = &default_scale;
+  } else {
+    const_cast<Tensor*>(scale)->Resize(phi::make_ddim(axes));
+  }
+
+  phi::DenseTensor default_bias;
+  if (!bias) {
+    phi::DenseTensorMeta default_bias_meta = {x.dtype(), phi::make_ddim(axes)};
+    default_bias.set_meta(default_bias_meta);
+    dev_ctx.template Alloc<T>(&default_bias);
+    custom_kernel::FillKernel<T, Context>(dev_ctx, default_bias, bias_val);
+    bias = &default_bias;
+  } else {
+    const_cast<Tensor*>(bias)->Resize(phi::make_ddim(axes));
+  }
+
+  phi::DenseTensor cast_scale;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      scale->dtype() == phi::DataType::FLOAT32) {
+    cast_scale.Resize(scale->dims());
+    dev_ctx.template Alloc<T>(&cast_scale);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *scale, x.dtype(), &cast_scale);
+  } else {
+    cast_scale = *scale;
+  }
+
+  // cast bias from LayerNormParamType to T if needed
+  phi::DenseTensor cast_bias;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      bias->dtype() == phi::DataType::FLOAT32) {
+    cast_bias.Resize(bias->dims());
+    dev_ctx.template Alloc<T>(&cast_bias);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *bias, x.dtype(), &cast_bias);
+  } else {
+    cast_bias = *bias;
+  }
+  double eps = epsilon;
+  phi::DenseTensorMeta mean_meta = {x.dtype(), phi::make_ddim(mean_shape)};
+  mean->set_meta(mean_meta);
+  phi::DenseTensorMeta variance_meta = {x.dtype(), phi::make_ddim(mean_shape)};
+  variance->set_meta(variance_meta);
+  dev_ctx.template Alloc<T>(mean);
+  dev_ctx.template Alloc<T>(variance);
+
+  EXEC_NPU_CMD(aclnnLayerNorm,
+               dev_ctx,
+               x,
+               axes,
+               cast_scale,
+               cast_bias,
+               eps,
+               *out,
+               *mean,
+               *variance);
+
+  mean->Resize(mean_dims);
+  variance->Resize(mean_dims);
+  const_cast<Tensor*>(scale)->Resize(phi::make_ddim({right}));
+  const_cast<Tensor*>(bias)->Resize(phi::make_ddim({right}));
+}
+
+template <typename T, typename Context>
+void AclopLayerNormGradNPUKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& x,
+    const paddle::optional<phi::DenseTensor>& scale_opt,
+    const paddle::optional<phi::DenseTensor>& bias,
+    const phi::DenseTensor& mean,
+    const phi::DenseTensor& variance,
+    const phi::DenseTensor& out_grad,
+    float epsilon,
+    int begin_norm_axis,
+    phi::DenseTensor* x_grad,
+    phi::DenseTensor* scale_grad,
+    phi::DenseTensor* bias_grad) {
   using U = LayerNormParamType<T>;
   const auto& x_dims = x.dims();
   auto* scale = scale_opt.get_ptr();
@@ -435,6 +562,210 @@ void LayerNormGradNPUKernel(const Context& dev_ctx,
                     {*bias_grad},
                     {{"dst_type", static_cast<int>(dst_dtype)}});
     runner_cast_bias_grad.Run(stream);
+  }
+
+  const_cast<Tensor*>(&mean)->Resize(mean_dims);
+  const_cast<Tensor*>(&variance)->Resize(mean_dims);
+  const_cast<Tensor*>(scale)->Resize(phi::make_ddim({right}));
+  scale_grad->Resize(phi::make_ddim({right}));
+  bias_grad->Resize(phi::make_ddim({right}));
+}
+
+template <typename T, typename Context>
+void LayerNormGradNPUKernel(const Context& dev_ctx,
+                            const phi::DenseTensor& x,
+                            const paddle::optional<phi::DenseTensor>& scale_opt,
+                            const paddle::optional<phi::DenseTensor>& bias,
+                            const phi::DenseTensor& mean,
+                            const phi::DenseTensor& variance,
+                            const phi::DenseTensor& out_grad,
+                            float epsilon,
+                            int begin_norm_axis,
+                            phi::DenseTensor* x_grad,
+                            phi::DenseTensor* scale_grad,
+                            phi::DenseTensor* bias_grad) {
+  DO_COMPATIBILITY(
+      aclnnLayerNormBackward,
+      (custom_kernel::AclopLayerNormGradNPUKernel<T, Context>(dev_ctx,
+                                                              x,
+                                                              scale_opt,
+                                                              bias,
+                                                              mean,
+                                                              variance,
+                                                              out_grad,
+                                                              epsilon,
+                                                              begin_norm_axis,
+                                                              x_grad,
+                                                              scale_grad,
+                                                              bias_grad)));
+  using U = LayerNormParamType<T>;
+  const auto& x_dims = x.dims();
+  auto* scale = scale_opt.get_ptr();
+  auto* bias_ptr = bias.get_ptr();
+
+  auto matrix_dim = phi::flatten_to_2d(x_dims, begin_norm_axis);
+  int right = static_cast<int>(matrix_dim[1]);
+
+  std::vector<int64_t> axes;
+  for (auto i = begin_norm_axis; i < x_dims.size(); ++i) {
+    axes.push_back(x_dims[i]);
+  }
+
+  // No need to compute any gradient, jusr return
+  if (!x_grad && !scale_grad && !bias_grad) {
+    return;
+  }
+
+  // The rank of mean should be equal to x, required by npu.
+  std::vector<int> new_shape;
+  for (auto i = 0; i < begin_norm_axis; ++i) {
+    new_shape.push_back(x_dims[i]);
+  }
+  for (auto i = begin_norm_axis; i < x_dims.size(); ++i) {
+    new_shape.push_back(1);
+  }
+
+  auto mean_dims = mean.dims();
+  const_cast<Tensor*>(&mean)->Resize(phi::make_ddim({new_shape}));
+  const_cast<Tensor*>(&variance)->Resize(phi::make_ddim({new_shape}));
+
+  phi::Scalar scale_val = 1.0f;
+  phi::Scalar bias_val = 0.0f;
+
+  std::array<bool, 3> output_mask = {true, true, true};
+
+  phi::DenseTensor default_scale;
+  if (!scale) {
+    phi::DenseTensorMeta default_scale_meta = {x.dtype(), phi::make_ddim(axes)};
+    default_scale.set_meta(default_scale_meta);
+    dev_ctx.template Alloc<T>(&default_scale);
+    custom_kernel::FillKernel<T, Context>(dev_ctx, default_scale, scale_val);
+    scale = &default_scale;
+    output_mask[1] = false;
+  } else {
+    const_cast<Tensor*>(scale)->Resize(phi::make_ddim(axes));
+  }
+
+  phi::DenseTensor default_bias;
+  if (!bias_ptr) {
+    phi::DenseTensorMeta default_bias_meta = {x.dtype(), phi::make_ddim(axes)};
+    default_bias.set_meta(default_bias_meta);
+    dev_ctx.template Alloc<T>(&default_bias);
+    custom_kernel::FillKernel<T, Context>(dev_ctx, default_bias, bias_val);
+    bias_ptr = &default_bias;
+    output_mask[2] = false;
+  } else {
+    const_cast<Tensor*>(bias_ptr)->Resize(phi::make_ddim(axes));
+  }
+
+  phi::DenseTensor cast_scale;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      scale->dtype() == phi::DataType::FLOAT32) {
+    cast_scale.Resize(scale->dims());
+    dev_ctx.template Alloc<T>(&cast_scale);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *scale, x.dtype(), &cast_scale);
+  } else {
+    cast_scale = *scale;
+  }
+
+  phi::DenseTensor cast_bias;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      bias_ptr->dtype() == phi::DataType::FLOAT32) {
+    cast_bias.Resize(bias_ptr->dims());
+    dev_ctx.template Alloc<T>(&cast_bias);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *bias_ptr, x.dtype(), &cast_bias);
+  } else {
+    cast_bias = *bias_ptr;
+  }
+
+  // cast mean from LayerNormParamType to T if needed
+  phi::DenseTensor cast_mean;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      mean.dtype() == phi::DataType::FLOAT32) {
+    cast_mean.Resize(mean.dims());
+    dev_ctx.template Alloc<T>(&cast_mean);
+    custom_kernel::CastKernel<T, Context>(dev_ctx, mean, x.dtype(), &cast_mean);
+  } else {
+    cast_mean = mean;
+  }
+
+  // cast variance from LayerNormParamType to T if needed
+  phi::DenseTensor cast_variance;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      variance.dtype() == phi::DataType::FLOAT32) {
+    cast_variance.Resize(variance.dims());
+    dev_ctx.template Alloc<T>(&cast_variance);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, variance, x.dtype(), &cast_variance);
+  } else {
+    cast_variance = variance;
+  }
+
+  Tensor x_grad_, scale_grad_, bias_grad_;
+  x_grad = (x_grad == nullptr) ? &x_grad_ : x_grad;
+  scale_grad = (scale_grad == nullptr) ? &scale_grad_ : scale_grad;
+  bias_grad = (bias_grad == nullptr) ? &bias_grad_ : bias_grad;
+
+  x_grad->Resize(x.dims());
+  scale_grad->Resize(phi::make_ddim(axes));
+  bias_grad->Resize(phi::make_ddim(axes));
+
+  dev_ctx.template Alloc<T>(x_grad);
+  // scale_grad should be of  U type
+  Tensor* tmp_scale_grad = scale_grad;
+  Tensor cast_scale_grad;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      (mean.dtype() == phi::DataType::FLOAT32 ||
+       variance.dtype() == phi::DataType::FLOAT32)) {
+    cast_scale_grad.Resize(scale_grad->dims());
+    dev_ctx.template Alloc<T>(&cast_scale_grad);
+    tmp_scale_grad = &cast_scale_grad;
+    dev_ctx.template Alloc<U>(scale_grad);
+  } else {
+    dev_ctx.template Alloc<T>(scale_grad);
+  }
+
+  // same for bias_grad
+  Tensor* tmp_bias_grad = bias_grad;
+  Tensor cast_bias_grad;
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      (mean.dtype() == phi::DataType::FLOAT32 ||
+       variance.dtype() == phi::DataType::FLOAT32)) {
+    cast_bias_grad.Resize(bias_grad->dims());
+    dev_ctx.template Alloc<T>(&cast_bias_grad);
+    tmp_bias_grad = &cast_bias_grad;
+    dev_ctx.template Alloc<U>(bias_grad);
+  } else {
+    dev_ctx.template Alloc<T>(bias_grad);
+  }
+
+  EXEC_NPU_CMD(aclnnLayerNormBackward,
+               dev_ctx,
+               out_grad,
+               x,
+               axes,
+               cast_mean,
+               cast_variance,
+               cast_scale,
+               cast_bias,
+               output_mask,
+               *x_grad,
+               *tmp_scale_grad,
+               *tmp_bias_grad);
+
+  // cast back from FLOAT16 to FLOAT32
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      scale_grad->dtype() == phi::DataType::FLOAT32) {
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *tmp_scale_grad, scale_grad->dtype(), scale_grad);
+  }
+  // same for bias_grad
+  if (x.dtype() == phi::DataType::FLOAT16 &&
+      bias_grad->dtype() == phi::DataType::FLOAT32) {
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, *tmp_bias_grad, bias_grad->dtype(), bias_grad);
   }
 
   const_cast<Tensor*>(&mean)->Resize(mean_dims);

--- a/backends/npu/kernels/reduce_sum_kernel.cc
+++ b/backends/npu/kernels/reduce_sum_kernel.cc
@@ -356,12 +356,8 @@ void SumGradKernel(const Context& dev_ctx,
     out_grad_tmp.set_meta(meta);
     dev_ctx.Alloc(&out_grad_tmp, out_grad_tmp.dtype());
 
-    const auto& cast_runner = NpuOpRunner(
-        "Cast",
-        {out_grad},
-        {out_grad_tmp},
-        {{"dst_type", static_cast<int>(ConvertToNpuDtype(x_grad->dtype()))}});
-    cast_runner.Run(stream);
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, out_grad, x_grad->dtype(), &out_grad_tmp);
   }
 
   if (x.dims().size() == 0) {


### PR DESCRIPTION
[NPU] support aclnn for layer_norm layer_norm_grad sum_grad
ut:
backends/npu/tests/unittests/test_layer_norm_op_npu.py
backends/npu/tests/unittests/test_reduce_sum_op_npu.py
backends/npu/tests/unittests/test_reduce_sum_op_npu_eager.py
