### PR TITLE
[INTEL_HPU] added unit tests auto for PR testing

### DIFF
--- a/backends/intel_hpu/tests/README.md
+++ b/backends/intel_hpu/tests/README.md
@@ -1,0 +1,13 @@
+# How to run all unit tests for PR testing
+# setup the PYTHONPATH env
+export PYTHONPATH=/workspace/pdpd_ci/PaddleCustomDevice/python/:/workspace/pdpd_ci/PaddleCustomDevice/Paddle/test/legacy_test/
+
+# common cmdline
+python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/backends/intel_hpu/tests/unittests/
+
+# to run all test cases under the --test_path folder with xml output
+python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --junit test_result.xml --platform gaudi2
+
+# to run special test cases
+python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --junit test_result.xml --platform gaudi2 --k test_abs_op
+python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --junit test_result.xml --platform gaudi2 --k test_abs_op.py

--- a/backends/intel_hpu/tests/junitxml.py
+++ b/backends/intel_hpu/tests/junitxml.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lxml import etree as et
+from enum import Enum
+import subprocess
+import platform
+
+
+class jResult(Enum):
+    PASS = 0
+    FAIL = 1
+    SKIP = 2
+    ERROR = 3
+    DISABLE = 4
+
+
+class jXMLBase:
+    def __init__(self, tag: str):
+        self._attr_dict = dict()
+        self._tag = tag
+        self._text = ""
+
+    def setName(self, name):
+        self._attr_dict["name"] = name
+
+    def covertET(self) -> et:
+        elem = et.Element(self._tag)
+        for k, v in self._attr_dict.items():
+            elem.set(k, str(v))
+        if len(self._text) > 0:
+            elem.text = self._text
+        return elem
+
+    def toString(self, pretty_print=False):
+        return et.tostring(self.covertET(), pretty_print=pretty_print).decode()
+
+
+class jTestCase(jXMLBase):
+    result = jResult.PASS
+    _child_elem = None
+    _output = None
+
+    def __init__(self, name: str):
+        super().__init__("testcase")
+        self.setName(name)
+        self._child_elem = list()
+
+    def setClass(self, classname: str):
+        self._attr_dict["classname"] = classname
+
+    def setTime(self, time):
+        self._attr_dict["time"] = time
+
+    def AddOutput(self, output: str):
+        if self._output is None:
+            self._output = jXMLBase("system-out")
+            self._child_elem.append(self._output)
+        if len(output) >= 1:
+            self._output._text += output
+
+    def setFail(self, message: str):
+        self.result = jResult.FAIL
+        el = jXMLBase("failure")
+        el._attr_dict["message"] = message
+        el._attr_dict["type"] = "failure"
+        self._child_elem.append(el)
+
+    def setSkip(self, message: str):
+        self.result = jResult.SKIP
+        self._attr_dict["skipped"] = 1
+        self.AddOutput("")
+        el = jXMLBase("skipped")
+        el._attr_dict["type"] = message
+        self._child_elem.append(el)
+
+    def covertET(self) -> et:
+        elem = super().covertET()
+        for jxml in self._child_elem:
+            elem.append(jxml.covertET())
+        return elem
+
+
+class jTestSuite(jXMLBase):
+    _case_lst = None
+
+    def __init__(self, name: str):
+        super().__init__("testsuite")
+        self.setName(name)
+        self._case_lst = list()
+        for i in ["disabled", "tests", "passed", "errors", "failures", "skipped"]:
+            self._attr_dict[i] = 0
+        self._attr_dict["kernel"] = subprocess.getoutput("uname -r")
+        self._attr_dict["os"] = (
+            "wsl" if "microsoft" in platform.platform().lower() else "linux"
+        )
+
+    def setPlatform(self, platform):
+        self._attr_dict["platform"] = platform
+
+    def addCase(self, case: jTestCase):
+        if case.result == jResult.FAIL:
+            self._attr_dict["failures"] += 1
+        elif case.result == jResult.ERROR:
+            self._attr_dict["errors"] += 1
+        elif case.result == jResult.SKIP:
+            self._attr_dict["skipped"] += 1
+        elif case.result == jResult.DISABLE:
+            self._attr_dict["disabled"] += 1
+        else:
+            self._attr_dict["passed"] += 1
+        self._case_lst.append(case)
+
+    def covertET(self) -> et:
+        self._attr_dict["tests"] = len(self._case_lst)
+        elem = super().covertET()
+        for jxml in self._case_lst:
+            elem.append(jxml.covertET())
+        return elem

