### PR TITLE
[MLU] Fix reduce_mean bug

### DIFF
--- a/backends/mlu/kernels/funcs/reduce_op.h
+++ b/backends/mlu/kernels/funcs/reduce_op.h
@@ -38,7 +38,7 @@ void MLUReduceOp(const Context& dev_ctx,
   const auto& input_dim_size = x.dims().size();
   std::vector<int> reduce_dims;
   VLOG(3) << "ReduceOp keep_dim " << keep_dim;
-  if (!keep_dim && dims.size() == 0) reduce_all = true;
+  if (dims.size() == 0) reduce_all = true;
   if (reduce_all) {
     for (size_t i = 0; i < input_dims.size(); i++) {
       reduce_dims.push_back(static_cast<int>(i));


### PR DESCRIPTION
fix reduce mean bug in this case：
```python
x = paddle.randn([2, 3])
mea = x.mean(keepdim=True) # should be with shape [1, 1], but got error
```