### PR TITLE
[GCU] Add dockerfile and some updates

### DIFF
--- a/backends/gcu/README.md
+++ b/backends/gcu/README.md
@@ -75,9 +75,9 @@ python -c "import paddle; print(paddle.device.get_all_custom_device_type())"
 # 2) Check currently installed version.
 python -c "import paddle_custom_device; paddle_custom_device.gcu.version()"
 # Expect to get output like this.
-version: 0.0.0.9e03b0a
-commit: 9e03b0a42a530d07fb60e141ee618fc02595bd96
-tops-sdk: 2.5.20231128
+version: 3.0.0b1+3.1.0.20241113
+commit: f05823682bf607deb1b4adf9a9309f81225958fe
+TopsPlatform: 1.2.0.301
 
 # 3) Unit test, compiled with -DWITH_TESTING=ON and executed in the build directory.
 ctest

--- a/backends/gcu/README.md
+++ b/backends/gcu/README.md
@@ -7,11 +7,39 @@ Please refer to the following steps to compile, install and verify the hardware 
 ## Prepare environment and source code
 
 ```bash
-# 1) Pull PaddlePaddle development docker image，and install Enflame GCU development kit.
+# 1) Pull the image. Note that this image is only for development environment
+#    and does not contain precompiled PaddlePaddle installation package.
+#    The build script and dockerfile of this image are located in the tools/dockerfile directory.
+#    Note: This docker is in the release process now. (20241113)
+registry.baidubce.com/device/paddle-gcu:topsrider3.2.109-ubuntu20-x86_64-gcc84
 
-# 2) Clone the source code.
+# 2) Refer to the following command to start the container.
+docker run --name paddle-gcu-dev -v /home:/home \
+    --network=host --ipc=host -it --privileged \
+    registry.baidubce.com/device/paddle-gcu:topsrider3.2.109-ubuntu20-x86_64-gcc84 /bin/bash
+
+# 3) Clone the source code.
 git clone https://github.com/PaddlePaddle/PaddleCustomDevice
 cd PaddleCustomDevice
+
+# 4) Prepare the machine and initialize the environment (only required for device used for execution).
+# 4a) Get the driver: The full software package is placed in docker in advance
+#     and needs to be copied to the directory outside docker, such as: /home/workspace/deps/.
+mkdir -p /home/workspace/deps/ && cp /root/TopsRider_i3x_*/TopsRider_i3x_*_deb_amd64.run /home/workspace/deps/
+
+# 4b) Verify whether the machine has Enflame S60 accelerators.
+#     Check whether the following command has output in the system environment.
+#     Note: You need to press Ctrl+D to exit docker.
+#     The following initialization environment operations are all performed in the system environment.
+lspci | grep S60
+
+# 4c) Install the driver.
+cd /home/workspace/deps/
+bash TopsRider_i3x_*_deb_amd64.run --driver --no-auto-load
+
+# 4d) After the driver is installed, refer to the following command to re-enter docker.
+docker start paddle-gcu-dev
+docker exec -it paddle-gcu-dev bash
 ```
 
 ## PaddleCustomDevice Installation and Verification
@@ -20,7 +48,7 @@ cd PaddleCustomDevice
 
 ```bash
 # 1) Enter the hardware backend (Enflame GCU) directory.
-cd backends/gcu
+cd PaddleCustomDevice/backends/gcu
 
 # 2) Before compiling, you need to ensure that the PaddlePaddle installation package is installed in the environment.
 #    Just install the PaddlePaddle CPU version directly.

--- a/backends/gcu/README_cn.md
+++ b/backends/gcu/README_cn.md
@@ -7,11 +7,35 @@
 ## 环境准备与源码同步
 
 ```bash
-# 1) 获取PaddlePaddle Docker镜像，并安装燧原GCU软件栈
+# 1) 拉取镜像，注意此镜像仅为开发环境，镜像中不包含预编译的飞桨安装包
+#    此镜像的构建脚本与dockerfile位于tools/dockerfile目录下
+#    注意： 此docker正在发布流程中(20241113)
+registry.baidubce.com/device/paddle-gcu:topsrider3.2.109-ubuntu20-x86_64-gcc84
 
-# 2) 克隆PaddleCustomDevice源码
+# 2) 参考如下命令启动容器
+docker run --name paddle-gcu-dev -v /home:/home \
+    --network=host --ipc=host -it --privileged \
+    registry.baidubce.com/device/paddle-gcu:topsrider3.2.109-ubuntu20-x86_64-gcc84 /bin/bash
+
+# 3) 克隆PaddleCustomDevice源码
 git clone https://github.com/PaddlePaddle/PaddleCustomDevice
 cd PaddleCustomDevice
