### PR TITLE
【Hackathon 7th PPSCI No.12】Adam、AdamW 优化器支持 amsgrad

### DIFF
--- a/backends/npu/tests/unittests/test_adam_op_npu.py
+++ b/backends/npu/tests/unittests/test_adam_op_npu.py
@@ -104,7 +104,9 @@ class TestAdam(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 @check_run_big_shape_test()
@@ -159,7 +161,9 @@ class TestAdamRank1(OpTest):
         self.shape = (4000, 8192)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 @check_run_big_shape_test()
@@ -241,7 +245,9 @@ class TestAdamWithEpsilonTensor(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 @unittest.skip(reason="disable_ut in Paddle CI")
@@ -294,7 +300,9 @@ class TestAdamOpWithSkipUpdate(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 class TestAdamOpWithGlobalBetaPow(OpTest):
@@ -350,7 +358,9 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 def create_test_fp64_class(parent):
@@ -359,7 +369,9 @@ def create_test_fp64_class(parent):
             self.dtype = np.float64
 
         def test_check_output(self):
-            self.check_output_with_place(self.place, atol=1e-5, rtol=1e-4)
+            self.check_output_with_place(
+                no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5, rtol=1e-4
+            )
 
     cls_name = "{0}_{1}".format(parent.__name__, "Fp64")
     TestAdamOpFp64Case.__name__ = cls_name
@@ -378,7 +390,9 @@ def create_test_fp16_class(parent):
             self.dtype = np.float16
 
         def test_check_output(self):
-            self.check_output_with_place(self.place, atol=1e-5, rtol=1e-4)
+            self.check_output_with_place(
+                no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5, rtol=1e-4
+            )
 
     cls_name = "{0}_{1}".format(parent.__name__, "Fp16")
     TestAdamOpFp16Case.__name__ = cls_name

--- a/backends/npu/tests/unittests/test_adam_op_npu.py
+++ b/backends/npu/tests/unittests/test_adam_op_npu.py
@@ -54,7 +54,9 @@ def adam_step(inputs, attributes):
     moment2_out = beta2 * moment2 + (1 - beta2) * np.square(grad)
     lr_t = lr * np.sqrt(1 - beta2_pow) / (1 - beta1_pow)
     param_out = param - lr_t * (moment1_out / (np.sqrt(moment2_out) + epsilon))
-    return param_out, moment1_out, moment2_out
+
+    moment2_max_out = np.empty_like(moment2_out)
+    return param_out, moment1_out, moment2_out, moment2_max_out
 
 
 class TestAdam(OpTest):
@@ -67,6 +69,8 @@ class TestAdam(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype(self.dtype)
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype(self.dtype)
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype(self.dtype)
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -80,18 +84,27 @@ class TestAdam(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype(self.dtype),
             "Beta1Pow": np.array([beta1_pow]).astype(self.dtype),
             "Beta2Pow": np.array([beta2_pow]).astype(self.dtype),
         }
 
-        self.attrs = {"epsilon": epsilon, "beta1": beta1, "beta2": beta2}
+        self.attrs = {
+            "epsilon": epsilon,
+            "beta1": beta1,
+            "beta2": beta2,
+            "amsgrad": False,
+        }
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -121,6 +134,8 @@ class TestAdamRank1(OpTest):
         moment1 = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
         # The second moment is positive
         moment2 = np.random.random(self.shape).astype(self.dtype)
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros(self.shape).astype(self.dtype)
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -134,18 +149,27 @@ class TestAdamRank1(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype(self.dtype),
             "Beta1Pow": np.array([beta1_pow]).astype(self.dtype),
             "Beta2Pow": np.array([beta2_pow]).astype(self.dtype),
         }
 
-        self.attrs = {"epsilon": epsilon, "beta1": beta1, "beta2": beta2}
+        self.attrs = {
+            "epsilon": epsilon,
+            "beta1": beta1,
+            "beta2": beta2,
+            "amsgrad": False,
+        }
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -206,6 +230,9 @@ class TestAdamWithEpsilonTensor(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype(self.dtype)
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype(self.dtype)
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype(self.dtype)
+
         learning_rate = 0.004
         beta1 = 0.78
         beta2 = 0.836
@@ -218,6 +245,7 @@ class TestAdamWithEpsilonTensor(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype(self.dtype),
             "Beta1Pow": np.array([beta1_pow]).astype(self.dtype),
             "Beta2Pow": np.array([beta2_pow]).astype(self.dtype),
@@ -228,11 +256,14 @@ class TestAdamWithEpsilonTensor(OpTest):
 
         self.attrs = {"epsilon": epsilon}
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -261,6 +292,8 @@ class TestAdamOpWithSkipUpdate(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype(self.dtype)
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype(self.dtype)
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype(self.dtype)
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -274,6 +307,7 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype(self.dtype),
             "Beta1Pow": np.array([beta1_pow]).astype(self.dtype),
             "Beta2Pow": np.array([beta2_pow]).astype(self.dtype),
@@ -283,11 +317,12 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "SkipUpdate": np.array([True]).astype("bool"),
         }
 
-        self.attrs = {"epsilon": epsilon}
+        self.attrs = {"epsilon": epsilon, "amsgrad": False}
 
         self.outputs = {
             "Moment1Out": moment1,
             "Moment2Out": moment2,
+            "Moment2MaxOut": moment2_max,
             "ParamOut": param,
             "Beta1PowOut": self.inputs["Beta1Pow"],
             "Beta2PowOut": self.inputs["Beta2Pow"],
@@ -315,6 +350,8 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype(self.dtype)
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype(self.dtype)
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype(self.dtype)
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -328,6 +365,7 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype(self.dtype),
             "Beta1Pow": np.array([beta1_pow]).astype(self.dtype),
             "Beta2Pow": np.array([beta2_pow]).astype(self.dtype),
@@ -336,16 +374,19 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
             "EpsilonTensor": np.array([epsilon]).astype(self.dtype),
         }
 
-        attributes = {"epsilon": epsilon}
+        attributes = {"epsilon": epsilon, "amsgrad": False}
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, attributes)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, attributes
+        )
 
-        self.attrs = {"use_global_beta_pow": True}
+        self.attrs = {"use_global_beta_pow": True, "amsgrad": False}
 
         # use_global_beta_pow=True, Beta1PowOut and Beta2PowOut are empty.
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([]),
             "Beta2PowOut": np.array([]),

--- a/backends/npu/tests/unittests/test_adam_op_npu_eager.py
+++ b/backends/npu/tests/unittests/test_adam_op_npu_eager.py
@@ -118,7 +118,9 @@ class TestAdam(OpTest):
 
     @check_soc_version
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=4e-3)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=4e-3
+        )
 
 
 class TestAdamWithEpsilonTensor(OpTest):
@@ -192,7 +194,9 @@ class TestAdamWithEpsilonTensor(OpTest):
 
     @check_soc_version
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=4e-3)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=4e-3
+        )
 
 
 class TestAdamOpWithSkipUpdate(OpTest):
