### PR TITLE
[NPU] fix BN question

### DIFF
--- a/backends/npu/kernels/batch_norm_kernel.cc
+++ b/backends/npu/kernels/batch_norm_kernel.cc
@@ -530,8 +530,10 @@ void BatchNormKernel(const Context& dev_ctx,
     EXEC_NPU_CMD(aclnnMuls, dev_ctx, tmp_running_mean, momentum_f, *mean_out);
     EXEC_NPU_CMD(aclnnInplaceAdd, dev_ctx, *mean_out, *saved_mean, momentum_p);
 
-    EXEC_NPU_CMD(aclnnMuls, dev_ctx, tmp_running_var, momentum_f, *variance_out);
-    EXEC_NPU_CMD(aclnnInplaceAdd, dev_ctx, *variance_out, *saved_variance, momentum_p);
+    EXEC_NPU_CMD(
+        aclnnMuls, dev_ctx, tmp_running_var, momentum_f, *variance_out);
+    EXEC_NPU_CMD(
+        aclnnInplaceAdd, dev_ctx, *variance_out, *saved_variance, momentum_p);
     auto stream = dev_ctx.stream();
 
     const auto& adds_runner =

--- a/backends/npu/tools/disable_ut_npu_910b
+++ b/backends/npu/tools/disable_ut_npu_910b
@@ -1,5 +1,4 @@
 disable_ut_npu
-test_batch_norm_op_npu
 test_check_nan_inf_op_npu
 test_conv2d_op_npu
 test_conv3d_op_npu


### PR DESCRIPTION
nan occasionally occurs in the global mean and variance of batchnorm, which may be caused by the axpy kernel.