--- a/backends/intel_hpu/tests/pr-test-run.py
+++ b/backends/intel_hpu/tests/pr-test-run.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import os
+import argparse
+import fnmatch
+
+realwd = os.path.dirname(os.path.realpath(__file__))
+pdpd_pcd_unit_test_path = os.environ.get(
+    "PDPD_PCD_UNITTEST_DIR", "/PaddleCustomDevice/backends/intel_hpu/tests/unittests"
+)
+
+os.environ.setdefault("GAUDI2_CI", "1")
+
+
+def case_command(command, test_case=None, test_suite=None):
+    output = ""
+    output += f"Command: {command}\n"
+    proc = subprocess.Popen(
+        command, bufsize=0, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    try:
+        line = proc.stdout.readline().decode()
+        while len(line) > 0:
+            print(f"{line[:-1]}")  # line include '\n' at last
+            output += line
+            line = proc.stdout.readline().decode()
+    except Exception as e:
+        if test_case:
+            test_case.setFail("Command abnormally")
+        print(e)
+    finally:
+        proc.communicate()
+    if proc.returncode != 0 and test_case:
+        test_case.setFail(f"Command return code:{proc.returncode}")
+    if test_case:
+        test_case.AddOutput(output)
+    if test_suite:
+        ts.addCase(test_case)
+
+    return proc.returncode, output
+
+
+def run_unit_test(test_suite, test_case, cmd_env=""):
+    testcase_name = test_case.get("testcase_name", "")
+    testcase_path = test_case.get("testcase_path", "")
+
+    run_cmd = f"python {testcase_path}"
+    _env = os.environ.copy()
+    for opt in cmd_env.split():
+        _env.setdefault(opt.split("=")[0], opt.split("=")[1])
+    print(f"RUN shell CMD: {cmd_env} {run_cmd}")
+
+    testcase = None
+    if test_suite:
+        testcase = jTestCase(testcase_name)
+    else:
+        testcase = None
+
+    ret, output = case_command(run_cmd, testcase, test_suite)
+
+
+cmd_args = {}
+parser = argparse.ArgumentParser(
+    description="help scriopt for run the test",
+    add_help=True,
+    formatter_class=argparse.RawTextHelpFormatter,
+)
+parser.add_argument(
+    "--test_path",
+    type=str,
+    help="path of PaddleCustomDevice unit tests folder",
+    default=pdpd_pcd_unit_test_path,
+)
+parser.add_argument("--platform", type=str, help="platform name")
+parser.add_argument("--junit", type=str, help="junit result file")
+parser.add_argument("--k", type=str, help="designative test case name to run")
+
+cmd_args.update(vars(parser.parse_args()))
+
+if cmd_args["junit"]:
+    libpath = os.path.dirname(os.path.dirname(realwd))
+    if os.path.exists(f"{libpath}/junitxml.py"):
+        import sys
+
+        sys.path.append(libpath)
+    from junitxml import jTestSuite, jTestCase
+
+test_platform = "Gaudi2"
+if cmd_args["platform"]:
+    test_platform = cmd_args["platform"]
+
+if os.path.exists(cmd_args["test_path"]) is False:
+    print(
+        "test path not exist, please check for parameter: test_path / environment PDPD_PCD_UNITTEST_DIR"
+    )
+    exit(2)
+
+test_case_dict_lst = []
+
+pdpd_pcd_unittest_path = cmd_args["test_path"]
+for file in os.listdir(os.path.dirname(pdpd_pcd_unittest_path)):
+    if fnmatch.fnmatch(file, "*.py"):
+        absfile = os.path.join(os.path.dirname(pdpd_pcd_unittest_path), file)
+        test_case_dict = {}
+        test_case_dict["testcase_name"] = file
+        test_case_dict["testcase_path"] = absfile
+        test_case_dict_lst.append(test_case_dict)
+
+ts = None
+if cmd_args["junit"]:
+    ts = jTestSuite("PaddleCustomDevice/UnitTests")
+    ts.setPlatform(test_platform)
+
+match_test_case_name = ""
+if cmd_args["k"]:
+    match_test_case_name = cmd_args["k"]
+    match_test_case_name = match_test_case_name.strip()
+
+script_path = os.path.dirname(os.path.realpath(__file__))
+os.chdir(script_path)
+
+for test_case in test_case_dict_lst:
+    testcase_name = test_case.get("testcase_name", "")
+    if match_test_case_name and match_test_case_name not in testcase_name:
+        continue
+    run_unit_test(ts, test_case)
+
+if cmd_args["junit"]:
+    with open(cmd_args["junit"], "w+") as f:
+        f.write(ts.toString())
+    print(ts.toString(True))


### PR DESCRIPTION
export PYTHONPATH=/workspace/pdpd_ci/PaddleCustomDevice/python/:\ /workspace/pdpd_ci/PaddleCustomDevice/Paddle/test/legacy_test/

python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/\ backends/intel_hpu/tests/unittests/

python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/\ backends/intel_hpu/tests/unittests/ --junit test_result.xml --platform gaudi2

python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/\ backends/intel_hpu/tests/unittests/ --junit test_result.xml \ --platform gaudi2 --k test_abs_op
python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/\ backends/intel_hpu/tests/unittests/ --junit test_result.xml \ --platform gaudi2 --k test_abs_op.py