### PR TITLE
[intel_hpu]Fused new ropy custom OPs

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_get_rotary_embedding.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_get_rotary_embedding.cc
@@ -1,0 +1,213 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <vector>
+
+#include "paddle/extension.h"
+
+template <typename T, int N>
+struct GetPackType {
+  using type =
+      typename std::aligned_storage<N * sizeof(T), N * sizeof(T)>::type;
+};
+
+template <typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
+
+template <typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
+
+void fused_get_rotary_embedding_neox(const int64_t* position_ids,
+                                     const int32_t bsz,
+                                     const int32_t max_seq_length,
+                                     const int32_t max_position_seq_length,
+                                     const int32_t head_dim,
+                                     const int32_t prompt_num,
+                                     const float inv_head_dim,
+                                     const int32_t elem_cnt,
+                                     const float theta,
+                                     float* rope_embedding) {
+  constexpr int PackSize = 2;
+  const int half_head_dim = head_dim / PackSize;
+
+  for (int idx = 0; idx < elem_cnt; idx++) {
+    const int32_t bsz_seq_idx = idx / half_head_dim;
+    const int32_t bsz_idx = bsz_seq_idx / max_seq_length;
+    const int32_t seq_idx = bsz_seq_idx % max_seq_length;
+    const int64_t position_offset =
+        bsz_idx * max_position_seq_length + seq_idx + prompt_num;
+    const int32_t half_head_idx = (idx % half_head_dim) * PackSize;
+    const float exponent_factor =
+        -static_cast<float>(half_head_idx) *
+        inv_head_dim;  // * inv_head_dim equals to / head_dim.
+    const float inv_freq_val = powf(theta, exponent_factor);
+    const float freqs_val =
+        static_cast<float>(position_ids[position_offset]) * inv_freq_val;
+    const float cos_embedding_val = cos(freqs_val);
+    const float sin_embedding_val = sin(freqs_val);
+    const int32_t cos_offset =
+        bsz_seq_idx * head_dim + half_head_idx / PackSize;
+    rope_embedding[cos_offset] = cos_embedding_val;
+    rope_embedding[cos_offset + half_head_dim] = cos_embedding_val;
+    const int32_t sin_offset = bsz * max_seq_length * head_dim + cos_offset;
+    rope_embedding[sin_offset] = sin_embedding_val;
+    rope_embedding[sin_offset + half_head_dim] = sin_embedding_val;
+  }
+}
+
+void fused_get_rotary_embedding(const int64_t* position_ids,
+                                const int32_t bsz,
+                                const int32_t max_seq_length,
+                                const int32_t max_position_seq_length,
+                                const int32_t head_dim,
+                                const int32_t prompt_num,
+                                const float inv_head_dim,
+                                const int32_t elem_cnt,
+                                const float theta,
+                                float* rope_embedding) {
+  constexpr int PackSize = 2;
+  Pack<float, PackSize> SinStorePack{};
+  Pack<float, PackSize> CosStorePack{};
+
+  const int half_head_dim = head_dim / PackSize;
+  for (int idx = 0; idx < elem_cnt; idx++) {
+    const int32_t bsz_seq_idx = idx / half_head_dim;
+    const int32_t bsz_idx = bsz_seq_idx / max_seq_length;
+    const int32_t seq_idx = bsz_seq_idx % max_seq_length;
+
+    const int64_t position_offset =
+        bsz_idx * max_position_seq_length + seq_idx + prompt_num;
+    const int32_t half_head_idx = (idx % half_head_dim) * PackSize;
+    const float exponent_factor =
+        -static_cast<float>(half_head_idx) *
+        inv_head_dim;  // * inv_head_dim equals to / head_dim.
+    const float inv_freq_val = powf(theta, exponent_factor);
+    // printf("[%d] %d = %d * %d + %d + %d\t    %d=%d/%d    \t%d=%d/%d
+    // \t%d=%d%%%d\n",
+    //       idx, position_offset, bsz_idx, max_position_seq_length, seq_idx,
+    //       prompt_num, bsz_seq_idx, idx, half_head_dim, bsz_idx, bsz_seq_idx,
+    //       max_seq_length, seq_idx, bsz_seq_idx, max_seq_length);
+    const float freqs_val =
+        static_cast<float>(position_ids[position_offset]) * inv_freq_val;
+    const float cos_embedding_val = cos(freqs_val);
+    const float sin_embedding_val = sin(freqs_val);
+
+    /*
+    Since After stack, the continuous 2 elements value is same.
+    So here each threads store 2 computed embedding value.
+    */
+#pragma unroll
+    for (int unroll_idx = 0; unroll_idx < PackSize; unroll_idx++) {
+      CosStorePack.elem[unroll_idx] = cos_embedding_val;
+      SinStorePack.elem[unroll_idx] = sin_embedding_val;
+    }
+
+    const int32_t cos_offset = bsz_seq_idx * head_dim + half_head_idx;
+    const int32_t sin_offset = bsz * max_seq_length * head_dim + cos_offset;
+    // printf("[%d]  cos_offset=%d = %d * %d + %d     sin_offset=%d = %d * %d *
+    // %d + %d   \n  ",
+    //        idx, cos_offset, bsz_seq_idx, head_dim, half_head_idx,
+    //        sin_offset, bsz, max_seq_length, head_dim, cos_offset);
+    *(reinterpret_cast<PackType<float, PackSize>*>(
+        rope_embedding + cos_offset)) = CosStorePack.storage;
+    *(reinterpret_cast<PackType<float, PackSize>*>(
+        rope_embedding + sin_offset)) = SinStorePack.storage;
+  }
+}
+
+std::vector<paddle::Tensor> GetRoPE(const paddle::Tensor& input_ids,
+                                    const paddle::Tensor& position_ids,
+                                    const paddle::Tensor& head_dim_shape_tensor,
+                                    int prompt_num,
+                                    float theta,
+                                    bool use_neox) {
+  const int64_t batch_size = input_ids.shape()[0];
+  const int64_t max_seq_length = input_ids.shape()[1];
+  const int64_t max_position_seq_length = position_ids.shape()[1];
+  const int64_t head_dim = head_dim_shape_tensor.shape()[0];
+  const float inv_head_dim = 1.0f / static_cast<float>(head_dim);
+
+  std::vector<int64_t> out_shape = {2, batch_size, 1, max_seq_length, head_dim};
+  auto rotary_embedding = paddle::full(
+      out_shape, -1, paddle::DataType::FLOAT32, paddle::CPUPlace());
+
+  assert(head_dim % 2 == 0);
+  const int32_t elem_cnt = batch_size * max_seq_length * head_dim / 2;
+  int32_t grid_size = 1;
+
+  auto position_ids_cpu = position_ids.copy_to(paddle::CPUPlace(), true);
+  if (use_neox) {
+    fused_get_rotary_embedding_neox(
+        position_ids_cpu.data<int64_t>(),
+        batch_size,
+        max_seq_length,
+        max_position_seq_length,
+        head_dim,
+        prompt_num,
+        inv_head_dim,
+        elem_cnt,
+        theta,
+        reinterpret_cast<float*>(rotary_embedding.data<float>()));
+  } else {
+    fused_get_rotary_embedding(
+        position_ids_cpu.data<int64_t>(),
+        batch_size,
+        max_seq_length,
+        max_position_seq_length,
+        head_dim,
+        prompt_num,
+        inv_head_dim,
+        elem_cnt,
+        theta,
+        reinterpret_cast<float*>(rotary_embedding.data<float>()));
+  }
+
+  return {rotary_embedding.copy_to(position_ids.place(), false)};
+}
+
+std::vector<std::vector<int64_t>> GetRoPEInferShape(
+    const std::vector<int64_t>& input_ids_shape,
+    const std::vector<int64_t>& position_ids_shape,
+    const std::vector<int64_t>& head_dim_shape_tensor_shape) {
+  const int64_t batch_size = position_ids_shape[0];
+  const int64_t max_seq_length = input_ids_shape[1];
+  const int64_t head_dim = head_dim_shape_tensor_shape[0];
+  std::vector<int64_t> out_shape = {2, batch_size, 1, max_seq_length, head_dim};
+
+  return {out_shape};
+}
+
+std::vector<paddle::DataType> GetRoPEInferDtype(
+    const paddle::DataType& input_ids_dtype,
+    const paddle::DataType& position_ids_dtype,
+    const paddle::DataType& head_dim_shape_tensor_dtype) {
+  // RoPE output dtype is Float.
+  return {paddle::DataType::FLOAT32};
+}
+
+PD_BUILD_OP(fused_get_rotary_embedding)
+    .Inputs({"input_ids", "position_ids", "head_dim_shape_tensor"})
+    .Outputs({"rotary_embedding"})
+    .Attrs({"prompt_num: int", "theta: float", "use_neox: bool"})
+    .SetKernelFn(PD_KERNEL(GetRoPE))
+    .SetInferShapeFn(PD_INFER_SHAPE(GetRoPEInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(GetRoPEInferDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_rms_qkv_rope_v2.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_rms_qkv_rope_v2.cc
@@ -1,0 +1,632 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+struct FusedRmsQkvRopeParams {
+  ns_LayerNormKernel::Params rmsnorm_params;
+
+  int head_dim;
+  int num_head;
+  int kv_num_head;
+};
+
+class FusedRmsQkvRopeV2 : public HpuOperator {
+ public:
+  explicit FusedRmsQkvRopeV2(synDataType dtype)
+      : HpuOperator("fused_rms_qkv_rope_v2_fwd_"), dtype_(dtype) {}
+
+  void AddNode(const std::vector<DIMS>& ins,
+               const std::vector<DIMS>& outs,
+               FusedRmsQkvRopeParams& params) {
+    synStatus status = synFail;
+
+    std::string name_reshape = guid_ + "reshape";
+    std::string name_rmsnorm = guid_ + "rmsnorm";
+    std::string name_rope = guid_ + "rope";
+
+    std::string guid_reshape = "reshape";
+    std::string guid_rmsnorm = "rms_norm_ex_fwd_";
+    std::string guid_rope = "rotary_pos_embedding_fwd_";
+    // std::string guid_rope = "rope_st2_fwd_";
+
+    if (dtype_ == syn_type_fp16) {
+      guid_rmsnorm = guid_rmsnorm + "f16";
+      guid_rope = guid_rope + "f16";
+    } else if (dtype_ == syn_type_bf16) {
+      guid_rmsnorm = guid_rmsnorm + "bf16";
+      guid_rope = guid_rope + "bf16";
+    }
+
+    auto src = createTensor(ins[0].size(), dtype_, ins[0], true, "src");
+    auto ln_scales =
+        createTensor(ins[1].size(), dtype_, ins[1], true, "ln_scales");
+
+    std::vector<synTensor> rmsnorm_inputs;
+    rmsnorm_inputs.push_back(src);
+    rmsnorm_inputs.push_back(ln_scales);
+
+    auto tmp_dims = ins[0];
+    tmp_dims[2] = 1;
+    auto norm_out =
+        createTensor(ins[0].size(), dtype_, ins[0], false, "norm_out");
+    auto norm_var =
+        createTensor(tmp_dims.size(), dtype_, tmp_dims, false, "norm_var");
+
+    std::vector<synTensor> rmsnorm_outputs;
+    rmsnorm_outputs.push_back(norm_out);
+    rmsnorm_outputs.push_back(norm_var);
+
+    status = synNodeCreate(graphHandle_,
+                           rmsnorm_inputs.data(),
+                           rmsnorm_outputs.data(),
+                           2,
+                           2,
+                           &params.rmsnorm_params,
+                           sizeof(params.rmsnorm_params),
+                           guid_rmsnorm.c_str(),
+                           name_rmsnorm.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    auto qkv_weights =
+        createTensor(ins[2].size(), dtype_, ins[2], true, "qkv_weights");
+    std::vector<synTensor> mul_inputs;
+    mul_inputs.push_back(norm_out);
+    mul_inputs.push_back(qkv_weights);
+
+    auto wt_dims = ins[2];
+    tmp_dims[2] = wt_dims[0];
+
+    auto qkv_out =
+        createTensor(tmp_dims.size(), dtype_, tmp_dims, false, "qkv_out");
+    std::vector<synTensor> mul_outputs;
+    mul_outputs.push_back(qkv_out);
+
+    synGEMMParams gemm_params;
+    gemm_params.transpose_a = false;
+    gemm_params.transpose_b = true;
+    std::string guid_gemm = "gemm";
+    std::string gemm_name = guid_ + "gemm";
+    status = synNodeCreate(graphHandle_,
+                           mul_inputs.data(),
+                           mul_outputs.data(),
+                           2,
+                           1,
+                           &gemm_params,
+                           sizeof(gemm_params),
+                           guid_gemm.c_str(),
+                           gemm_name.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    mul_outputs.push_back(qkv_out);
+
+    auto reshape_dims = ins[0];
+    reshape_dims[2] = params.num_head + 2 * params.kv_num_head;
+    reshape_dims.push_back(params.head_dim);
+
+    std::vector<synTensor> reshape_outputs;
+    auto reshape_out = createTensor(
+        reshape_dims.size(), dtype_, reshape_dims, false, "reshape_out");
+    reshape_outputs.push_back(reshape_out);
+
+    status = synNodeCreate(graphHandle_,
+                           mul_outputs.data(),
+                           reshape_outputs.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    int rank = reshape_dims.size();
+    std::vector<int> axis = {0, 2, 1, 3};
+    synTransposeParams trans_params;
+    for (size_t i = 0; i < axis.size(); i++) {
+      trans_params.permutation[i] =
+          static_cast<TransposePermutationDim>(axis[i]);
+    }
+    trans_params.tensorDim = rank;
+
+    std::vector<int64_t> trans_dims(reshape_dims.cbegin(), reshape_dims.cend());
+    trans_dims[rank - 3] = reshape_dims[rank - 2];
+    trans_dims[rank - 2] = reshape_dims[rank - 3];
+
+    std::vector<synTensor> transpose_outputs;
+    auto trans_out =
+        createTensor(trans_dims.size(), dtype_, trans_dims, false, "trans_out");
+    transpose_outputs.push_back(trans_out);
+
+    std::string guid_trans = "transpose";
+    std::string name_trans = guid_ + "transpose";
+    status = synNodeCreate(graphHandle_,
+                           reshape_outputs.data(),
+                           transpose_outputs.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    synSplitParams splitParams;
+    splitParams.axis = 2;
+
+    std::vector<synTensor> split_outpus;
+    auto q = createTensor(outs[0].size(), dtype_, outs[0], false, "q_states");
+    split_outpus.push_back(q);
+
+    auto k = createTensor(outs[1].size(), dtype_, outs[1], false, "k_states");
+    split_outpus.push_back(k);
+
+    auto v =
+        createTensor(outs[2].size(), dtype_, outs[2], true, "value_states");
+    split_outpus.push_back(v);
+
+    std::string split_guid = "split";
+    std::string split_name = guid_ + "split";
+    status = synNodeCreate(graphHandle_,
+                           transpose_outputs.data(),
+                           split_outpus.data(),
+                           1,
+                           split_outpus.size(),
+                           &splitParams,
+                           sizeof(splitParams),
+                           split_guid.c_str(),
+                           split_name.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    std::vector<synTensor> rotary_embs_c_inputs;
+    auto rotary_embs_c =
+        createTensor(ins[3].size(), dtype_, ins[3], true, "rotary_embs");
+    rotary_embs_c_inputs.push_back(rotary_embs_c);
+
+    auto rotary_embs_dims = ins[3];
+    rotary_embs_dims[0] = 1;
+
+    std::vector<synTensor> cos_inputs;
+    auto cos_in = createTensor(
+        rotary_embs_dims.size(), dtype_, rotary_embs_dims, false, "cos_in");
+    cos_inputs.push_back(cos_in);
+
+    synSliceParamsV2 sliceParams;
+    for (int i = 0; i < rotary_embs_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = rotary_embs_dims[rotary_embs_dims.size() - 1 - i];
+    }
+
+    std::string slice_guid = "slice";
+    std::string slice_name = guid_ + "slice";
+    std::string slice_name_cos = slice_name + "_cos";
+    status = synNodeCreate(graphHandle_,
+                           rotary_embs_c_inputs.data(),
+                           cos_inputs.data(),
+                           rotary_embs_c_inputs.size(),
+                           cos_inputs.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_cos.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    std::vector<synTensor> rotary_embs_s_inputs;
+    auto rotary_embs_s =
+        createTensor(ins[3].size(), dtype_, ins[3], true, "rotary_embs");
+    rotary_embs_s_inputs.push_back(rotary_embs_s);
+
+    std::vector<synTensor> sin_inputs;
+    auto sin_in = createTensor(
+        rotary_embs_dims.size(), dtype_, rotary_embs_dims, false, "sin_in");
+    sin_inputs.push_back(sin_in);
+    sliceParams.starts[rotary_embs_dims.size() - 1] = 1;
+    sliceParams.ends[rotary_embs_dims.size() - 1] = 2;
+    std::string slice_name_sin = slice_name + "_sin";
+    status = synNodeCreate(graphHandle_,
+                           rotary_embs_s_inputs.data(),
+                           sin_inputs.data(),
+                           rotary_embs_s_inputs.size(),
+                           sin_inputs.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_sin.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    synSqueezeParams squeezeParams;
+    squeezeParams.axis = 4;
+    std::string squeeze_guid = "squeeze";
+    std::string squeeze_name = guid_ + "squeeze";
+
+    rotary_embs_dims.erase(rotary_embs_dims.begin());
+
+    std::vector<synTensor> sin_squeezed;
+    auto sin_sq = createTensor(rotary_embs_dims.size(),
+                               dtype_,
+                               rotary_embs_dims,
+                               false,
+                               "sin_squeezed");
+    // auto sin_sq = createTensor(
+    //     rotary_embs_dims.size(), dtype_, rotary_embs_dims, true, "debugs");
+    sin_squeezed.push_back(sin_sq);
+    std::string squeeze_name_sin = squeeze_name + "_sin";
+    status = synNodeCreate(graphHandle_,
+                           sin_inputs.data(),
+                           sin_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_sin.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    std::vector<synTensor> cos_squeezed;
+    auto cos_sq = createTensor(rotary_embs_dims.size(),
+                               dtype_,
+                               rotary_embs_dims,
+                               false,
+                               "cos_squeezed");
+    // auto cos_sq = createTensor(
+    //     rotary_embs_dims.size(), dtype_, rotary_embs_dims, true, "debugc");
+    cos_squeezed.push_back(cos_sq);
+    std::string squeeze_name_cos = squeeze_name + "_cos";
+    status = synNodeCreate(graphHandle_,
+                           cos_inputs.data(),
+                           cos_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_cos.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    std::vector<synTensor> inputs_q;
+    std::vector<synTensor> outputs_q;
+    inputs_q.push_back(q);
+    inputs_q.push_back(sin_sq);
+    inputs_q.push_back(cos_sq);
+
+    auto q_states =
+        createTensor(outs[0].size(), dtype_, outs[0], true, "query_states");
+    outputs_q.push_back(q_states);
+
+    ns_RoPESt2::ParamsV2 ropeParams;
+    ropeParams.offset = 0;
+    ropeParams.mode = ROTARY_POS_EMBEDDING_MODE_BLOCKWISE;
+
+    status = synNodeCreate(graphHandle_,
+                           inputs_q.data(),
+                           outputs_q.data(),
+                           inputs_q.size(),
+                           outputs_q.size(),
+                           &ropeParams,
+                           sizeof(ropeParams),
+                           guid_rope.c_str(),
+                           name_rope.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+
+    std::vector<synTensor> inputs_k;
+    std::vector<synTensor> outputs_k;
+    inputs_k.push_back(k);
+    inputs_k.push_back(sin_sq);
+    inputs_k.push_back(cos_sq);
+
+    auto k_states =
+        createTensor(outs[1].size(), dtype_, outs[1], true, "key_states");
+    outputs_k.push_back(k_states);
+
+    status = synNodeCreate(graphHandle_,
+                           inputs_k.data(),
+                           outputs_k.data(),
+                           inputs_k.size(),
+                           outputs_k.size(),
+                           &ropeParams,
+                           sizeof(ropeParams),
+                           guid_rope.c_str(),
+                           name_rope.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate () failed = ",
+             status);
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedRmsQkvRopeKernelV2(const Context& dev_ctx,
+                             const phi::DenseTensor& src,
+                             const phi::DenseTensor& ln_scales,
+                             const phi::DenseTensor& qkv_weights,
+                             const phi::DenseTensor& rotary_embs,
+                             phi::DenseTensor* query_states,
+                             phi::DenseTensor* key_states,
+                             phi::DenseTensor* value_states,
+                             phi::DenseTensor* debugc,
+                             phi::DenseTensor* debugs,
+                             const phi::Scalar& epsilon,
+                             const phi::Scalar& head_dim,
+                             const phi::Scalar& num_head) {
+  std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
+  std::vector<int64_t> ln_scales_dims =
+      phi::vectorize<int64_t>(ln_scales.dims());
+  std::vector<int64_t> qkv_weights_dims =
+      phi::vectorize<int64_t>(qkv_weights.dims());
+  std::vector<int64_t> rotary_embs_dims =
+      phi::vectorize<int64_t>(rotary_embs.dims());
+
+  std::vector<int64_t> out_q_dim =
+      phi::vectorize<int64_t>(query_states->dims());
+  std::vector<int64_t> out_k_dim = phi::vectorize<int64_t>(key_states->dims());
+  std::vector<int64_t> out_v_dim =
+      phi::vectorize<int64_t>(value_states->dims());
+  std::vector<int64_t> out_debug_dim = phi::vectorize<int64_t>(debugc->dims());
+
+  std::vector<DIMS> inputs = {
+      src_dims, ln_scales_dims, qkv_weights_dims, rotary_embs_dims};
+  std::vector<DIMS> outputs = {
+      out_q_dim, out_k_dim, out_v_dim, out_debug_dim, out_debug_dim};
+
+  int head_dim_ = head_dim.to<int>();
+  int num_head_ = num_head.to<int>();
+  const int64_t bsz = src_dims[0];
+  const int64_t seq_len = src_dims[1];
+  const int64_t fused_hidden_size = qkv_weights_dims[0];
+  const int64_t hidden_size = qkv_weights_dims[1];
+  const int kv_num_head =
+      (fused_hidden_size - num_head_ * head_dim_) / head_dim_ / 2;
+  const int num_groups = num_head_ / kv_num_head;
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_rms_qkv_rope_fwd_", {src_dims}, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedRmsQkvRopeParams params;
+    memset(
+        reinterpret_cast<void*>(&params), 0x00, sizeof(FusedRmsQkvRopeParams));
+    params.rmsnorm_params.epsValid = true;
+    params.rmsnorm_params.eps = epsilon.to<float>();
+    params.head_dim = head_dim_;
+    params.num_head = num_head_;
+    params.kv_num_head = kv_num_head;
+
+    FusedRmsQkvRopeV2 op(op_info.datatype_);
+    op.AddNode(inputs, outputs, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors;
+  tensors["src"] = reinterpret_cast<uint64_t>(src.data<T>());
+  tensors["ln_scales"] = reinterpret_cast<uint64_t>(ln_scales.data<T>());
+  tensors["qkv_weights"] = reinterpret_cast<uint64_t>(qkv_weights.data<T>());
+  tensors["rotary_embs"] = reinterpret_cast<uint64_t>(rotary_embs.data<T>());
+
+  tensors["query_states"] = reinterpret_cast<uint64_t>(query_states->data<T>());
+  tensors["key_states"] = reinterpret_cast<uint64_t>(key_states->data<T>());
+  tensors["value_states"] = reinterpret_cast<uint64_t>(value_states->data<T>());
+  tensors["debugc"] = reinterpret_cast<uint64_t>(debugc->data<T>());
+  tensors["debugs"] = reinterpret_cast<uint64_t>(debugs->data<T>());
+
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedRmsQkvRopeKernelV2(const Context& dev_ctx,
+                                 const phi::DenseTensor& src,
+                                 const phi::DenseTensor& ln_scales,
+                                 const phi::DenseTensor& qkv_weights,
+                                 const phi::DenseTensor& rotary_embs,
+                                 phi::DenseTensor* query_states,
+                                 phi::DenseTensor* key_states,
+                                 phi::DenseTensor* value_states,
+                                 phi::DenseTensor* debugc,
+                                 phi::DenseTensor* debugs,
+                                 const phi::Scalar& epsilon,
+                                 const phi::Scalar& head_dim,
+                                 const phi::Scalar& num_head) {
+  if (src.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedRmsQkvRopeKernelV2<phi::dtype::float16>(dev_ctx,
+                                                                src,
+                                                                ln_scales,
+                                                                qkv_weights,
+                                                                rotary_embs,
+                                                                query_states,
+                                                                key_states,
+                                                                value_states,
+                                                                debugc,
+                                                                debugs,
+                                                                epsilon,
+                                                                head_dim,
+                                                                num_head);
+  } else if (src.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedRmsQkvRopeKernelV2<phi::dtype::bfloat16>(dev_ctx,
+                                                                 src,
+                                                                 ln_scales,
+                                                                 qkv_weights,
+                                                                 rotary_embs,
+                                                                 query_states,
+                                                                 key_states,
+                                                                 value_states,
+                                                                 debugc,
+                                                                 debugs,
+                                                                 epsilon,
+                                                                 head_dim,
+                                                                 num_head);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedRmsQkvRopeKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedRmsQkvRopeV2(const paddle::Tensor& src,
+                                              const paddle::Tensor& ln_scales,
+                                              const paddle::Tensor& qkv_weights,
+                                              const paddle::Tensor& rotary_embs,
+                                              float epsilon,
+                                              int head_dim,
+                                              int num_head) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
+  auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto ln_scales_tensor =
+      static_cast<const phi::DenseTensor*>(ln_scales.impl().get());
+  auto qkv_weights_tensor =
+      static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
+  auto rotary_embs_tensor =
+      static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
+
+  // allocate memory on device.
+  int64_t bsz = src.dims()[0];
+  int64_t seq_len = src.dims()[1];
+  int64_t fused_hidden_size = qkv_weights.dims()[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+
+  std::shared_ptr<phi::DenseTensor> query_states =
+      std::make_shared<phi::DenseTensor>();
+  query_states->Resize(phi::make_ddim({bsz, num_head, seq_len, head_dim}));
+  dev_ctx->Alloc(query_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> key_states =
+      std::make_shared<phi::DenseTensor>();
+  key_states->Resize(phi::make_ddim({bsz, kv_num_head, seq_len, head_dim}));
+  dev_ctx->Alloc(key_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> value_states =
+      std::make_shared<phi::DenseTensor>();
+  value_states->Resize(phi::make_ddim({bsz, kv_num_head, seq_len, head_dim}));
+  dev_ctx->Alloc(value_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> debugc =
+      std::make_shared<phi::DenseTensor>();
+  debugc->Resize(phi::make_ddim({bsz, 1, seq_len, head_dim}));
+  dev_ctx->Alloc(debugc.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> debugs =
+      std::make_shared<phi::DenseTensor>();
+  debugs->Resize(phi::make_ddim({bsz, 1, seq_len, head_dim}));
+  dev_ctx->Alloc(debugs.get(), src_tensor->dtype());
+
+  CallFusedRmsQkvRopeKernelV2(*dev_ctx,
+                              *src_tensor,
+                              *ln_scales_tensor,
+                              *qkv_weights_tensor,
+                              *rotary_embs_tensor,
+                              query_states.get(),
+                              key_states.get(),
+                              value_states.get(),
+                              debugc.get(),
+                              debugs.get(),
+                              phi::Scalar(epsilon),
+                              phi::Scalar(head_dim),
+                              phi::Scalar(num_head));
+  return {paddle::Tensor(query_states),
+          paddle::Tensor(key_states),
+          paddle::Tensor(value_states),
+          paddle::Tensor(debugc),
+          paddle::Tensor(debugs)};
+}
+
+std::vector<std::vector<int64_t>> FusedRmsQkvRopeV2Shape(
+    const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& ln_scales_shape,
+    const std::vector<int64_t>& qkv_weights_shape,
+    const std::vector<int64_t>& rotary_embs_shape,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  int64_t bsz = src_shape[0];
+  int64_t seq_len = src_shape[1];
+  int64_t fused_hidden_size = qkv_weights_shape[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+  return {{bsz, num_head, seq_len, head_dim},
+          {bsz, kv_num_head, seq_len, head_dim},
+          {bsz, kv_num_head, seq_len, head_dim},
+          {bsz, 1, seq_len, head_dim},
+          {bsz, 1, seq_len, head_dim}};
+}
+
+std::vector<paddle::DataType> FusedRmsQkvRopeV2Dtype(
+    const paddle::DataType& src_dtype,
+    const paddle::DataType& ln_scales_dtype,
+    const paddle::DataType& qkv_weights_dtype,
+    const paddle::DataType& rotary_embs_dtype) {
+  return {src_dtype, src_dtype, src_dtype};
+}
+
+PD_BUILD_OP(fused_rms_qkv_rope_v2)
+    .Inputs({"src", "ln_scales", "qkv_weights", "rotary_embs"})
+    .Outputs({"query_states", "key_states", "value_states", "debugc", "debugs"})
+    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .SetKernelFn(PD_KERNEL(FusedRmsQkvRopeV2))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedRmsQkvRopeV2Shape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedRmsQkvRopeV2Dtype));


### PR DESCRIPTION
Apply new fused OPs:
- fused_get_rotary_embedding
- fused_rms_qkv_rope_v2

remove cos/sin/position_ids for fused_rms_qkv_rope, use rotary_embs instead in V2.