### PR TITLE
[INTEL_HPU] add initial profiling support.

### DIFF
--- a/backends/intel_hpu/CMakeLists.txt
+++ b/backends/intel_hpu/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}
                     ${CMAKE_SOURCE_DIR}/kernels /usr/include/habanalabs)
 link_directories(${PADDLE_LIB_DIR} /usr/lib/habanalabs)
 
-add_definitions(-std=c++14)
+add_definitions(-std=c++17)
 
 file(
   GLOB_RECURSE PLUGIN_SRCS

--- a/backends/intel_hpu/runtime/runtime.h
+++ b/backends/intel_hpu/runtime/runtime.h
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/device_ext.h"
 #include "runtime/flags.h"
 #include "utils/hpu_helper.h"
+#include "utils/hpu_tracer.h"
 
 #define CHECK_HCCL_STATUS(x)                                            \
   {                                                                     \

--- a/backends/intel_hpu/tests/test_profiler.py
+++ b/backends/intel_hpu/tests/test_profiler.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.profiler as profiler
+import paddle
+from paddle.static import InputSpec
+
+paddle.set_device("intel_hpu")
+
+BATCH_SIZE = 1
+T = 2
+H = 16
+
+
+class ADDMUL(paddle.nn.Layer):
+    def __init__(self):
+        super(ADDMUL, self).__init__()
+
+    def forward(self, inputX, inputY, bias):
+        out = paddle.matmul(inputX, inputY)
+        out = paddle.add(out, bias)
+        return out
+
+
+class ADD(paddle.nn.Layer):
+    def __init__(self):
+        super(ADD, self).__init__()
+
+    def forward(self, inputY, bias):
+        out = paddle.add(inputY, bias)
+        out = paddle.add(out, bias)
+        out = paddle.add(out, inputY)
+        return out
+
+
+# bfloat16
+x_spec = InputSpec(shape=[T, H], dtype="bfloat16", name="x")
+y_spec = InputSpec(shape=[H, T], dtype="bfloat16", name="y")
+b_spec = InputSpec(shape=[T], dtype="bfloat16", name="b")
+
+model = ADDMUL()
+
+with profiler.Profiler(
+    targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.CUSTOM_DEVICE],
+    scheduler=(0, 5),
+    on_trace_ready=profiler.export_chrome_tracing("./log"),
+) as p:
+    X = paddle.randn([T, H], dtype="bfloat16")
+    Y = paddle.randn([H, T], dtype="bfloat16")
+    B = paddle.randn([T], dtype="bfloat16")
+
+    print(X.shape)
+    print(Y.shape)
+    print(B.shape)
+    out = model(X, Y, B)
+    p.step()
+    print(out.shape)
+    print(Y)
+    print(B)
+    print(out)

--- a/backends/intel_hpu/utils/hpu_tracer.cc
+++ b/backends/intel_hpu/utils/hpu_tracer.cc
@@ -1,0 +1,151 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils/hpu_tracer.h"
+
+HpuTraceParser::HpuTraceParser(uint64_t hpu_start_time)
+    : hpu_start_time_ns{hpu_start_time} {}
+
+HpuTraceParser::~HpuTraceParser() {}
+
+void HpuTraceParser::Export(C_Profiler prof,
+                            synTraceEvent* events_ptr,
+                            size_t num_events,
+                            uint64_t wall_start_time) {
+  wall_start_time_ns = wall_start_time;
+  engine_type_database = EngineDatabase::buildDatabase(events_ptr, num_events);
+  initLanes();
+  convertEventsToActivities(prof, events_ptr, num_events);
+}
+
+bool HpuTraceParser::skipEvent(const synTraceEvent* events_ptr) {
+  if (events_ptr->type == 'M') return true;
+
+  auto& engine_types = engine_type_database->engine_types;
+  if (engine_types.find(events_ptr->engineType) == engine_types.end())
+    return true;
+
+  std::string_view name = events_ptr->name;
+  if (name.find("write to mem") != std::string_view::npos) {
+    return true;
+  }
+  return false;
+}
+
+bool HpuTraceParser::Contains(const char* haystack, const char* needle) {
+  return (haystack != nullptr && needle != nullptr &&
+          std::strstr(haystack, needle) != nullptr);
+}
+
+void HpuTraceParser::initLanes() {
+  auto& engine_types = engine_type_database->engine_types;
+  for (auto& e : engine_types) {
+    auto& engine_type = e.second;
+    auto& engine_type_index = e.first;
+
+    if (!EngineType::isHost(engine_type.name)) {
+      for (auto& engine : engine_type.engines) {
+        std::string key = std::to_string(engine_type_index) + "_" +
+                          std::to_string(engine.index);
+        lanes[key] = engine.name;
+      }
+    }
+  }
+}
+
+bool HpuTraceParser::isEventInTime(uint64_t start,
+                                   uint64_t end,
+                                   uint64_t hpu_stop_time_ns) {
+  return start > hpu_start_time_ns && end < hpu_stop_time_ns;
+}
+
+void HpuTraceParser::convertEventsToActivities(C_Profiler prof,
+                                               synTraceEvent* events_ptr,
+                                               size_t num_events) {
+  struct ActiveEvent {
+    synTraceEvent* begin_;
+    synTraceEvent* enqueue_;
+  };
+  using ActiveEventsMap =
+      std::unordered_map<uint32_t,
+                         std::unordered_map<uint32_t, std::list<ActiveEvent>>>;
+  using ActiveEnqueueEventsMap = std::unordered_map<uint32_t, synTraceEvent*>;
+  ActiveEventsMap activeEvents;
+  ActiveEnqueueEventsMap activeEnqueueEvents;
+
+  for (size_t i{}; i < num_events; i++, events_ptr++) {
+    if (skipEvent(events_ptr)) {
+      continue;
+    }
+
+    if (events_ptr->arguments.recipeId != 0 &&
+        Contains(events_ptr->name, "enqueueWithExternalEvents")) {
+      activeEnqueueEvents[events_ptr->arguments.recipeId] = events_ptr;
+    }
+
+    switch (events_ptr->type) {
+      case 'B': {
+        auto& eventList =
+            activeEvents[events_ptr->engineIndex][events_ptr->contextId];
+        ActiveEvent activeEvent{
+            events_ptr, activeEnqueueEvents[events_ptr->arguments.recipeId]};
+        eventList.push_back(activeEvent);
+      } break;
+      case 'E': {
+#if (CAPTURE_EVENTS & STREAMS_EVENT)
+        auto& eventList =
+            activeEvents[events_ptr->engineIndex][events_ptr->contextId];
+        if (!eventList.empty()) {
+          auto begin = timeStampHpuToTB(eventList.front().begin_->timestamp);
+          auto end = timeStampHpuToTB(events_ptr->timestamp);
+          std::string key = std::to_string(events_ptr->engineType) + "_" +
+                            std::to_string(events_ptr->engineIndex);
+          std::string engineName = lanes[key];
+          std::string name{engineName + ": " + events_ptr->name};
+          phi::RuntimeTraceEvent event;
+
+          event.name = name;
+          event.start_ns = begin;
+          event.end_ns = end;
+          event.process_id = events_ptr->engineType;
+          event.thread_id = events_ptr->engineIndex;
+          event.correlation_id = 0;
+          profiler_add_runtime_trace_event(prof, &event);
+          eventList.pop_front();
+#endif
+        }
+      } break;
+      case 'X': {
+#if (CAPTURE_EVENTS & SYNAPSE_API_EVENT)
+        auto begin = timeStampHpuToTB(events_ptr->timestamp);
+        auto end =
+            timeStampHpuToTB(events_ptr->timestamp + events_ptr->duration);
+        phi::RuntimeTraceEvent event;
+        event.name = events_ptr->name;
+        event.start_ns = begin;
+        event.end_ns = end;
+        event.process_id = static_cast<uint32_t>(getpid());
+        event.thread_id = static_cast<uint32_t>(getpid());
+        event.correlation_id = 0;
+        profiler_add_runtime_trace_event(prof, &event);
+#endif
+      } break;
+    }
+  }
+}
+
+int64_t HpuTraceParser::timeStampHpuToTB(long double t) {
+  uint64_t _t = static_cast<int64_t>(roundl(t * 1000));
+  return _t - hpu_start_time_ns + wall_start_time_ns;
+}

--- a/backends/intel_hpu/utils/hpu_tracer.h
+++ b/backends/intel_hpu/utils/hpu_tracer.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unistd.h>
+
+#include <cmath>
+#include <cstring>
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "habanalabs/synapse_api.h"
+#include "paddle/phi/api/profiler/trace_event.h"
+#include "paddle/phi/backends/device_ext.h"
+
+#define STREAMS_EVENT 0x1
+#define SYNAPSE_API_EVENT 0x2
+#define CAPTURE_EVENTS (STREAMS_EVENT | SYNAPSE_API_EVENT)
+
+struct EngineType {
+  struct Engine {
+    uint32_t index;
+    std::string name;
+  };
+  std::string name;
+  std::vector<Engine> engines;
+
+  static bool isInteresting(const std::string_view name) {
+    return std::strstr(name.data(), "*TPC") ||
+           std::strstr(name.data(), "*MME") ||
+           std::strstr(name.data(), "*EDMA") ||
+           std::strstr(name.data(), "*PDMA") ||
+           std::strstr(name.data(), "*KDMA");
+  }
+  static bool isHost(const std::string_view name) {
+    static std::string host_meta_name = "***Host";
+    return name == host_meta_name;
+  }
+};
+
+struct EngineDatabase {
+  EngineDatabase() {}
+
+  std::unordered_map<uint32_t, EngineType> engine_types;
+
+  static std::unique_ptr<EngineDatabase> buildDatabase(
+      synTraceEvent* events_ptr, size_t num_events) {
+    std::unique_ptr<EngineDatabase> result = std::make_unique<EngineDatabase>();
+    auto& engine_types = result->engine_types;
+
+    synTraceEvent* host_meta_event_ptr = events_ptr;
+    for (uint64_t i = 0; i < num_events; i++, host_meta_event_ptr++) {
+      if (host_meta_event_ptr->type != 'M') break;
+      if (host_meta_event_ptr->engineIndex == 0 &&
+          EngineType::isHost(host_meta_event_ptr->arguments.name)) {
+        auto& engine_type = engine_types[host_meta_event_ptr->engineType];
+        engine_type.name = host_meta_event_ptr->arguments.name;
+        break;
+      }
+    }
+
+    for (uint64_t i = 0; i < num_events; i++, events_ptr++) {
+      if (events_ptr->type != 'M') {
+        continue;
+      }
+
+      if (events_ptr->engineIndex == 0 &&
+          EngineType::isInteresting(events_ptr->arguments.name)) {
+        auto& engine_type = engine_types[events_ptr->engineType];
+        engine_type.name = events_ptr->arguments.name;
+        continue;
+      }
+      auto engine_type_it = engine_types.find(events_ptr->engineType);
+      if (engine_type_it != engine_types.end()) {
+        auto& engine_type = engine_type_it->second;
+        engine_type.engines.push_back({.index = events_ptr->engineIndex,
+                                       .name = events_ptr->arguments.name});
+      }
+    }
+    return result;
+  }
+};
+
+class HpuTraceParser {
+ public:
+  explicit HpuTraceParser(uint64_t hpu_start_time);
+
+  ~HpuTraceParser();
+
+  void Export(C_Profiler prof,
+              synTraceEvent* events_ptr,
+              size_t num_events,
+              uint64_t wall_stop_time);
+
+ private:
+  bool skipEvent(const synTraceEvent* events_ptr);
+  bool Contains(const char* haystack, const char* needle);
+
+  void initLanes();
+  bool isEventInTime(uint64_t start, uint64_t end, uint64_t hpu_stop_time);
+  void convertEventsToActivities(C_Profiler prof,
+                                 synTraceEvent* events_ptr,
+                                 size_t num_events);
+  int64_t timeStampHpuToTB(long double t);
+  std::unordered_map<std::string, std::string> lanes;
+  uint64_t hpu_start_time_ns;
+  uint64_t wall_start_time_ns;
+  std::unique_ptr<EngineDatabase> engine_type_database;
+};


### PR DESCRIPTION
1. CMakeList.txt was modified to enable c++17 as string_view is used.
2. MME, TPC, DMA, and Synapse API are all included in the trace.
3. CAPTURE_EVENTS is for control the interested events. If needed, it can also be used to reduce the trace file size.