### PR TITLE
[GCU] fix fused conv2d_add_act kernel

### DIFF
--- a/backends/gcu/kernels/fused_conv2d_add_act_kernel.cc
+++ b/backends/gcu/kernels/fused_conv2d_add_act_kernel.cc
@@ -105,8 +105,8 @@ void FusedConv2dAddActKernel(const Context& dev_ctx,
     auto new_bias = bias;
     auto bias_dims = common::vectorize(bias.dims());
     if (bias_dims.size() != 1) {
-      if (std::count(bias_dims.begin(), bias_dims.end(), 1) !=
-          bias_dims.size() - 1) {
+      auto one_cnt = std::count(bias_dims.begin(), bias_dims.end(), 1);
+      if ((one_cnt != 4) && (one_cnt != bias_dims.size() - 1)) {
         PADDLE_THROW(phi::errors::InvalidArgument(
             "Bias rank should be 1, unsupport bias dims: %s.",
             bias.dims().to_str().c_str()));


### PR DESCRIPTION
修复`fused_conv2d_add_act`的`kernel`实现逻辑，以满足`pass`和算子库`kernel`要求