### PR TITLE
[GCU] Remove repeated actions in concat kernel

### DIFF
--- a/backends/gcu/kernels/concat_kernel.cc
+++ b/backends/gcu/kernels/concat_kernel.cc
@@ -23,19 +23,6 @@ void ConcatKernel(const Context& dev_ctx,
                   const phi::Scalar& axis_scalar,
                   phi::DenseTensor* out) {
   PADDLE_GCU_KERNEL_TRACE("concat");
-  int64_t dim = axis_scalar.to<int64_t>();
-  if (common::contain_unknown_dim(out->dims())) {
-    std::vector<phi::MetaTensor> x_meta_vec;
-    x_meta_vec.reserve(ins.size());
-    std::vector<const phi::MetaTensor*> x_metas(ins.size(), nullptr);
-    for (size_t i = 0; i < ins.size(); ++i) {
-      x_meta_vec.emplace_back(*ins[i]);
-      x_metas[i] = &x_meta_vec[i];
-    }
-    phi::MetaTensor meta_out(*out);
-    phi::ConcatInferMeta(x_metas, dim, &meta_out);
-  }
-
   dev_ctx.template Alloc<T>(out);
 
   if (LaunchAOTKernel()) {
@@ -67,7 +54,7 @@ void ConcatKernel(const Context& dev_ctx,
       }
       in_tensors.emplace_back(CreateTopsatenTensor(tensor));
     }
-
+    int64_t dim = axis_scalar.to<int64_t>();
     if (dim < 0 && !ins.empty()) {
       dim += ins[0]->dims().size();
     }


### PR DESCRIPTION
删除```concat kernel```中的```meta```信息推导逻辑，相关功能已在```phi::ConcatInferMeta```中完成