### PR TITLE
【NPU】 Acceleration: adam, gather_nd, avgpool2dbackward.

### DIFF
--- a/backends/npu/kernels/adam_kernel.cc
+++ b/backends/npu/kernels/adam_kernel.cc
@@ -157,13 +157,9 @@ void AdamImplKernel(const Context& dev_ctx,
     phi::DenseTensor param_fp32;
     param_fp32.Resize(calc_param->dims());
     dev_ctx.template Alloc<MPDType>(&param_fp32);
-    const auto& cast_runner = NpuOpRunner(
-        "Cast",
-        {param},
-        {param_fp32},
-        {{"dst_type",
-          static_cast<int>(cpp_type_to_acl_dtype<MPDType>::value())}});
-    cast_runner.Run(stream);
+
+    custom_kernel::CastKernel<T, Context>(
+        dev_ctx, param, param_fp32.dtype(), &param_fp32);
 
     const auto& runner = NpuOpRunner("ApplyAdamD",
                                      {

--- a/backends/npu/kernels/adam_kernel.cc
+++ b/backends/npu/kernels/adam_kernel.cc
@@ -16,7 +16,7 @@
 #include "kernels/funcs/npu_op_runner.h"
 
 namespace custom_kernel {
-
+ 
 template <typename T, typename Context>
 void CastKernel(const Context& dev_ctx,
                 const phi::DenseTensor& x,

--- a/backends/npu/kernels/adam_kernel.cc
+++ b/backends/npu/kernels/adam_kernel.cc
@@ -16,7 +16,7 @@
 #include "kernels/funcs/npu_op_runner.h"
 
 namespace custom_kernel {
- 
+
 template <typename T, typename Context>
 void CastKernel(const Context& dev_ctx,
                 const phi::DenseTensor& x,

--- a/backends/npu/kernels/pool2d_kernel.cc
+++ b/backends/npu/kernels/pool2d_kernel.cc
@@ -497,7 +497,8 @@ void Pool2dGradKernel(const Context& dev_ctx,
                                                         padding_algorithm,
                                                         in_x_grad)));
   // aclnnAvgPool2dBackward do not support padding_algorithm = "SAME"
-  if (pooling_type == "max" || padding_algorithm == "SAME" || adaptive == false) {
+  if (pooling_type == "max" || padding_algorithm == "SAME" ||
+      adaptive == false) {
     return custom_kernel::AclopPool2dGradKernel<T, Context>(dev_ctx,
                                                             in_x,
                                                             out,

--- a/backends/npu/kernels/pool2d_kernel.cc
+++ b/backends/npu/kernels/pool2d_kernel.cc
@@ -497,7 +497,7 @@ void Pool2dGradKernel(const Context& dev_ctx,
                                                         padding_algorithm,
                                                         in_x_grad)));
   // aclnnAvgPool2dBackward do not support padding_algorithm = "SAME"
-  if (pooling_type == "max" || padding_algorithm == "SAME") {
+  if (pooling_type == "max" || padding_algorithm == "SAME" || adaptive == false) {
     return custom_kernel::AclopPool2dGradKernel<T, Context>(dev_ctx,
                                                             in_x,
                                                             out,


### PR DESCRIPTION
1.  adam: modify cast from aclop to aclnn.
2.  gather_nd: modify broadcastto from aclop to aclnn.
3.  avgpool2dbackward: The avg_pool2d_backward and adaptive_avg_2dpool2d_backward operators use their own fast paths.