### PR TITLE
[NPU]modify batchnorm op bug

### DIFF
--- a/backends/npu/kernels/batch_norm_kernel.cc
+++ b/backends/npu/kernels/batch_norm_kernel.cc
@@ -492,6 +492,9 @@ void BatchNormKernel(const Context& dev_ctx,
   double this_factor = 1. - momentum;
   double epsilon_d = epsilon;
 
+  saved_mean->Resize(mean_out->dims());
+  saved_variance->Resize(mean_out->dims());
+
   EXEC_NPU_CMD(aclnnBatchNorm,
                dev_ctx,
                transformed_x,


### PR DESCRIPTION
修复aclnnBatchNorm在ppyoloe静态图推理的问题：传入shape为空，data也为空的tensor
修改点：设置tensor的shape