### PR TITLE
[npu] fix histogram bug

### DIFF
--- a/backends/npu/kernels/histogram_kernel.cc
+++ b/backends/npu/kernels/histogram_kernel.cc
@@ -25,7 +25,6 @@ void HistogramKernel(const Context& dev_ctx,
                      float max,
                      bool density,
                      phi::DenseTensor* output) {
-
   PADDLE_ENFORCE_EQ(
       weight || density,
       false,

--- a/backends/npu/kernels/histogram_kernel.cc
+++ b/backends/npu/kernels/histogram_kernel.cc
@@ -21,10 +21,11 @@ void HistogramKernel(const Context& dev_ctx,
                      const phi::DenseTensor& input,
                      const paddle::optional<phi::DenseTensor>& weight,
                      int64_t bins,
-                     int min,
-                     int max,
+                     float min,
+                     float max,
                      bool density,
                      phi::DenseTensor* output) {
+
   PADDLE_ENFORCE_EQ(
       weight || density,
       false,


### PR DESCRIPTION
Paddle框架pr: https://github.com/PaddlePaddle/Paddle/pull/69750 修改了min/max数据类型，导致910b单测报错
![6abd8e1ebf6ed523a7328013bbed3487](https://github.com/user-attachments/assets/40a9a8bb-d6a7-47b3-81ce-71138c13d76d)
