### PR TITLE
[NPU] Fix unittest

### DIFF
--- a/backends/npu/kernels/scale_kernel.cc
+++ b/backends/npu/kernels/scale_kernel.cc
@@ -21,10 +21,11 @@ template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
                  const phi::DenseTensor& x,
                  const phi::Scalar& in_scale,
-                 float bias,
+                 const phi::Scalar& in_bias,
                  bool bias_after_scale,
                  phi::DenseTensor* out) {
   auto scale = in_scale.to<float>();
+  auto bias = in_bias.to<float>();
   auto stream = dev_ctx.stream();
   float power = 1.0;
   VLOG(4) << "scale:" << scale << ", bias:" << bias

--- a/backends/npu/tests/unittests/test_expand_v2_op_npu.py
+++ b/backends/npu/tests/unittests/test_expand_v2_op_npu.py
@@ -18,7 +18,8 @@ import numpy as np
 
 from tests.op_test import OpTest
 import paddle.base as base
-from paddle.base import Program, program_guard
+from paddle.framework import in_pir_mode
+from paddle.pir_utils import test_with_pir_api
 import paddle
 
 paddle.enable_static()
@@ -262,18 +263,22 @@ class TesstExpandV2OpBool(TestExpandV2OpInteger):
 
 
 class TestExpandV2Error(unittest.TestCase):
+    @test_with_pir_api
     def test_errors(self):
-        with program_guard(Program(), Program()):
-            x1 = base.create_lod_tensor(
-                np.array([[-1]]), [[1]], paddle.CustomPlace("npu", 0)
-            )
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
             shape = [2, 2]
-            self.assertRaises(TypeError, paddle.tensor.expand, x1, shape)
-            x2 = paddle.static.data(name="x2", shape=[-1, 2], dtype="uint8")
-            self.assertRaises(TypeError, paddle.tensor.expand, x2, shape)
-            x3 = paddle.static.data(name="x3", shape=[-1, 2], dtype="bool")
-            x3.stop_gradient = False
-            self.assertRaises(ValueError, paddle.tensor.expand, x3, shape)
+            if not in_pir_mode():
+                x1 = base.create_lod_tensor(
+                    np.array([[-1]]), [[1]], paddle.CustomPlace("npu", 0)
+                )
+                self.assertRaises(TypeError, paddle.tensor.expand, x1, shape)
+            x2 = paddle.static.data(name="x2", shape=[-1, 4], dtype="bool")
+            x2.stop_gradient = False
+            self.assertRaises(ValueError, paddle.tensor.expand, x2, shape)
+            x2.stop_gradient = True
+            self.assertRaises(TypeError, paddle.tensor.expand, x2, 1)
 
 
 # Test python API

--- a/backends/npu/tests/unittests/test_transpose_op_npu.py
+++ b/backends/npu/tests/unittests/test_transpose_op_npu.py
@@ -173,6 +173,7 @@ class TestTransposeAPIWithNPUStroageFormat(unittest.TestCase):
         x_grad_expect = x.grad
 
         # fwd and bwd with storage format
+        paddle.base.set_flags({"FLAGS_use_stride_kernel": False})
         x_format = paddle.incubate._npu_identity(x, self.format)
         x_format.stop_gradient = False
         out_format = paddle.transpose(x_format, axis)


### PR DESCRIPTION
修改：
- scale_kernel.cc：ScaleKernel 的参数列表中，bias 的类型已由 float 改为 Scalar，参考：[#62598](https://github.com/PaddlePaddle/Paddle/pull/62598)；
- test_expand_v2_op_npu.py：expand 已支持 uint8 等类型，同步修改单测，参考：[#62849](https://github.com/PaddlePaddle/Paddle/pull/62849)；
- test_transpose_op_npu.py：transpose 已经支持 stride，默认调用 Paddle 主框架中的 transpose，只有 npu 的 transpose 支持非标准格式，故设置 FLAGS_use_stride_kernel 为 False 来调用 npu 上的 transpose。

相关单测已测试通过；
- test_elementwise_add_op_npu
- test_matmulv2_op_npu
- test_npu_identity_op
- test_multinomial_op_npu
- test_momentum_op_npu
- test_rms_norm_npu
- test_rope_npu
- test_transpose_op_npu
- test_unbind_op_npu
- test_expand_v2_op_npu
- test_flashattention_npu
- test_adadelta_op_npu
- test_LeNet_MNIST