### PR TITLE
[NPU] add custom_op commit

### DIFF
--- a/backends/npu/CMakeLists.txt
+++ b/backends/npu/CMakeLists.txt
@@ -125,6 +125,13 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "Git commit id is: ${GIT_HASH}")
 
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/custom_op
+  OUTPUT_VARIABLE CUSTOM_OP_GIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+message(STATUS "Custom op git commit id is: ${CUSTOM_OP_GIT_HASH}")
+
 # configure setup.py
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/setup.py)

--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -40,6 +40,7 @@ from .ops import *
 full_version  = '@PADDLE_VERSION@'
 cann_version  = '@ASCEND_TOOLKIT_VERSION@'
 git_commit_id = '@GIT_HASH@'
+custom_op_git_commit_id = '@CUSTOM_OP_GIT_HASH@'
 
 __all__ = ['version']
 
@@ -63,8 +64,9 @@ def version():
     """
     print('version:', full_version)
     print('commit:', git_commit_id)
+    print('custom_op commit:', custom_op_git_commit_id)
     print('cann:', cann_version)
-    return {'version': full_version, 'commit': git_commit_id, 'cann': cann_version}
+    return {'version': full_version, 'commit': git_commit_id, 'custom_op commit': custom_op_git_commit_id, 'cann': cann_version}
 '''
 
     with open(filename, 'w') as f:


### PR DESCRIPTION
add custom_op commit in paddle_custom_npu.npu.version()

当custom_op文件夹下存在git信息时，结果如下：
![e142e2588b7bc5dba0253940ed75b8f3](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/45005871/0fb7919b-012d-4470-b560-d1a218386c3e)


当custom_op文件夹下不存在git信息，custom_op commit与commit信息一致
![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/45005871/3881bb55-50ef-4db2-b364-cf0a0ceef6aa)
