### PR TITLE
[NPU] fix gridsample name error & speed up groupnorm

### DIFF
--- a/backends/npu/kernels/grid_sample_kernel.cc
+++ b/backends/npu/kernels/grid_sample_kernel.cc
@@ -350,7 +350,7 @@ void GridSampleGradKernel(const Context& dev_ctx,
       if (find_it != paddlingModeMap.end()) {
         paddle_mode_to_int = find_it->second;
       }
-      EXEC_NPU_CMD(aclnnGridSamplerd3DBackward,
+      EXEC_NPU_CMD(aclnnGridSampler3DBackward,
                    dev_ctx,
                    out_grad,
                    x,
@@ -374,7 +374,7 @@ void GridSampleGradKernel(const Context& dev_ctx,
       if (find_it != paddlingModeMap.end()) {
         paddle_mode_to_int = find_it->second;
       }
-      EXEC_NPU_CMD(aclnnGridSamplerd3DBackward,
+      EXEC_NPU_CMD(aclnnGridSampler3DBackward,
                    dev_ctx,
                    out_grad,
                    x,

--- a/backends/npu/kernels/group_norm_kernel.cc
+++ b/backends/npu/kernels/group_norm_kernel.cc
@@ -364,13 +364,15 @@ void AclnnGroupNormKernel(const Context& dev_ctx,
     scale_tensor = scale.get();
   } else {
     scale_tensor.Resize({C});
-    FillNpuTensorWithConstant<T>(&scale_tensor, dev_ctx, static_cast<T>(1));
+    dev_ctx.template Alloc<T>(&scale_tensor);
+    EXEC_NPU_CMD(aclnnInplaceOne, dev_ctx, scale_tensor);
   }
   if (bias) {
     bias_tensor = bias.get();
   } else {
     bias_tensor.Resize({C});
-    FillNpuTensorWithConstant<T>(&bias_tensor, dev_ctx, static_cast<T>(0));
+    dev_ctx.template Alloc<T>(&bias_tensor);
+    EXEC_NPU_CMD(aclnnInplaceZero, dev_ctx, bias_tensor);
   }
   double eps = static_cast<double>(epsilon);
   EXEC_NPU_CMD(aclnnGroupNorm,

--- a/backends/npu/kernels/sigmoid_cross_entropy_with_logits_kernel.cc
+++ b/backends/npu/kernels/sigmoid_cross_entropy_with_logits_kernel.cc
@@ -51,12 +51,14 @@ void SigmoidCrossEntropyWithLogitsKernel(
   phi::DenseTensor pos_weight_tensor;
   phi::DenseTensorMeta weight_tensor_meta = {phi::DataType::FLOAT32, x.dims()};
   weight_tensor.set_meta(weight_tensor_meta);
-  FillNpuTensorWithConstant<float>(&weight_tensor, dev_ctx, 1.0);
+  dev_ctx.template Alloc<float>(&weight_tensor);
+  EXEC_NPU_CMD(aclnnInplaceOne, dev_ctx, weight_tensor);
   weight_tensor.Resize(x.dims());
 
   if (pos_weight.get_ptr() == nullptr) {
     pos_weight_tensor.set_meta(weight_tensor_meta);
-    FillNpuTensorWithConstant<float>(&pos_weight_tensor, dev_ctx, 1.0);
+    dev_ctx.template Alloc<float>(&pos_weight_tensor);
+    EXEC_NPU_CMD(aclnnInplaceOne, dev_ctx, pos_weight_tensor);
     pos_weight_tensor.Resize(x.dims());
   } else {
     pos_weight_tensor = *pos_weight.get_ptr();

--- a/backends/npu/kernels/sigmoid_cross_entropy_with_logits_kernel.cc
+++ b/backends/npu/kernels/sigmoid_cross_entropy_with_logits_kernel.cc
@@ -51,14 +51,12 @@ void SigmoidCrossEntropyWithLogitsKernel(
   phi::DenseTensor pos_weight_tensor;
   phi::DenseTensorMeta weight_tensor_meta = {phi::DataType::FLOAT32, x.dims()};
   weight_tensor.set_meta(weight_tensor_meta);
-  dev_ctx.template Alloc<float>(&weight_tensor);
-  EXEC_NPU_CMD(aclnnInplaceOne, dev_ctx, weight_tensor);
+  FillNpuTensorWithConstant<float>(&weight_tensor, dev_ctx, 1.0);
   weight_tensor.Resize(x.dims());
 
   if (pos_weight.get_ptr() == nullptr) {
     pos_weight_tensor.set_meta(weight_tensor_meta);
-    dev_ctx.template Alloc<float>(&pos_weight_tensor);
-    EXEC_NPU_CMD(aclnnInplaceOne, dev_ctx, pos_weight_tensor);
+    FillNpuTensorWithConstant<float>(&pos_weight_tensor, dev_ctx, 1.0);
     pos_weight_tensor.Resize(x.dims());
   } else {
     pos_weight_tensor = *pos_weight.get_ptr();


### PR DESCRIPTION
1. fix gridsample3d aclnn name error.
2.  FillNpuTensorWithConstant<T>(&scale_tensor, dev_ctx, static_cast<T>(1)); is slow, when fill 0 or 1, we can use aclnnInplaceZero or aclnnInplaceOne.