@@ -265,7 +269,9 @@ class TestAdamOpWithSkipUpdate(OpTest):
 
     @check_soc_version
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=4e-3)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=4e-3
+        )
 
 
 class TestAdamOpWithGlobalBetaPow(OpTest):
@@ -342,7 +348,9 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
 
     @check_soc_version
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=4e-3)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=4e-3
+        )
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_adam_op_npu_eager.py
+++ b/backends/npu/tests/unittests/test_adam_op_npu_eager.py
@@ -53,7 +53,9 @@ def adam_step(inputs, attributes):
     moment2_out = beta2 * moment2 + (1 - beta2) * np.square(grad)
     lr_t = lr * np.sqrt(1 - beta2_pow) / (1 - beta1_pow)
     param_out = param - lr_t * (moment1_out / (np.sqrt(moment2_out) + epsilon))
-    return param_out, moment1_out, moment2_out
+
+    moment2_max_out = np.empty_like(moment2_out)
+    return param_out, moment1_out, moment2_out, moment2_max_out
 
 
 class TestAdam(OpTest):
@@ -74,6 +76,8 @@ class TestAdam(OpTest):
         moment2 = convert_float_to_uint16(
             np.random.random((102, 105)).astype(self.dtype)
         )
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = convert_float_to_uint16(np.zeros((102, 105)).astype(self.dtype))
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -87,6 +91,7 @@ class TestAdam(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": convert_float_to_uint16(
                 np.array([learning_rate]).astype(self.dtype)
             ),
@@ -98,13 +103,21 @@ class TestAdam(OpTest):
             ),
         }
 
