### PR TITLE
[Intel HPU] added FLAGS_selected_intel_hpus support

### DIFF
--- a/backends/intel_hpu/tests/unittests/test_abs_op.py
+++ b/backends/intel_hpu/tests/unittests/test_abs_op.py
@@ -21,6 +21,10 @@ import paddle
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestNPUAbs(OpTest):
     def setUp(self):
@@ -39,7 +43,7 @@ class TestNPUAbs(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32

--- a/backends/intel_hpu/tests/unittests/test_abs_op_eager.py
+++ b/backends/intel_hpu/tests/unittests/test_abs_op_eager.py
@@ -25,6 +25,10 @@ from tests.op_test import (
     convert_uint16_to_float,
 )
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestNPUAbsBF16(OpTest):
     def setUp(self):
@@ -44,7 +48,7 @@ class TestNPUAbsBF16(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_check_output(self):
         self.check_output_with_place(self.place)

--- a/backends/intel_hpu/tests/unittests/test_activation_op.py
+++ b/backends/intel_hpu/tests/unittests/test_activation_op.py
@@ -28,11 +28,15 @@ from tests.utils import static_guard
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()
@@ -177,7 +181,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -268,7 +272,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -341,7 +345,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 #         self.executed_api()
 
 #     def executed_api(self):
@@ -531,7 +535,7 @@ class TestReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):
@@ -599,7 +603,7 @@ class TestReluAPI(unittest.TestCase):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 10, [10, 12]).astype(np.float64)
 #         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -700,7 +704,7 @@ class TestSqrt(TestActivation):
 #         self.out = np.sqrt(convert_uint16_to_float(self.x))
 
 #     def test_check_output(self):
-#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0), atol=0.004)
+#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), atol=0.004)
 
 #     def test_check_grad(self):
 #         pass
@@ -726,7 +730,7 @@ class TestSqrt(TestActivation):
 #         self.out = 1.0 / np.sqrt(convert_uint16_to_float(self.x))
 
 #     def test_check_output(self):
-#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0), atol=0.004)
+#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), atol=0.004)
 
 #     def test_check_grad(self):
 #         pass
@@ -774,7 +778,7 @@ class TestTanhAPI(unittest.TestCase):
         self.dtype = "float32"
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):
@@ -842,7 +846,7 @@ class TestFloor(TestActivation):
 #     def setUp(self):
 #         self.set_npu()
 #         self.op_type = "softshrink"
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 #         self.init_dtype()
 #         self.init_shape()
 