+
+# 4) 机器准备，初始化环境(仅用于执行的设备需要)
+# 4a) 驱动获取：docker内提前放置了全量软件包，需拷贝至docker外目录，如：/home/workspace/deps/
+mkdir -p /home/workspace/deps/ && cp /root/TopsRider_i3x_*/TopsRider_i3x_*_deb_amd64.run /home/workspace/deps/
+
+# 4b) 验证机器是否插有燧原S60加速卡，系统环境下查看如下命令是否有输出
+#     注：需Ctrl+D退出docker， 以下初始化环境相关操作均在系统环境下执行
+lspci | grep S60
+
+# 4c) 安装驱动
+cd /home/workspace/deps/
+bash TopsRider_i3x_*_deb_amd64.run --driver --no-auto-load
+
+# 4d) 驱动安装完成后重新进入docker，参考如下命令
+docker start paddle-gcu-dev
+docker exec -it paddle-gcu-dev bash
 ```
 
 ## PaddleCustomDevice安装与运行
@@ -20,7 +44,7 @@ cd PaddleCustomDevice
 
 ```bash
 # 1) 进入硬件后端(燧原GCU)目录
-cd backends/gcu
+cd PaddleCustomDevice/backends/gcu
 
 # 2) 编译之前需确保环境下装有飞桨安装包，直接安装飞桨CPU版本即可
 python -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/

--- a/backends/gcu/README_cn.md
+++ b/backends/gcu/README_cn.md
@@ -70,9 +70,9 @@ python -c "import paddle; print(paddle.device.get_all_custom_device_type())"
 # 2) 检查当前安装版本
 python -c "import paddle_custom_device; paddle_custom_device.gcu.version()"
 # 预期得到类似以下的输出结果
-version: 0.0.0.9e03b0a
-commit: 9e03b0a42a530d07fb60e141ee618fc02595bd96
-tops-sdk: 2.5.20231128
+version: 3.0.0b1+3.1.0.20241113
+commit: f05823682bf607deb1b4adf9a9309f81225958fe
+TopsPlatform: 1.2.0.301
 
 # 3) 单元测试，带上-DWITH_TESTING=ON编译后在build目录下执行
 ctest

--- a/backends/gcu/cmake/external/gcu.cmake
+++ b/backends/gcu/cmake/external/gcu.cmake
@@ -44,7 +44,7 @@ set(GCU_LIBS
     ${TOPSATENOP_LIB}
     -Wl,--as-needed)
 
-set(VERSION_REGEX "( [0-9]+\.[0-9]+\.(RC)?[0-9]*) ")
+set(VERSION_REGEX "( [0-9]+\.[0-9]+\.[0-9]+\.(RC)?[0-9]*) ")
 macro(find_gcu_version component)
   execute_process(
     COMMAND dpkg -l | grep ${component}
@@ -53,7 +53,13 @@ macro(find_gcu_version component)
     RESULT_VARIABLE VERSION_INFO_RESULT
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT ${SRC_VERSION_INFO})
-    string(REGEX MATCH ${VERSION_REGEX} VERSION_CONTENTS "${SRC_VERSION_INFO}")
+    message(STATUS "${component} SRC_VERSION_INFO is ${SRC_VERSION_INFO}")
+    set(VERSION_REGEX_FILTER
+        "(${component})( +[0-9]+\.[0-9]+\.[0-9]+\.(RC)?[0-9]*) ")
+    string(REGEX MATCH ${VERSION_REGEX_FILTER} VERSION_CONTENTS_FILTER
+                 "${SRC_VERSION_INFO}")
+    string(REGEX MATCH ${VERSION_REGEX} VERSION_CONTENTS
+                 "${VERSION_CONTENTS_FILTER}")
     string(STRIP "${VERSION_CONTENTS}" VERSION_STR)
     set(COMPONENT_VERSION ${VERSION_STR})
   else()
@@ -63,5 +69,5 @@ macro(find_gcu_version component)
   set(TOPS_VERSION ${COMPONENT_VERSION})
 endmacro()
 
-find_gcu_version("tops-sdk")
+find_gcu_version("topsruntime")
 message(STATUS "TOPS_VERSION is ${TOPS_VERSION}")