-        self.attrs = {"epsilon": epsilon, "beta1": beta1, "beta2": beta2}
+        self.attrs = {
+            "epsilon": epsilon,
+            "beta1": beta1,
+            "beta2": beta2,
+            "amsgrad": False,
+        }
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -141,6 +154,8 @@ class TestAdamWithEpsilonTensor(OpTest):
         moment2 = convert_float_to_uint16(
             np.random.random((102, 105)).astype(self.dtype)
         )
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = convert_float_to_uint16(np.zeros((102, 105)).astype(self.dtype))
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -154,6 +169,7 @@ class TestAdamWithEpsilonTensor(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": convert_float_to_uint16(
                 np.array([learning_rate]).astype(self.dtype)
             ),
@@ -174,13 +190,16 @@ class TestAdamWithEpsilonTensor(OpTest):
             ),
         }
 
-        self.attrs = {"epsilon": epsilon}
+        self.attrs = {"epsilon": epsilon, "amsgrad": False}
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -217,6 +236,8 @@ class TestAdamOpWithSkipUpdate(OpTest):
         moment2 = convert_float_to_uint16(
             np.random.random((102, 105)).astype(self.dtype)
         )
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = convert_float_to_uint16(np.zeros((102, 105)).astype(self.dtype))
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -230,6 +251,7 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": convert_float_to_uint16(
                 np.array([learning_rate]).astype(self.dtype)
             ),
@@ -251,11 +273,12 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "SkipUpdate": np.array([True]).astype("bool"),
         }
 
-        self.attrs = {"epsilon": epsilon}
+        self.attrs = {"epsilon": epsilon, "amsgrad": False}
 
         self.outputs = {
             "Moment1Out": moment1,
             "Moment2Out": moment2,
+            "Moment2MaxOut": moment2_max,
             "ParamOut": param,
             "Beta1PowOut": self.inputs["Beta1Pow"],
             "Beta2PowOut": self.inputs["Beta2Pow"],
@@ -292,6 +315,8 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         moment2 = convert_float_to_uint16(
             np.random.random((102, 105)).astype(self.dtype)
         )
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = convert_float_to_uint16(np.zeros((102, 105)).astype(self.dtype))
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -305,6 +330,7 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": convert_float_to_uint16(
                 np.array([learning_rate]).astype(self.dtype)
             ),
@@ -325,9 +351,11 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
             ),
         }
 
-        attributes = {"epsilon": epsilon}
+        attributes = {"epsilon": epsilon, "amsgrad": False}
 
-        param_out, moment1_out, moment2_out = adam_step(self.inputs, attributes)
+        param_out, moment1_out, moment2_out, moment2_max_out = adam_step(
+            self.inputs, attributes
+        )
 
         self.attrs = {"use_global_beta_pow": True}
 
@@ -335,6 +363,7 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([]),
             "Beta2PowOut": np.array([]),

--- a/backends/npu/tests/unittests/test_adamw_op_npu.py
+++ b/backends/npu/tests/unittests/test_adamw_op_npu.py
@@ -58,7 +58,8 @@ def adamw_step(inputs, attributes):
     lr_t = lr * np.sqrt(1 - beta2_pow) / (1 - beta1_pow)
     param_out = param - lr_t * (moment1_out / (np.sqrt(moment2_out) + epsilon))
 
-    return param_out, moment1_out, moment2_out
+    moment2_max_out = np.empty_like(moment2_out)
+    return param_out, moment1_out, moment2_out, moment2_max_out
 
 
 class TestAdamW(OpTest):
@@ -71,6 +72,8 @@ class TestAdamW(OpTest):
         moment1 = np.random.uniform(-1, 1, (105, 102)).astype("float32")
         # The second moment is positive
         moment2 = np.random.random((105, 102)).astype("float32")
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((105, 102)).astype("float32")
 
         learning_rate = 0.5
         beta1 = 0.78
@@ -84,6 +87,7 @@ class TestAdamW(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype("float32"),
             "Beta1Pow": np.array([beta1_pow]).astype("float32"),
             "Beta2Pow": np.array([beta2_pow]).astype("float32"),
@@ -95,13 +99,17 @@ class TestAdamW(OpTest):
             "beta2": beta2,
             "coeff": 0.9,
             "with_decay": True,
+            "amsgrad": False,
         }
 
