### PR TITLE
[NPU] fix atb core dump in dockerfile

### DIFF
--- a/backends/npu/cmake/external/ascend.cmake
+++ b/backends/npu/cmake/external/ascend.cmake
@@ -47,7 +47,7 @@ set_property(TARGET acl_op_compiler PROPERTY IMPORTED_LOCATION
 if(DEFINED ENV{ATB_HOME_PATH})
   set(ATB_HOME_DIR $ENV{ATB_HOME_PATH})
 else()
-  set(ATB_HOME_DIR ${ASCEND_DIR}/mindie/latest/mindie-rt/mindie-atb/atb)
+  set(ATB_HOME_DIR ${ASCEND_DIR}/atb/latest/atb)
 endif()
 
 set(ascend_atb_lib ${ATB_HOME_DIR}/lib/libatb.so)

--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
@@ -75,7 +75,6 @@ ENV HCCL_SECURITY_MODE=1
 ENV HCCL_BUFFSIZE=120
 
 # environment for PaddlePaddle
-ENV FLAGS_npu_jit_compile=0
 ENV FLAGS_npu_storage_format=0
 ENV FLAGS_use_stride_kernel=0
 ENV FLAGS_allocator_strategy=naive_best_fit

--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
@@ -81,9 +81,6 @@ ENV FLAGS_use_stride_kernel=0
 ENV FLAGS_allocator_strategy=naive_best_fit
 ENV PADDLE_XCCL_BACKEND=npu
 
-# environment for ATB
-ENV ATB_MATMUL_SHUFFLE_K_ENABLE=0
-
 # map this foler in docker run
 RUN rm -rf /usr/local/Ascend/driver
 

--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
@@ -48,12 +48,12 @@ COPY ${ASCEND_KLS} /usr/local/Ascend/
 RUN chmod +x ${ASCEND_KLS} && ./${ASCEND_KLS} --install --quiet && rm -rf ${ASCEND_KLS}
 
 # Install Ascend Transformer Boost
-ARG ASCEND_ATB=Ascend-mindie*linux*.run
+ARG ASCEND_ATB=Ascend-mindie-atb*linux*_abi1.run
 COPY ${ASCEND_ATB} /usr/local/Ascend/
 RUN . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     chmod +x ${ASCEND_ATB} && ./${ASCEND_ATB} --install --quiet && rm -rf ${ASCEND_ATB}
 # update env for mindie
-RUN echo "source /usr/local/Ascend/mindie/set_env.sh" >> /root/.bashrc
+RUN echo "source /usr/local/Ascend/atb/set_env.sh" >> /root/.bashrc
 
 # install post process ops
 COPY code-share /usr/local/Ascend/code-share/
@@ -79,6 +79,9 @@ ENV FLAGS_npu_storage_format=0
 ENV FLAGS_use_stride_kernel=0
 ENV FLAGS_allocator_strategy=naive_best_fit
 ENV PADDLE_XCCL_BACKEND=npu
+
+# environment for ATB
+ENV ATB_MATMUL_SHUFFLE_K_ENABLE=0
 
 # map this foler in docker run
 RUN rm -rf /usr/local/Ascend/driver

--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
@@ -75,6 +75,7 @@ ENV HCCL_SECURITY_MODE=1
 ENV HCCL_BUFFSIZE=120
 
 # environment for PaddlePaddle
+ENV FLAGS_npu_jit_compile=0
 ENV FLAGS_npu_storage_format=0
 ENV FLAGS_use_stride_kernel=0
 ENV FLAGS_allocator_strategy=naive_best_fit


### PR DESCRIPTION
先用如下命令将mindie run包解压

./Ascend-mindie_1.0.RC1_linux-x86_64.run --extract=./temp

解压之后获得如下目录

```
temp/
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi0.run
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi0.run.cms
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi0.run.crl
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi1.run # ======> 只需要这个run包进行安装即可
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi1.run.cms
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi1.run.crl
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi0.run
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi0.run.cms
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi0.run.crl
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi1.run
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi1.run.cms
├── Ascend-mindie-rt_1.0.RC1_linux-x86_64_abi1.run.crl
├── Ascend-mindie-service_1.0.RC1_linux-x86_64.run
├── Ascend-mindie-service_1.0.RC1_linux-x86_64.run.cms
├── Ascend-mindie-service_1.0.RC1_linux-x86_64.run.crl
├── Ascend-mindie-torch_1.0.RC1_linux-x86_64.tar.gz
├── Ascend-mindie-torch_1.0.RC1_linux-x86_64.tar.gz.cms
├── Ascend-mindie-torch_1.0.RC1_linux-x86_64.tar.gz.crl
├── install.sh
├── install.sh.cms
├── install.sh.crl
├── scripts
│   ├── uninstall.sh
│   ├── uninstall.sh.cms
│   └── uninstall.sh.crl
├── set_env.sh
├── set_env.sh.cms
├── set_env.sh.crl
├── version.info
├── version.info.cms
└── version.info.crl
```

将解压得到的 Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi1.run 拷贝出来到dockerfile目录下进行安装即可

```
backends/npu/tools/dockerfile/
├── Ascend-cann-kernels-910b_8.0.RC1_linux.run
├── Ascend-cann-toolkit_8.0.RC1_linux-x86_64.run
├── Ascend-mindie-atb_1.0.RC1_linux-x86_64_abi1.run
├── build-image.sh
├── code-share # 推理自定义算子库，源码 https://gitee.com/oliverWang213/code-share
└── Dockerfile.npu.ubuntu20.gcc84
```

在以上目录下运行 `bash -x build-image.sh` 即可构建NPU镜像。