--- a/backends/gcu/setup.py.in
+++ b/backends/gcu/setup.py.in
@@ -58,7 +58,7 @@ def write_version_py(filename='python/paddle_custom_device/gcu/__init__.py'):
     cnt = '''# THIS FILE IS GENERATED FROM PADDLEPADDLE SETUP.PY
 #
 full_version  = '@OUTPUT_PADDLE_PACKAGE_VERSION@'
-sdk_version  = '@TOPS_VERSION@'
+tops_version  = '@TOPS_VERSION@'
 git_commit_id = '@GIT_HASH@'
 
 __all__ = ['version']
@@ -77,13 +77,13 @@ def version():
             import paddle_custom_device
 
             paddle_custom_device.gcu.version()
-            # version: 0.0.0.9e03b0a
-            # commit: 9e03b0a42a530d07fb60e141ee618fc02595bd96
-            # tops-sdk: 2.5.20231128
+            # version: 3.0.0b1+3.1.0.20241113
+            # commit: f05823682bf607deb1b4adf9a9309f81225958fe
+            # TopsPlatform: 1.2.0.301
     """
     print('version:', full_version)
     print('commit:', git_commit_id)
-    print('tops-sdk:', sdk_version)
+    print('TopsPlatform:', tops_version)
 '''
     dirname = os.path.dirname(filename)
     if not os.path.exists(dirname):