@@ -884,7 +888,7 @@ class TestFloor(TestActivation):
 #         self.threshold = 0.8
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(0.25, 10, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -967,7 +971,7 @@ class TestFloor(TestActivation):
 #         self.threshold = 15
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -1050,7 +1054,7 @@ class TestSin(TestActivation):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         with static_guard():
@@ -1115,7 +1119,7 @@ class TestSiluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_static_api(self):
         with static_guard():
@@ -1176,7 +1180,7 @@ class TestSiluAPI(unittest.TestCase):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         with static_guard():

--- a/backends/intel_hpu/tests/unittests/test_arg_max_op.py
+++ b/backends/intel_hpu/tests/unittests/test_arg_max_op.py
@@ -22,6 +22,10 @@ import paddle.base.core as core
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestHpuArgMaxOp(OpTest):
     def setUp(self):
@@ -38,7 +42,7 @@ class TestHpuArgMaxOp(OpTest):
 
     def set_hpu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.int32

--- a/backends/intel_hpu/tests/unittests/test_cast.py
+++ b/backends/intel_hpu/tests/unittests/test_cast.py
@@ -29,6 +29,10 @@ from tests.op_test import (
 
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 @skip_check_grad_ci(reason="[skip INTEL HPU cast grad check] not implemented yet.")
 class TestCastBF16(OpTest):
@@ -37,7 +41,7 @@ class TestCastBF16(OpTest):
         self.init_dtype()
         self.init_shape()
         self.op_type = "cast"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
         ipt = np.random.random(size=self.shape) + 1
         x = convert_float_to_uint16(ipt.astype(self.input_dtype))
@@ -230,7 +234,7 @@ class TestCastOpFp32ToFp64(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "cast"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
         ipt = np.random.random(size=[10, 10])
         self.inputs = {"X": ipt.astype("float32")}

--- a/backends/intel_hpu/tests/unittests/test_concat.py
+++ b/backends/intel_hpu/tests/unittests/test_concat.py
@@ -23,6 +23,10 @@ from tests.op_test import skip_check_grad_ci
 
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
@@ -32,7 +36,7 @@ class TestConcatOp(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "concat"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.init_dtype()
         self.init_test_data()
 

--- a/backends/intel_hpu/tests/unittests/test_contiguous.py
+++ b/backends/intel_hpu/tests/unittests/test_contiguous.py
@@ -19,6 +19,10 @@ import paddle
 import unittest
 import numpy as np
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestContiguous(unittest.TestCase):
     def setUp(self):

--- a/backends/intel_hpu/tests/unittests/test_cumsum_op.py
+++ b/backends/intel_hpu/tests/unittests/test_cumsum_op.py
@@ -20,6 +20,10 @@ import numpy as np
 from tests.op_test import OpTest
 import paddle
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestHPUCumSumOp(OpTest):
     def setUp(self):
@@ -33,7 +37,7 @@ class TestHPUCumSumOp(OpTest):
 
     def set_hpu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.int32

--- a/backends/intel_hpu/tests/unittests/test_elementwise_add_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_add_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseAddOp(OpTest):
     def setUp(self):
@@ -40,7 +44,7 @@ class TestElementwiseAddOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input_output(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_div_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_div_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseDivOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwiseDivOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_max_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_max_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseMaxOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwiseMaxOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_min_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_min_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseMinOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwiseMinOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_mod_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_mod_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseModOp(OpTest):
     def setUp(self):
@@ -40,7 +44,7 @@ class TestElementwiseModOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input_output(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_mul_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_mul_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseMulOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwiseMulOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_pow_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_pow_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwisePowOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwisePowOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_elementwise_sub_op.py
+++ b/backends/intel_hpu/tests/unittests/test_elementwise_sub_op.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestElementwiseSubOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestElementwiseSubOp(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_input(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_expand.py
+++ b/backends/intel_hpu/tests/unittests/test_expand.py
@@ -23,11 +23,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestExpandV2HPUOp(OpTest):
     def setUp(self):
         self.set_hpu()
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.op_type = "expand_v2"
         self.init_dtype()
         self.init_data()

--- a/backends/intel_hpu/tests/unittests/test_floor.py
+++ b/backends/intel_hpu/tests/unittests/test_floor.py
@@ -25,11 +25,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()

--- a/backends/intel_hpu/tests/unittests/test_full_like_op.py
+++ b/backends/intel_hpu/tests/unittests/test_full_like_op.py
@@ -22,6 +22,10 @@ from paddle.base.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestHPU(OpTest):
     def setUp(self):
@@ -43,7 +47,7 @@ class TestHPU(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -72,7 +76,7 @@ class TestHPU_INT64(TestHPU):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = "int64"

--- a/backends/intel_hpu/tests/unittests/test_full_op.py
+++ b/backends/intel_hpu/tests/unittests/test_full_op.py
@@ -22,6 +22,10 @@ from paddle.base.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestHPU(OpTest):
     def setUp(self):
@@ -43,7 +47,7 @@ class TestHPU(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -72,7 +76,7 @@ class TestHPU_BOOL(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.bool

--- a/backends/intel_hpu/tests/unittests/test_gather.py
+++ b/backends/intel_hpu/tests/unittests/test_gather.py
@@ -24,6 +24,10 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 def gather_numpy(x, index, axis):
     x_transpose = np.swapaxes(x, 0, axis)
@@ -35,7 +39,7 @@ def gather_numpy(x, index, axis):
 class TestGatherOp(OpTest):
     def setUp(self):
         self.set_intel_hpu()
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.op_type = "gather"
         self.config()
         xnp = np.random.random(self.x_shape).astype(self.x_type)
@@ -126,7 +130,7 @@ class API_TestGather(unittest.TestCase):
             data1 = paddle.static.data("data1", shape=[-1, 2], dtype="float32")
             index = paddle.static.data("index", shape=[-1, 1], dtype="int32")
             out = paddle.gather(data1, index)
-            place = paddle.CustomPlace("intel_hpu", 0)
+            place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             exe = base.Executor(place)
             input = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
             index_1 = np.array([1, 2]).astype("int32")
@@ -143,7 +147,7 @@ class API_TestGather(unittest.TestCase):
             x = paddle.static.data("x", shape=[-1, 2], dtype="float32")
             index = paddle.static.data("index", shape=[-1, 1], dtype="int32")
             out = paddle.gather(x, index)
-            place = paddle.CustomPlace("intel_hpu", 0)
+            place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             exe = paddle.static.Executor(place)
             x_np = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
             index_np = np.array([1, 1]).astype("int32")

--- a/backends/intel_hpu/tests/unittests/test_gather_nd.py
+++ b/backends/intel_hpu/tests/unittests/test_gather_nd.py
@@ -20,6 +20,10 @@ import numpy as np
 from tests.op_test import OpTest, skip_check_grad_ci
 import paddle
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 def gather_nd_grad(x, index):
     dout_shape = index.shape[:-1] + x.shape[index.shape[-1] :]
@@ -44,7 +48,7 @@ def test_class1(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             xnp = np.random.random((5, 20)).astype(typename)
             self.inputs = {"X": xnp, "Index": np.array([[], []]).astype("int32")}
@@ -68,7 +72,7 @@ def test_class2(op_type, typename):
     class TestGatherNdOpWithIndex1(OpTest):
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             xnp = np.random.random((5, 20)).astype(typename)
             self.inputs = {"X": xnp, "Index": np.array([1]).astype("int32")}
@@ -100,7 +104,7 @@ def test_class3(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([[1], [2]]).astype("int64")
@@ -129,7 +133,7 @@ def test_class4(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([1, 2]).astype("int64")
@@ -161,7 +165,7 @@ def test_class5(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             xnp = np.random.uniform(0, 100, (10, 10)).astype(typename)
             index = np.array([[1, 1], [2, 1]]).astype("int64")
@@ -192,7 +196,7 @@ def test_class6(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             shape = (5, 2, 3, 1, 10)
             xnp = np.random.rand(*shape).astype(typename)
@@ -224,7 +228,7 @@ def test_class7(op_type, typename):
 
         def setUp(self):
             self.set_npu()
-            self.place = paddle.CustomPlace("intel_hpu", 0)
+            self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
             self.op_type = "gather_nd"
             shape = (2, 3, 4, 1, 10)
             xnp = np.random.rand(*shape).astype(typename)

--- a/backends/intel_hpu/tests/unittests/test_index_sample.py
+++ b/backends/intel_hpu/tests/unittests/test_index_sample.py
@@ -22,6 +22,10 @@ import paddle
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestIndexSampleOp(OpTest):
     def set_npu(self):
@@ -45,10 +49,14 @@ class TestIndexSampleOp(OpTest):
         self.outputs = {"Out": out}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0))
+        self.check_output_with_place(
+            paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
+        )
 
     def test_check_grad(self):
-        self.check_grad_with_place(paddle.CustomPlace("intel_hpu", 0), ["X"], "Out")
+        self.check_grad_with_place(
+            paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), ["X"], "Out"
+        )
 
     def config(self):
         """

--- a/backends/intel_hpu/tests/unittests/test_pow.py
+++ b/backends/intel_hpu/tests/unittests/test_pow.py
@@ -28,11 +28,15 @@ from tests.utils import static_guard
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()
@@ -177,7 +181,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -268,7 +272,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -341,7 +345,7 @@ def ref_leaky_relu(x, alpha=0.01):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-3, 3, [10, 12]).astype("float32")
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 #         self.executed_api()
 
 #     def executed_api(self):
@@ -531,7 +535,7 @@ class TestReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):
@@ -599,7 +603,7 @@ class TestReluAPI(unittest.TestCase):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 10, [10, 12]).astype(np.float64)
 #         self.x_np[np.abs(self.x_np) < 0.005] = 0.02
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -700,7 +704,7 @@ class TestSqrt(TestActivation):
 #         self.out = np.sqrt(convert_uint16_to_float(self.x))
 
 #     def test_check_output(self):
-#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0), atol=0.004)
+#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), atol=0.004)
 
 #     def test_check_grad(self):
 #         pass
@@ -726,7 +730,7 @@ class TestSqrt(TestActivation):
 #         self.out = 1.0 / np.sqrt(convert_uint16_to_float(self.x))
 
 #     def test_check_output(self):
-#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0), atol=0.004)
+#         self.check_output_with_place(paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), atol=0.004)
 
 #     def test_check_grad(self):
 #         pass
@@ -774,7 +778,7 @@ class TestTanhAPI(unittest.TestCase):
         self.dtype = "float32"
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):
@@ -842,7 +846,7 @@ class TestFloor(TestActivation):
 #     def setUp(self):
 #         self.set_npu()
 #         self.op_type = "softshrink"
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 #         self.init_dtype()
 #         self.init_shape()
 
@@ -884,7 +888,7 @@ class TestFloor(TestActivation):
 #         self.threshold = 0.8
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(0.25, 10, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -967,7 +971,7 @@ class TestFloor(TestActivation):
 #         self.threshold = 15
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         paddle.enable_static()
@@ -1050,7 +1054,7 @@ class TestSin(TestActivation):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         with static_guard():
@@ -1115,7 +1119,7 @@ class TestSiluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_static_api(self):
         with static_guard():
@@ -1176,7 +1180,7 @@ class TestSiluAPI(unittest.TestCase):
 #     def setUp(self):
 #         np.random.seed(1024)
 #         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(np.float64)
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_static_api(self):
 #         with static_guard():

--- a/backends/intel_hpu/tests/unittests/test_reduce_any.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_any.py
@@ -22,6 +22,9 @@ import paddle
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
 
 # class TestAny8DOp(OpTest):
 #     def setUp(self):
@@ -35,10 +38,10 @@ paddle.enable_static()
 
 #     def set_hpu(self):
 #         self.__class__.use_custom_device = True
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_check_output(self):
-#         self.check_output_with_place(self.place)
+#         self.check_output_with_place(self.place)int(intel_hpus_module_id)
 
 
 class TestAnyOpWithDim(OpTest):
@@ -51,7 +54,7 @@ class TestAnyOpWithDim(OpTest):
 
     def set_hpu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -69,7 +72,7 @@ class TestAnyOpWithDim(OpTest):
 
 #     def set_hpu(self):
 #         self.__class__.use_custom_device = True
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_check_output(self):
 #         self.check_output_with_place(self.place)
@@ -87,7 +90,7 @@ class TestAnyOpWithKeepDim(OpTest):
 
     def set_hpu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_check_output(self):
         self.check_output_with_place(self.place)
@@ -107,7 +110,7 @@ class TestAnyOpWithKeepDim(OpTest):
 
 #     def set_hpu(self):
 #         self.__class__.use_custom_device = True
-#         self.place = paddle.CustomPlace("intel_hpu", 0)
+#         self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 #     def test_check_output(self):
 #         self.check_output_with_place(self.place)

--- a/backends/intel_hpu/tests/unittests/test_reduce_max.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_max.py
@@ -22,6 +22,10 @@ import paddle.base.core as core
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 @skip_check_grad_ci(
     reason="reduce_max is discontinuous non-derivable function,"
@@ -44,7 +48,7 @@ class TestNPUReduceMaxOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -71,7 +75,7 @@ class TestNPUReduceMaxOpRank(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32

--- a/backends/intel_hpu/tests/unittests/test_reduce_mean.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_mean.py
@@ -23,6 +23,10 @@ from tests.op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestMeanOp(OpTest):
     def set_npu(self):
@@ -39,7 +43,9 @@ class TestMeanOp(OpTest):
         self.x = np.random.random((5, 6, 10)).astype("float32")
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0))
+        self.check_output_with_place(
+            paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
+        )
 
     def test_check_grad(self):
         pass
@@ -69,7 +75,9 @@ class TestMeanOpFP16(OpTest):
         self.outputs = {"Out": self.inputs["X"].mean(axis=0)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0))
+        self.check_output_with_place(
+            paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
+        )
 
     def test_check_grad(self):
         pass
@@ -99,7 +107,9 @@ class TestMeanOpBF16(OpTest):
         self.out = convert_uint16_to_float(self.x).mean(axis=0)
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.CustomPlace("intel_hpu", 0), atol=0.004)
+        self.check_output_with_place(
+            paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id)), atol=0.004
+        )
 
     def test_check_grad(self):
         pass

--- a/backends/intel_hpu/tests/unittests/test_reduce_min.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_min.py
@@ -22,6 +22,10 @@ import paddle.base.core as core
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 @skip_check_grad_ci(
     reason="reduce_min is discontinuous non-derivable function,"
@@ -44,7 +48,7 @@ class TestNPUReduceMinOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32

--- a/backends/intel_hpu/tests/unittests/test_reduce_prod.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_prod.py
@@ -22,6 +22,10 @@ import paddle.base.core as core
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestNPUReduceProd(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestNPUReduceProd(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32

--- a/backends/intel_hpu/tests/unittests/test_reduce_sum.py
+++ b/backends/intel_hpu/tests/unittests/test_reduce_sum.py
@@ -23,13 +23,17 @@ from tests.op_test import OpTest, skip_check_grad_ci
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestReduceSum(OpTest):
     def setUp(self):
         np.random.seed(SEED)
         self.set_npu()
         self.init_dtype()
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.init_op_type()
         self.initTestCase()
 

--- a/backends/intel_hpu/tests/unittests/test_relu.py
+++ b/backends/intel_hpu/tests/unittests/test_relu.py
@@ -26,11 +26,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()
@@ -92,7 +96,7 @@ class TestReluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):

--- a/backends/intel_hpu/tests/unittests/test_scale.py
+++ b/backends/intel_hpu/tests/unittests/test_scale.py
@@ -21,6 +21,10 @@ import paddle
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestHpuScaleOp(OpTest):
     def setUp(self):
@@ -41,7 +45,7 @@ class TestHpuScaleOp(OpTest):
 
     def set_hpu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float16
@@ -81,7 +85,7 @@ class TestBiasAfterScale(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "scale"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.init_dtype()
 
         self.inputs = {

--- a/backends/intel_hpu/tests/unittests/test_scatter_hpu.py
+++ b/backends/intel_hpu/tests/unittests/test_scatter_hpu.py
@@ -21,12 +21,16 @@ import paddle
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class test_gather_i64_ow(OpTest):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
         x = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
         index = np.array([2, 1, 0, 1]).astype("int64")
@@ -49,7 +53,7 @@ class test_gather_i64_no_ow(OpTest):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.python_api = paddle.scatter
 
         x = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
@@ -76,7 +80,7 @@ class test_gather_i32_ow(OpTest):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
         x = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
         index = np.array([2, 1, 0, 1]).astype("int32")
@@ -99,7 +103,7 @@ class test_gather_i32_no_ow(OpTest):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.python_api = paddle.scatter
 
         x = np.array([[1, 2], [3, 4], [5, 6]]).astype("float32")
@@ -126,7 +130,7 @@ class test_gather_fp32_no_ow(OpTest):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.python_api = paddle.scatter
 
         ref_np = np.ones((3, 2)).astype("float32")
@@ -159,7 +163,7 @@ class test_gather_fp32_no_ow_2(test_gather_fp32_no_ow):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.python_api = paddle.scatter
 
         ref_np = np.ones((3, 2)).astype("float32")
@@ -177,7 +181,7 @@ class test_gather_fp32_no_ow_3(test_gather_fp32_no_ow):
     def setUp(self):
         self.set_hpu()
         self.op_type = "scatter"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
         ref_np = np.ones((3, 2)).astype("float32")
         index_np = np.array([1, 2]).astype("int32")

--- a/backends/intel_hpu/tests/unittests/test_sigmoid.py
+++ b/backends/intel_hpu/tests/unittests/test_sigmoid.py
@@ -25,11 +25,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()

--- a/backends/intel_hpu/tests/unittests/test_silu.py
+++ b/backends/intel_hpu/tests/unittests/test_silu.py
@@ -27,11 +27,15 @@ from tests.utils import static_guard
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()
@@ -96,7 +100,7 @@ class TestSiluAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [11, 17]).astype("float32")
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def test_static_api(self):
         with static_guard():

--- a/backends/intel_hpu/tests/unittests/test_sin.py
+++ b/backends/intel_hpu/tests/unittests/test_sin.py
@@ -25,11 +25,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()

--- a/backends/intel_hpu/tests/unittests/test_slice.py
+++ b/backends/intel_hpu/tests/unittests/test_slice.py
@@ -22,11 +22,15 @@ from tests.op_test import OpTest
 
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestSliceOp(OpTest):
     def setUp(self):
         self.set_hpu()
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.op_type = "slice"
         self.init_dtype()
         self.config()

--- a/backends/intel_hpu/tests/unittests/test_softmax.py
+++ b/backends/intel_hpu/tests/unittests/test_softmax.py
@@ -22,11 +22,15 @@ from tests.op_test import OpTest
 
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestSoftmax(OpTest):
     def setUp(self):
         self.set_npu()
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.op_type = "softmax"
         self.init_dtype()
 

--- a/backends/intel_hpu/tests/unittests/test_split.py
+++ b/backends/intel_hpu/tests/unittests/test_split.py
@@ -19,12 +19,16 @@ import unittest
 from tests.op_test import OpTest
 import paddle
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class HPUOpTest(OpTest):
     def set_plugin(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
 
 class TestHPUSplitOp(HPUOpTest):

--- a/backends/intel_hpu/tests/unittests/test_sqrt.py
+++ b/backends/intel_hpu/tests/unittests/test_sqrt.py
@@ -25,11 +25,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()

--- a/backends/intel_hpu/tests/unittests/test_swiglu_op.py
+++ b/backends/intel_hpu/tests/unittests/test_swiglu_op.py
@@ -20,6 +20,10 @@ import paddle.nn.functional as F
 import paddle.incubate.nn.functional.swiglu as swigluimpl
 from tests.op_test import convert_float_to_uint16, convert_uint16_to_float
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 def swiglu_naive(x, y=None):
     if y is None:
@@ -30,7 +34,7 @@ def swiglu_naive(x, y=None):
 #  只有X，Y为空
 class TestSwigluFP16OnlyX(unittest.TestCase):
     def setUp(self):
-        self.npu_place = paddle.CustomPlace("intel_hpu", 0)
+        self.npu_place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.shape = (20, 512)
         self.init_dtype()
 
@@ -158,7 +162,7 @@ class TestSwigluFP32BothXY(TestSwigluFP16BothXY):
 
 class TestSwigluFP16BothXY3D(TestSwigluFP16BothXY):
     def setUp(self):
-        self.npu_place = paddle.CustomPlace("intel_hpu", 0)
+        self.npu_place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.shape = (2, 20, 512)
         self.init_dtype()
 

--- a/backends/intel_hpu/tests/unittests/test_tanh.py
+++ b/backends/intel_hpu/tests/unittests/test_tanh.py
@@ -26,11 +26,15 @@ from tests.op_test import OpTest
 paddle.enable_static()
 SEED = 2021
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestActivation(OpTest):
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def setUp(self):
         self.set_npu()
@@ -91,7 +95,7 @@ class TestTanhAPI(unittest.TestCase):
         self.dtype = "float32"
         np.random.seed(1024)
         self.x_np = np.random.uniform(-1, 1, [10, 12]).astype(self.dtype)
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.executed_api()
 
     def executed_api(self):

--- a/backends/intel_hpu/tests/unittests/test_top_p_sampling.py
+++ b/backends/intel_hpu/tests/unittests/test_top_p_sampling.py
@@ -14,6 +14,10 @@
 import unittest
 import paddle
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class top_p_sampling_test(unittest.TestCase):
     def is_token_in_targets(self, tokens, target_tensors):

--- a/backends/intel_hpu/tests/unittests/test_transpose_op_eager.py
+++ b/backends/intel_hpu/tests/unittests/test_transpose_op_eager.py
@@ -19,12 +19,16 @@ import unittest
 from tests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 import paddle
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestTransposeOp(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "transpose2"
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
         self.init_dtype()
         self.init_shape_axis()
 

--- a/backends/intel_hpu/tests/unittests/test_tril_triu.py
+++ b/backends/intel_hpu/tests/unittests/test_tril_triu.py
@@ -22,6 +22,10 @@ from tests.op_test import OpTest
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestTrilTriu(OpTest):
     def setUp(self):
@@ -45,7 +49,7 @@ class TestTrilTriu(OpTest):
     def set_hpu(self):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def initTestCase(self):
         np.random.seed(1024)

--- a/backends/intel_hpu/tests/unittests/test_uniform.py
+++ b/backends/intel_hpu/tests/unittests/test_uniform.py
@@ -26,6 +26,10 @@ import paddle.base as base
 
 paddle.enable_static()
 
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
 
 class TestUniformRandomOp(OpTest):
     def setUp(self):
@@ -111,7 +115,7 @@ class TestNPUUniformRandomOp(OpTest):
 
     def set_npu(self):
         self.__class__.use_custom_device = True
-        self.place = paddle.CustomPlace("intel_hpu", 0)
+        self.place = paddle.CustomPlace("intel_hpu", int(intel_hpus_module_id))
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -129,7 +133,7 @@ class TestNPUUniformRandomOp(OpTest):
 class TestNPUUniformRandomOpSelectedRows(unittest.TestCase):
     def get_places(self):
         places = [core.CPUPlace()]
-        places.append(core.CustomPlace("intel_hpu", 0))
+        places.append(core.CustomPlace("intel_hpu", int(intel_hpus_module_id)))
         return places
 
     def test_check_output(self):


### PR DESCRIPTION
currently, when hpu=0 was used, all unit test cases will be failed, although many HPUs are available

after this patch:
when the env FLAGS_selected_intel_hpus setuped,
all unit test will use hpu=FLAGS_selected_intel_hpus 
otherwise it will use hpu=0