### PR TITLE
[INTEL_HPU] refine gaudi profiling code

### DIFF
--- a/backends/intel_hpu/runtime/runtime.cc
+++ b/backends/intel_hpu/runtime/runtime.cc
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -486,7 +487,13 @@ class RuntimeManager {
   void initParser() {
     uint64_t hpu_start_time_ns;
     synProfilerGetCurrentTimeNS(&hpu_start_time_ns);
-    parser = std::make_unique<HpuTraceParser>(hpu_start_time_ns);
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    uint64_t wall_start_time_ns = ts.tv_sec * 1000000000 + ts.tv_nsec;
+
+    parser =
+        std::make_unique<HpuTraceParser>(hpu_start_time_ns, wall_start_time_ns);
   }
 
   void exportTrace(C_Profiler prof,

--- a/backends/intel_hpu/utils/hpu_tracer.h
+++ b/backends/intel_hpu/utils/hpu_tracer.h
@@ -50,6 +50,10 @@ struct EngineType {
     static std::string host_meta_name = "***Host";
     return name == host_meta_name;
   }
+
+  static bool isKernelEvent(const std::string_view name) {
+    return std::strstr(name.data(), "*TPC") || std::strstr(name.data(), "*MME");
+  }
 };
 
 struct EngineDatabase {
@@ -97,7 +101,7 @@ struct EngineDatabase {
 
 class HpuTraceParser {
  public:
-  explicit HpuTraceParser(uint64_t hpu_start_time);
+  explicit HpuTraceParser(uint64_t hpu_start_time, uint64_t wall_start_time);
 
   ~HpuTraceParser();
 
@@ -112,6 +116,8 @@ class HpuTraceParser {
 
   void initLanes();
   bool isEventInTime(uint64_t start, uint64_t end, uint64_t hpu_stop_time);
+  bool isKernelEvent(const synTraceEvent* events_ptr);
+  bool inHiddenList(const synTraceEvent* events_ptr);
   void convertEventsToActivities(C_Profiler prof,
                                  synTraceEvent* events_ptr,
                                  size_t num_events);


### PR DESCRIPTION
1. Move gaudi device events to gpu events.
2. Add correlationID for GPU events.
3. Fix the incorrect time gap of cpu and gpu.