### PR TITLE
[NPU] add aclnn of tril/bitwise/masked_select/fill_diagonal

### DIFF
--- a/backends/npu/kernels/bitwise_kernel.cc
+++ b/backends/npu/kernels/bitwise_kernel.cc
@@ -65,10 +65,10 @@ void BitwiseAndKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseOrKernel(const Context& dev_ctx,
-                     const phi::DenseTensor& x,
-                     const phi::DenseTensor& y,
-                     phi::DenseTensor* out) {
+void AclopBitwiseOrKernel(const Context& dev_ctx,
+                          const phi::DenseTensor& x,
+                          const phi::DenseTensor& y,
+                          phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -88,6 +88,29 @@ void BitwiseOrKernel(const Context& dev_ctx,
         NpuOpRunner("BitwiseOr", {x_tensor, y_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseOrKernel(const Context& dev_ctx,
+                     const phi::DenseTensor& x,
+                     const phi::DenseTensor& y,
+                     phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseOrTensor,
+      (custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopBitwiseOrKernel<T, Context>(dev_ctx, x, y, out);
+    return;
+  }
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), y_tensor(y), out_tensor(*out);
+  if (x.dims().size() == 0 && y.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    y_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseOrTensor, dev_ctx, x_tensor, y_tensor, out_tensor);
 }
 
 template <typename T, typename Context>
@@ -137,9 +160,9 @@ void BitwiseXorKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void BitwiseNotKernel(const Context& dev_ctx,
-                      const phi::DenseTensor& x,
-                      phi::DenseTensor* out) {
+void AclopBitwiseNotKernel(const Context& dev_ctx,
+                           const phi::DenseTensor& x,
+                           phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   auto stream = dev_ctx.stream();
 
@@ -156,6 +179,27 @@ void BitwiseNotKernel(const Context& dev_ctx,
     const auto& runner = NpuOpRunner("Invert", {x_tensor}, {out_tensor});
     runner.Run(stream);
   }
+}
+
+template <typename T, typename Context>
+void BitwiseNotKernel(const Context& dev_ctx,
+                      const phi::DenseTensor& x,
+                      phi::DenseTensor* out) {
+  DO_COMPATIBILITY(
+      aclnnBitwiseNot,
+      (custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopBitwiseNotKernel<T, Context>(dev_ctx, x, out);
+    return;
+  }
+  dev_ctx.template Alloc<T>(out);
+
+  phi::DenseTensor x_tensor(x), out_tensor(*out);
+  if (x.dims().size() == 0) {
+    x_tensor.Resize(phi::make_ddim({1}));
+    out_tensor.Resize(phi::make_ddim({1}));
+  }
+  EXEC_NPU_CMD(aclnnBitwiseNot, dev_ctx, x_tensor, out_tensor);
 }
 
 }  // namespace custom_kernel

--- a/backends/npu/kernels/tril_triu_kernel.cc
+++ b/backends/npu/kernels/tril_triu_kernel.cc
@@ -18,11 +18,11 @@
 namespace custom_kernel {
 
 template <typename T, typename Context>
-void TrilTriuKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    int diagonal,
-                    bool lower,
-                    phi::DenseTensor* out) {
+void AclopTrilTriuKernel(const Context& dev_ctx,
+                         const phi::DenseTensor& x,
+                         int diagonal,
+                         bool lower,
+                         phi::DenseTensor* out) {
   const auto* x_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -69,6 +69,33 @@ void TrilTriuKernel(const Context& dev_ctx,
   } else {
     const auto& runner = NpuOpRunner(op_type, {x}, {*out}, attr_input);
     runner.Run(dev_ctx.stream());
+  }
+}
+
+template <typename T, typename Context>
+void TrilTriuKernel(const Context& dev_ctx,
+                    const phi::DenseTensor& x,
+                    int diagonal,
+                    bool lower,
+                    phi::DenseTensor* out) {
+  DO_COMPATIBILITY(aclnnTril,
+                   (custom_kernel::AclopTrilTriuKernel<T, Context>(
+                       dev_ctx, x, diagonal, lower, out)));
+  DO_COMPATIBILITY(aclnnTriu,
+                   (custom_kernel::AclopTrilTriuKernel<T, Context>(
+                       dev_ctx, x, diagonal, lower, out)));
+  if (x.storage_properties_initialized()) {
+    custom_kernel::AclopTrilTriuKernel<T, Context>(
+        dev_ctx, x, diagonal, lower, out);
+    return;
+  }
+
+  int64_t dia = diagonal;
+  dev_ctx.template Alloc<T>(out);
+  if (lower) {
+    EXEC_NPU_CMD(aclnnTril, dev_ctx, x, dia, *out);
+  } else {
+    EXEC_NPU_CMD(aclnnTriu, dev_ctx, x, dia, *out);
   }
 }
 


### PR DESCRIPTION
本次迁移kernel：TrilKernel、TrilGradKernel、TrilTriuKernel、TrilTriuGradKernel、TriuKernel、TriuGradKernel、BitwiseOrKernel、BitwiseNotKernel、MaskedSelectKernel、FillDiagonalKernel、FillDiagonalGradKernel，对应的测试用例：test_tril_triu_op_npu、test_bitwise_op_npu、test_masked_select_op_npu、test_fill_diagonal_op_npu