### PR TITLE
[CI] disable test_matmulv2_op_npu for now

### DIFF
--- a/backends/npu/tools/disable_ut_npu_910b
+++ b/backends/npu/tools/disable_ut_npu_910b
@@ -9,3 +9,4 @@ test_fused_matmul_bias_op_npu
 test_histogram_op_npu
 test_kldiv_loss_op_npu
 test_zero_dim_tensor_npu
+test_matmulv2_op_npu


### PR DESCRIPTION
disable test_matmulv2_op_npu for now (raise accuracy error after upgrading numpy)