### PR TITLE
[NPU] fix CANN 8.0.RC1 bug

### DIFF
--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu20.gcc84
@@ -39,6 +39,8 @@ COPY Ascend-cann-toolkit_${CANN_VERSION}_linux-*.run /usr/local/Ascend/
 RUN chmod +x Ascend-cann-toolkit_${CANN_VERSION}_linux-*.run && \
     ./Ascend-cann-toolkit_${CANN_VERSION}_linux-*.run --install --quiet && \
     rm -rf Ascend-cann-toolkit_${CANN_VERSION}_linux-*.run
+# fix bug in CANN 8.0.RC1
+RUN sed -i '205s/self.dim_3/self.ub_per_reser_number * self.dim_3/' /usr/local/Ascend/ascend-toolkit/8.0.RC1/opp/built-in/op_impl/ai_core/tbe/impl/dynamic/rotary_mul_grad.py
 # udpate envs for toolkit
 RUN echo "source /usr/local/Ascend/ascend-toolkit/set_env.sh" >> /root/.bashrc
 


### PR DESCRIPTION
CANN 8.0.RC1 存在BUG，根据华为昇腾同学建议，商发包修改下这段代码

![image](https://github.com/PaddlePaddle/PaddleCustomDevice/assets/16605440/e984af05-9975-4bbf-997a-6a147e5079bb)

文件：ops/built-in/tbe/impl/dynamic/rotary_mul_grad.py

行数：205行

self.burst.set_as((self.dim_3 + self.x_data_each_block - 1) // self.x_data_each_block)

-->

self.burst.set_as(

(self.ub_per_reser_number * self.dim_3 + self.x_data_each_block - 1) // self.x_data_each_block)


