### PR TITLE
[MLU] fix mlu argsort

### DIFF
--- a/backends/mlu/kernels/argsort_kernel.cc
+++ b/backends/mlu/kernels/argsort_kernel.cc
@@ -22,6 +22,7 @@ void ArgsortKernel(const Context& dev_ctx,
                    const phi::DenseTensor& in,
                    int axis,
                    bool descending,
+                   bool stable,
                    phi::DenseTensor* output,
                    phi::DenseTensor* indices) {
   const auto& sorted = true;
@@ -83,6 +84,7 @@ void ArgsortGradKernel(const Context& dev_ctx,
                        const phi::DenseTensor& out_grad,
                        int axis,
                        bool descending,
+                       bool stable,
                        phi::DenseTensor* in_grad) {
   dev_ctx.template Alloc<T>(in_grad);
 


### PR DESCRIPTION
MLU argsort 单测错误，是由于主框架 https://github.com/PaddlePaddle/Paddle/pull/63513 算子参数变化引入。