### PR TITLE
[Adam/AdamW] Update adamw.py

### DIFF
--- a/backends/gcu/tests/unittests_legacy/test_merged_adam_op_gcu.py
+++ b/backends/gcu/tests/unittests_legacy/test_merged_adam_op_gcu.py
@@ -58,7 +58,7 @@ def run_adam_op(
 
     if not use_merged:
         for i in range(len(param_vars)):
-            _, _, _, _, _, _ = _legacy_C_ops.adam(
+            _, _, _, _, _, *_ = _legacy_C_ops.adam(
                 param_vars[i],
                 grad_vars[i],
                 lr_vars[i],

--- a/backends/mlu/tests/unittests/test_adamw_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_adamw_op_mlu.py
@@ -81,7 +81,7 @@ def adamw_wrapper(
     with_decay=True,
     lazy_mode=False,
 ):
-    _, _, _, _, _, _ = paddle._C_ops.adamw_(
+    _, _, _, _, _, *_ = paddle._C_ops.adamw_(
         param,
         grad,
         lr,
@@ -375,7 +375,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
         ref_moment_2 = moment2.astype(paddle.float32)
 
         # reference code
-        _, _, _, _, _, _ = paddle._C_ops.adamw_(
+        _, _, _, _, _, *_ = paddle._C_ops.adamw_(
             ref_param,
             main_grad,
             lr,
@@ -398,7 +398,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
         )
 
         if use_main_grad:
-            _, _, _, _, _, _ = paddle._C_ops.adamw_(
+            _, _, _, _, _, *_ = paddle._C_ops.adamw_(
                 param,
                 main_grad,
                 lr,
@@ -426,7 +426,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
                 master_weight.numpy(), ref_param.numpy(), atol=1e-5
             )
         else:
-            _, _, _, _, _, _ = paddle._C_ops.adamw_(
+            _, _, _, _, _, *_ = paddle._C_ops.adamw_(
                 param,
                 grad,
                 lr,
@@ -973,7 +973,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
         ref_moment_2 = moment2.astype(paddle.float32)
 
         # reference code
-        _, _, _, _, _, _ = paddle._C_ops.adamw_(
+        _, _, _, _, _, *_ = paddle._C_ops.adamw_(
             ref_param,
             main_grad,
             lr,
@@ -996,7 +996,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
         )
 
         if use_main_grad:
-            _, _, _, _, _, _ = paddle._C_ops.adamw_(
+            _, _, _, _, _, *_ = paddle._C_ops.adamw_(
                 param,
                 main_grad,
                 lr,
@@ -1024,7 +1024,7 @@ class TestAdamWOpMultiPrecisonWithMainGrad(unittest.TestCase):
                 master_weight.numpy(), ref_param.numpy(), atol=1e-4
             )
         else:
-            _, _, _, _, _, _ = paddle._C_ops.adamw_(
+            _, _, _, _, _, *_ = paddle._C_ops.adamw_(
                 param,
                 grad,
                 lr,

--- a/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_merged_adam_op_mlu.py
@@ -55,7 +55,7 @@ def run_adam_op(
 
     if not use_merged:
         for i in range(len(param_vars)):
-            _, _, _, _, _, _ = _C_ops.adamw_(
+            _, _, _, _, _, *_ = _C_ops.adamw_(
                 param_vars[i],
                 grad_vars[i],
                 lr_vars[i],

--- a/backends/sdaa/sdaa_ext/python/custom_parallel/Adam.py
+++ b/backends/sdaa/sdaa_ext/python/custom_parallel/Adam.py
@@ -292,7 +292,7 @@ class DistributeAdam(Adam, DistributeOptimizer):
             moment1_ = moment1
             moment2_ = moment2
 
-        _, _, _, _, _, _ = paddle._C_ops.adam_(
+        _, _, _, _, _, *_ = paddle._C_ops.adam_(
             param_,
             grad_,
             lr,

--- a/backends/sdaa/sdaa_ext/python/custom_parallel/AdamW.py
+++ b/backends/sdaa/sdaa_ext/python/custom_parallel/AdamW.py
@@ -294,7 +294,7 @@ class DistributeAdamW(AdamW, DistributeOptimizer):
             moment1_ = moment1
             moment2_ = moment2
 
-        _, _, _, _, _, _ = paddle._C_ops.adamw_(
+        _, _, _, _, _, *_ = paddle._C_ops.adamw_(
             param_,
             grad_,
             lr,

--- a/backends/sdaa/tests/unittests/test_adam_op_sdaa.py
+++ b/backends/sdaa/tests/unittests/test_adam_op_sdaa.py
@@ -37,7 +37,7 @@ def adam_wrapper(
     epsilon=1e-4,
     lazy_mode=False,
 ):
-    _, _, _, _, _, _ = paddle._C_ops.adam_(
+    _, _, _, _, _, *_ = paddle._C_ops.adam_(
         param,
         grad,
         LearningRate,

--- a/backends/sdaa/tests/unittests/test_merged_adam_op_sdaa.py
+++ b/backends/sdaa/tests/unittests/test_merged_adam_op_sdaa.py
@@ -69,7 +69,7 @@ def run_adam_op(
     if not use_merged:
         paddle.set_device("cpu")
         for i in range(len(param_vars)):
-            _, _, _, _, _, _ = _legacy_C_ops.adam(
+            _, _, _, _, _, *_ = _legacy_C_ops.adam(
                 param_vars[i],
                 grad_vars[i],
                 lr_vars[i],


### PR DESCRIPTION
`amsgrad` will be supported in <https://github.com/PaddlePaddle/Paddle/pull/68079> and added into parameter list of those two optimizers, therefore number of return value of `_C_ops.XX` will be incresed by 1. So `_` need to be replaced with `*_` for `compatibility`.