### PR TITLE
[NPU] add aclnn of AllRawKernel

### DIFF
--- a/backends/npu/kernels/expand_as_kernel.cc
+++ b/backends/npu/kernels/expand_as_kernel.cc
@@ -55,7 +55,7 @@ bool check_tensor_values_in_range(const Context& dev_ctx,
       dev_ctx, x, phi::DataType::INT32, &cast_x);
   custom_kernel::EqualKernel<T, Context>(dev_ctx, x, cast_x, &equal_result);
   const std::vector<int64_t> dims;
-  all_result.Resize(phi::make_ddim({1}));
+  all_result.Resize(phi::make_ddim({}));
   bool keep_dim = false;
   custom_kernel::AllKernel<bool, Context>(
       dev_ctx, equal_result, dims, keep_dim, &all_result);


### PR DESCRIPTION
本次迁移kernel：AllRawKernel、AllKernel，对应的测试用例：test_reduce_all_op_npu
expand_as中调用到了AllKernel，调Aclop时不出错，但调aclnn时报错，主要是因为，aclnn的out输出，需要size为[[]]的tensor，但expand_as中构建了一个size为[[1]]的tensor，因此修改expand_as中对out进行resize的代码