--- a/backends/gcu/tests/CMakeLists.txt
+++ b/backends/gcu/tests/CMakeLists.txt
@@ -22,12 +22,9 @@ function(py_test_modules TARGET_NAME RUN_JIT_KERNELS)
   add_test(
     NAME ${TARGET_NAME}
     COMMAND
-      ${CMAKE_COMMAND} -E env
-      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle_custom_device/
-      PYTHONPATH=${PYTHON_SOURCE_DIR}:${PYTHON_SOURCE_DIR}/tests:$ENV{PYTHONPATH}
-      PADDLE_GCU_USE_JIT_KERNELS_ONLY=${RUN_JIT_KERNELS}
+      ${CMAKE_COMMAND} -E env PADDLE_GCU_USE_JIT_KERNELS_ONLY=${RUN_JIT_KERNELS}
       FLAGS_use_stride_kernel=false ${py_test_modules_ENVS} python
-      ${PYTHON_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
+      ${CMAKE_BINARY_DIR}/tests/${py_test_modules_MODULES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
   if(py_test_modules_SERIAL)

--- a/backends/gcu/tests/fuse_pass/CMakeLists.txt
+++ b/backends/gcu/tests/fuse_pass/CMakeLists.txt
@@ -19,7 +19,7 @@ file(
 string(REPLACE ".py" "" TEST_FUSE_PASSES "${TEST_FUSE_PASSES}")
 
 foreach(TEST_PASS ${TEST_FUSE_PASSES})
-  py_test_modules(${TEST_PASS} true MODULES ${TEST_PASS})
+  py_test_modules(${TEST_PASS} false MODULES fuse_pass/${TEST_PASS}.py)
   message(STATUS "with fuse pass: ${TEST_PASS}")
 endforeach()
 

--- a/backends/gcu/tests/unittests/CMakeLists.txt
+++ b/backends/gcu/tests/unittests/CMakeLists.txt
@@ -19,7 +19,7 @@ file(
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
 foreach(TEST_OP ${TEST_OPS})
-  py_test_modules(${TEST_OP} false MODULES ${TEST_OP})
+  py_test_modules(${TEST_OP} false MODULES unittests/${TEST_OP}.py)
   message(STATUS "with op unittest: ${TEST_OP}")
 endforeach()
 

--- a/backends/gcu/tests/unittests_legacy/CMakeLists.txt
+++ b/backends/gcu/tests/unittests_legacy/CMakeLists.txt
@@ -19,7 +19,7 @@ file(
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
 foreach(TEST_OP ${TEST_OPS})
-  py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+  py_test_modules(${TEST_OP} false MODULES unittests_legacy/${TEST_OP}.py)
   message(STATUS "with op unittest: ${TEST_OP}")
 endforeach()
 

--- a/backends/gcu/tools/dockerfile/Dockerfile.gcu.ubuntu20.gcc84
+++ b/backends/gcu/tools/dockerfile/Dockerfile.gcu.ubuntu20.gcc84
@@ -1,0 +1,44 @@
+# Docker Image for PaddlePaddle GCU
+
+FROM registry.baidubce.com/device/paddle-cpu:ubuntu20-x86_64-gcc84-py310
+LABEL maintainer="PaddlePaddle Authors <paddle-dev@baidu.com>"
+
+# version and link for gcu packages
+ARG TOPS_RIDER_VERSION
+ARG TOPS_RIDER_PACKAGE_LINK
+
+# install base packages
+RUN apt-get update -y && apt-get install -y zlib1g zlib1g-dev libsqlite3-dev openssl libssl-dev libffi-dev libbz2-dev \
+    libxslt1-dev unzip pciutils net-tools libblas-dev gfortran libblas3 liblapack-dev liblapack3 libopenblas-dev
+
+RUN pip install --upgrade pip setuptools wheel && pip install ddt
+
+# install Enflame GCU development kit
+RUN rm -rf /tmp/TopsRider_i3x_*.run && mkdir -p ~/TopsRider_i3x_${TOPS_RIDER_VERSION} && \
+    cd /tmp && wget ${TOPS_RIDER_PACKAGE_LINK} && \
+    bash TopsRider_i3x_${TOPS_RIDER_VERSION}_deb_amd64.run -x && \
+    cd TopsRider_i3x_${TOPS_RIDER_VERSION}_deb_amd64 && \
+    find -name TopsPlatform_*_deb_amd64.run -exec bash '{}' --no-auto-load -y ';' && \
+    dpkg -i ./sdk/topsfactor_*.deb ./sdk/tops-sdk_*.deb && \
+    dpkg -i ./parallel_communication_toolkit/eccl_*.deb ./ai_hpc_sdk/topsaten_*.deb && \
+    cd /tmp && \
+    mv TopsRider_i3x_${TOPS_RIDER_VERSION}_deb_amd64.run ~/TopsRider_i3x_${TOPS_RIDER_VERSION} && \
+    rm -rf TopsRider_i3x_${TOPS_RIDER_VERSION}_deb_amd64
+
+# udpate envs
+ENV TOPS_HOME=/opt/tops
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TOPS_HOME/lib
+
+# environment for paddlepaddle-gcu
+ENV FLAGS_use_stride_kernel=false
+ENV FLAGS_allocator_strategy=auto_growth
+ENV FLAGS_auto_growth_chunk_size_in_mb=512
+ENV FLAGS_use_stream_safe_cuda_allocator=false
+ENV PADDLE_XCCL_BACKEND=gcu
+ENV PADDLE_RUN_ASYNC=true
+
+# Clean
+RUN apt-get clean -y
+RUN pip cache purge
+
+EXPOSE 22

--- a/backends/gcu/tools/dockerfile/build-image.sh
+++ b/backends/gcu/tools/dockerfile/build-image.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Usage:
+# bash build-image.sh ${TOPS_RIDER_VERSION} ${TOPS_RIDER_PACKAGE_LINK}
+
+TOPS_RIDER_VERSION=${1:-3.2.109} # default 3.2.109
+
+# Please contact Enflame (Email: developer-enflame@enflame-tech.com) to
+# obtain software driver packages and other assistance.
+TOPS_RIDER_PACKAGE_LINK=${2}
+
+if [ $(uname -i) == 'x86_64' ]; then
+  docker pull registry.baidubce.com/device/paddle-cpu:ubuntu20-x86_64-gcc84-py310
+  docker build --network=host -f Dockerfile.gcu.ubuntu20.gcc84 \
+       --build-arg TOPS_RIDER_VERSION=${TOPS_RIDER_VERSION} \
+       --build-arg TOPS_RIDER_PACKAGE_LINK=${TOPS_RIDER_PACKAGE_LINK} \
+       --build-arg http_proxy=${proxy} \
+       --build-arg https_proxy=${proxy} \
+       --build-arg no_proxy=bcebos.com \
+       -t registry.baidubce.com/device/paddle-gcu:topsrider${TOPS_RIDER_VERSION}-ubuntu20-x86_64-gcc84 .
+#   docker push registry.baidubce.com/device/paddle-gcu:topsrider${TOPS_RIDER_VERSION}-ubuntu20-x86_64-gcc84
+else
+  echo "Os $(uname -i) is not supported."
+fi


### PR DESCRIPTION
提交的主要内容：

- 新增`paddle-gcu`的`docker`镜像构建脚本和`dockerfile`；
- 更新`README`，描述基于预编译发布的`docker`镜像进行编译和验证的流程；
- 优化了单元测试的执行流程，缩短执行路径以减少其依赖项；
- 调整了安装信息的展示，修复了版本数据获取结果不正确的问题。

**注：`paddle-gcu`镜像已通过`EGC`提供，尚未发布到百度云端。**