-        param_out, moment1_out, moment2_out = adamw_step(self.inputs, self.attrs)
+        param_out, moment1_out, moment2_out, moment2_max_out = adamw_step(
+            self.inputs, self.attrs
+        )
 
         self.outputs = {
             "Moment1Out": moment1_out,
             "Moment2Out": moment2_out,
+            "Moment2MaxOut": moment2_max_out,
             "ParamOut": param_out,
             "Beta1PowOut": np.array([beta1_pow]).astype("float32") * beta1,
             "Beta2PowOut": np.array([beta2_pow]).astype("float32") * beta2,
@@ -129,6 +137,8 @@ class TestAdamOpWithSkipUpdate(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype("float32")
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype("float32")
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -142,6 +152,7 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype("float32"),
             "Beta1Pow": np.array([beta1_pow]).astype("float32"),
             "Beta2Pow": np.array([beta2_pow]).astype("float32"),
@@ -151,11 +162,17 @@ class TestAdamOpWithSkipUpdate(OpTest):
             "SkipUpdate": np.array([True]).astype("bool"),
         }
 
-        self.attrs = {"epsilon": epsilon, "coeff": 0.02, "with_decay": True}
+        self.attrs = {
+            "epsilon": epsilon,
+            "coeff": 0.02,
+            "with_decay": True,
+            "amsgrad": False,
+        }
 
         self.outputs = {
             "Moment1Out": moment1,
             "Moment2Out": moment2,
+            "Moment2MaxOut": moment2_max,
             "ParamOut": param,
             "Beta1PowOut": self.inputs["Beta1Pow"],
             "Beta2PowOut": self.inputs["Beta2Pow"],
@@ -183,6 +200,8 @@ class TestAdamOpWithoutDecay(OpTest):
         moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
         # The second moment is positive
         moment2 = np.random.random((102, 105)).astype("float32")
+        # npu not support amsgrad, `moment2_max` is useless
+        moment2_max = np.zeros((102, 105)).astype("float32")
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -196,6 +215,7 @@ class TestAdamOpWithoutDecay(OpTest):
             "Grad": grad,
             "Moment1": moment1,
             "Moment2": moment2,
+            "Moment2Max": moment2_max,
             "LearningRate": np.array([learning_rate]).astype("float32"),
             "Beta1Pow": np.array([beta1_pow]).astype("float32"),
             "Beta2Pow": np.array([beta2_pow]).astype("float32"),
@@ -205,11 +225,17 @@ class TestAdamOpWithoutDecay(OpTest):
             "SkipUpdate": np.array([True]).astype("bool"),
         }
 
-        self.attrs = {"epsilon": epsilon, "coeff": 0.02, "with_decay": False}
+        self.attrs = {
+            "epsilon": epsilon,
+            "coeff": 0.02,
+            "with_decay": False,
+            "amsgrad": False,
+        }
 
         self.outputs = {
             "Moment1Out": moment1,
             "Moment2Out": moment2,
+            "Moment2MaxOut": moment2_max,
             "ParamOut": param,
             "Beta1PowOut": self.inputs["Beta1Pow"],
             "Beta2PowOut": self.inputs["Beta2Pow"],

--- a/backends/npu/tests/unittests/test_adamw_op_npu.py
+++ b/backends/npu/tests/unittests/test_adamw_op_npu.py
@@ -114,7 +114,9 @@ class TestAdamW(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 class TestAdamOpWithSkipUpdate(OpTest):
@@ -166,7 +168,9 @@ class TestAdamOpWithSkipUpdate(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 class TestAdamOpWithoutDecay(OpTest):
@@ -218,7 +222,9 @@ class TestAdamOpWithoutDecay(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5)
+        self.check_output_with_place(
+            no_check_set=["Moment2MaxOut"], place=self.place, atol=1e-5
+        )
 
 
 class TestNet(unittest.TestCase):

--- a/python/tests/white_list/no_check_set_white_list.py
+++ b/python/tests/white_list/no_check_set_white_list.py
@@ -37,4 +37,6 @@ no_check_set_white_list = [
     "class_center_sample",
     "einsum",
     "rmsprop",
+    "adam",  # AMSGrad variant no check moment2 max output
+    "adamw",  # AMSGrad variant no check moment2 max output
 ]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
【Hackathon 7th No.12】Adam、AdamW 优化器支持 amsgrad

关联：
- [【Hackathon 7th No.12】Adam、AdamW 优化器支持 amsgrad](https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_7th/%E3%80%90Hackathon%207th%E3%80%91%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E2%80%94%E7%A7%91%E5%AD%A6%E8%AE%A1%E7%AE%97%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no12-adamadamw-%E4%BC%98%E5%8C%96%E5%99%A8%E6%94%AF%E6%8C%81-amsgrad)
- https://github.com/PaddlePaddle/community/pull/949
- https://github.com/PaddlePaddle/Paddle/pull/68079

在 `npu` 中 `AdamKernel` `AdamwKernel` 中添加 `amsgrad` 参数，但不实现相应逻辑 ～

@HydrogenSulfate @luotao1

