### PR TITLE
[INTEL_HPU] refine kernels use one recipe and fix issues

### DIFF
--- a/backends/intel_hpu/kernels/arange_kernel.cc
+++ b/backends/intel_hpu/kernels/arange_kernel.cc
@@ -55,7 +55,7 @@ class Range : public HpuOperator {
 class RangeI64 : public HpuOperator {
  public:
   RangeI64() : HpuOperator("range") {}
-  void AddNodeI64(ConvertTensors& ct, RangeParams& params) {
+  void AddNode(ConvertTensors& ct, RangeParams& params) {
     auto outputs = ct.GetTensors(false);
 
     std::vector<synTensor> range_out;

--- a/backends/intel_hpu/kernels/compare_kernel.cc
+++ b/backends/intel_hpu/kernels/compare_kernel.cc
@@ -557,6 +557,7 @@ PD_REGISTER_PLUGIN_KERNEL(equal,
                           uint8_t,
                           int16_t,
                           int32_t,
+                          int64_t,
                           bool) {}
 
 PD_REGISTER_PLUGIN_KERNEL(equal_raw,
@@ -579,6 +580,7 @@ PD_REGISTER_PLUGIN_KERNEL(less_than,
                           float,
                           uint8_t,
                           int32_t,
+                          int64_t,
                           bool) {}
 
 PD_REGISTER_PLUGIN_KERNEL(less_than_raw,
@@ -644,6 +646,7 @@ PD_REGISTER_PLUGIN_KERNEL(greater_equal,
                           float,
                           uint8_t,
                           int32_t,
+                          int64_t,
                           bool) {}
 
 PD_REGISTER_PLUGIN_KERNEL(greater_equal_raw,

--- a/backends/intel_hpu/kernels/compare_kernel.cc
+++ b/backends/intel_hpu/kernels/compare_kernel.cc
@@ -22,25 +22,6 @@ struct CompareParams {
   std::string op;
 };
 
-template <typename T, typename Context>
-void LogicalNotKernel(const Context& dev_ctx,
-                      const phi::DenseTensor& x,
-                      phi::DenseTensor* out);
-
-template <typename T, typename Context>
-void EqualRawKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    const phi::DenseTensor& y,
-                    int axis,
-                    phi::DenseTensor* out);
-
-template <typename T, typename Context>
-void GreaterEqualRawKernel(const Context& dev_ctx,
-                           const phi::DenseTensor& x,
-                           const phi::DenseTensor& y,
-                           int axis,
-                           phi::DenseTensor* out);
-
 class Compare : public HpuOperator {
  public:
   Compare() : HpuOperator("compare") {}
@@ -84,20 +65,206 @@ class Compare : public HpuOperator {
   }
 };
 
+class CompareCast : public HpuOperator {
+ public:
+  CompareCast() : HpuOperator("compare") {}
+  void AddNode(ConvertTensors& ct, CompareParams& params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    std::vector<synTensor> x_i64;
+    x_i64.push_back(createTensor(inputs[0].dims.size(),
+                                 inputs[0].type,
+                                 inputs[0].dims,
+                                 true,
+                                 inputs[0].name));
+    std::vector<synTensor> x_i32;
+    auto x_cast = createTensor(
+        inputs[0].dims.size(), syn_type_int32, inputs[0].dims, false, "x_cast");
+    x_i32.push_back(x_cast);
+
+    std::string guid_cast = "cast_i64_to_i32";
+    synStatus status = synNodeCreate(graphHandle_,
+                                     x_i64.data(),
+                                     x_i32.data(),
+                                     x_i64.size(),
+                                     x_i32.size(),
+                                     nullptr,
+                                     0,
+                                     guid_cast.c_str(),
+                                     "cast_x",
+                                     nullptr,
+                                     nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (compare/cast_x) failed = ",
+             status);
+
+    std::vector<synTensor> y_i64;
+    y_i64.push_back(createTensor(inputs[1].dims.size(),
+                                 inputs[1].type,
+                                 inputs[1].dims,
+                                 true,
+                                 inputs[1].name));
+
+    std::vector<synTensor> y_i32;
+    auto y_cast = createTensor(
+        inputs[1].dims.size(), syn_type_int32, inputs[1].dims, false, "y_cast");
+    y_i32.push_back(y_cast);
+
+    status = synNodeCreate(graphHandle_,
+                           y_i64.data(),
+                           y_i32.data(),
+                           y_i64.size(),
+                           y_i32.size(),
+                           nullptr,
+                           0,
+                           guid_cast.c_str(),
+                           "cast_y",
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (compare/cast_x) failed = ",
+             status);
+
+    std::vector<synTensor> syn_inputs;
+    syn_inputs.push_back(x_cast);
+    syn_inputs.push_back(y_cast);
+
+    std::vector<synTensor> syn_outputs;
+    for (size_t i = 0; i < outputs.size(); i++) {
+      syn_outputs.push_back(createTensor(outputs[i].dims.size(),
+                                         outputs[i].type,
+                                         outputs[i].dims,
+                                         true,
+                                         outputs[i].name));
+    }
+
+    std::string guid = params.op + "_fwd_i32";
+
+    status = synNodeCreate(graphHandle_,
+                           syn_inputs.data(),
+                           syn_outputs.data(),
+                           syn_inputs.size(),
+                           syn_outputs.size(),
+                           nullptr,
+                           0,
+                           guid.c_str(),
+                           params.op.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (compare) failed = ",
+             status);
+  }
+};
+
+class CompareNotEqual : public HpuOperator {
+ public:
+  CompareNotEqual() : HpuOperator("compare") {}
+  void AddNode(ConvertTensors& ct, CompareParams& params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    std::vector<synTensor> syn_inputs;
+    for (size_t i = 0; i < inputs.size(); i++) {
+      syn_inputs.push_back(createTensor(inputs[i].dims.size(),
+                                        inputs[i].type,
+                                        inputs[i].dims,
+                                        true,
+                                        inputs[i].name));
+    }
+
+    std::vector<synTensor> equal_out;
+    equal_out.push_back(createTensor(outputs[0].dims.size(),
+                                     outputs[0].type,
+                                     outputs[0].dims,
+                                     false,
+                                     "equal_out"));
+
+    std::string guid_eq = "equal_fwd_i64";
+
+    synStatus status = synNodeCreate(graphHandle_,
+                                     syn_inputs.data(),
+                                     equal_out.data(),
+                                     syn_inputs.size(),
+                                     equal_out.size(),
+                                     nullptr,
+                                     0,
+                                     guid_eq.c_str(),
+                                     "equal",
+                                     nullptr,
+                                     nullptr);
+    PD_CHECK(
+        status == synSuccess, "[RUNTIME] synNodeCreate () failed = %d", status);
+
+    std::vector<synTensor> syn_outputs;
+    for (size_t i = 0; i < outputs.size(); i++) {
+      syn_outputs.push_back(createTensor(outputs[i].dims.size(),
+                                         outputs[i].type,
+                                         outputs[i].dims,
+                                         true,
+                                         outputs[i].name));
+    }
+
+    std::string guid_not = "not_fwd_i8";
+
+    status = synNodeCreate(graphHandle_,
+                           equal_out.data(),
+                           syn_outputs.data(),
+                           equal_out.size(),
+                           syn_outputs.size(),
+                           nullptr,
+                           0,
+                           guid_not.c_str(),
+                           "not",
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess, "[RUNTIME] synNodeCreate () failed = %d", status);
+  }
+};
+
 template <typename T, typename Context>
 void NotEqualRawKernel(const Context& dev_ctx,
                        const phi::DenseTensor& x,
                        const phi::DenseTensor& y,
                        int axis,
                        phi::DenseTensor* out) {
-  phi::DenseTensor tmp;
-  phi::DenseTensorMeta meta({x.dtype(), x.dims()});
-  tmp.set_meta(meta);
-  custom_kernel::EqualRawKernel<T, Context>(dev_ctx, x, y, axis, &tmp);
-  // Need refine this logic later since input and output dims may be different
-  // for reduce_all case
-  if (tmp.dims() != out->dims()) tmp.Resize(out->dims());
-  custom_kernel::LogicalNotKernel<T, Context>(dev_ctx, tmp, out);
+  VLOG(6) << "call HPU NotEqualRawKernel";
+  dev_ctx.template Alloc<bool>(out);
+
+  ConvertTensors ct;
+  ct.Add(x);
+  ct.Add(y);
+  ct.Add(out, false);
+
+  CompareParams params;
+  params.op = "not_equal";
+  std::vector<DIMS> inputs_dims = ct.GetDims();
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, CompareParams>(
+      "NotEqualRawKernel", inputs_dims, &params);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    if (x.dtype() == phi::DataType::INT64) {
+      CompareNotEqual op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    } else {
+      Compare op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    }
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
 }
 
 template <typename T, typename Context>
@@ -114,6 +281,7 @@ void EqualRawKernel(const Context& dev_ctx,
                     const phi::DenseTensor& y,
                     int axis,
                     phi::DenseTensor* out) {
+  VLOG(6) << "call HPU EqualRawKernel";
   dev_ctx.template Alloc<bool>(out);
 
   ConvertTensors ct;
@@ -158,11 +326,41 @@ void LessThanRawKernel(const Context& dev_ctx,
                        const phi::DenseTensor& y,
                        int axis,
                        phi::DenseTensor* out) {
-  phi::DenseTensor tmp;
-  phi::DenseTensorMeta meta = {x.dtype(), x.dims()};
-  tmp.set_meta(meta);
-  custom_kernel::GreaterEqualRawKernel<T, Context>(dev_ctx, x, y, -1, &tmp);
-  custom_kernel::LogicalNotKernel<T, Context>(dev_ctx, tmp, out);
+  VLOG(6) << "call HPU LessThanRawKernel";
+  dev_ctx.template Alloc<bool>(out);
+
+  ConvertTensors ct;
+  ct.Add(x);
+  ct.Add(y);
+  ct.Add(out, false);
+
+  CompareParams params;
+  params.op = "less";
+  std::vector<DIMS> inputs_dims = ct.GetDims();
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, CompareParams>(
+      "LessThanRawKernel", inputs_dims, &params);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    if (x.dtype() == phi::DataType::INT64) {
+      CompareCast op;
+      op.AddNodeCast(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    } else {
+      Compare op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    }
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
 }
 
 template <typename T, typename Context>
@@ -179,6 +377,7 @@ void LessEqualRawKernel(const Context& dev_ctx,
                         const phi::DenseTensor& y,
                         int axis,
                         phi::DenseTensor* out) {
+  VLOG(6) << "call HPU LessEqualRawKernel";
   dev_ctx.template Alloc<bool>(out);
 
   ConvertTensors ct;
@@ -195,13 +394,19 @@ void LessEqualRawKernel(const Context& dev_ctx,
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    Compare op;
-
-    op.AddNode(ct, params);
-    op.Compile();
-    op_info.setOp(op);
-
-    recipe = op_info.GetRecipe();
+    if (x.dtype() == phi::DataType::INT64) {
+      CompareCast op;
+      op.AddNodeCast(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    } else {
+      Compare op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    }
   }
 
   std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
@@ -223,11 +428,41 @@ void GreaterThanRawKernel(const Context& dev_ctx,
                           const phi::DenseTensor& y,
                           int axis,
                           phi::DenseTensor* out) {
-  phi::DenseTensor tmp;
-  phi::DenseTensorMeta meta({x.dtype(), x.dims()});
-  tmp.set_meta(meta);
-  custom_kernel::LessEqualRawKernel<T, Context>(dev_ctx, x, y, -1, &tmp);
-  custom_kernel::LogicalNotKernel<T, Context>(dev_ctx, tmp, out);
+  VLOG(6) << "call HPU GreaterThanRawKernel";
+  dev_ctx.template Alloc<bool>(out);
+
+  ConvertTensors ct;
+  ct.Add(x);
+  ct.Add(y);
+  ct.Add(out, false);
+
+  CompareParams params;
+  params.op = "greater";
+  std::vector<DIMS> inputs_dims = ct.GetDims();
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, CompareParams>(
+      "GreaterThanRawKernel", inputs_dims, &params);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    if (x.dtype() == phi::DataType::INT64) {
+      CompareCast op;
+      op.AddNodeCast(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    } else {
+      Compare op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    }
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
 }
 
 template <typename T, typename Context>
@@ -244,6 +479,7 @@ void GreaterEqualRawKernel(const Context& dev_ctx,
                            const phi::DenseTensor& y,
                            int axis,
                            phi::DenseTensor* out) {
+  VLOG(6) << "call HPU GreaterEqualRawKernel";
   dev_ctx.template Alloc<bool>(out);
 
   ConvertTensors ct;
@@ -260,13 +496,19 @@ void GreaterEqualRawKernel(const Context& dev_ctx,
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    Compare op;
-
-    op.AddNode(ct, params);
-    op.Compile();
-    op_info.setOp(op);
-
-    recipe = op_info.GetRecipe();
+    if (x.dtype() == phi::DataType::INT64) {
+      CompareCast op;
+      op.AddNodeCast(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    } else {
+      Compare op;
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+      recipe = op_info.GetRecipe();
+    }
   }
 
   std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
@@ -288,10 +530,9 @@ PD_REGISTER_PLUGIN_KERNEL(not_equal,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::NotEqualKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -300,10 +541,9 @@ PD_REGISTER_PLUGIN_KERNEL(not_equal_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::NotEqualRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -312,8 +552,8 @@ PD_REGISTER_PLUGIN_KERNEL(equal,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::EqualKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
                           int16_t,
                           int32_t,
@@ -323,8 +563,8 @@ PD_REGISTER_PLUGIN_KERNEL(equal_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::EqualRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
                           int16_t,
                           int32_t,
@@ -335,10 +575,9 @@ PD_REGISTER_PLUGIN_KERNEL(less_than,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::LessThanKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           bool) {}
 
@@ -346,10 +585,9 @@ PD_REGISTER_PLUGIN_KERNEL(less_than_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::LessThanRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -358,10 +596,9 @@ PD_REGISTER_PLUGIN_KERNEL(less_equal,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::LessEqualKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -370,10 +607,9 @@ PD_REGISTER_PLUGIN_KERNEL(less_equal_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::LessEqualRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -382,10 +618,9 @@ PD_REGISTER_PLUGIN_KERNEL(greater_than,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::GreaterThanKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -394,10 +629,9 @@ PD_REGISTER_PLUGIN_KERNEL(greater_than_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::GreaterThanRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}
@@ -406,10 +640,9 @@ PD_REGISTER_PLUGIN_KERNEL(greater_equal,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::GreaterEqualKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           bool) {}
 
@@ -417,10 +650,9 @@ PD_REGISTER_PLUGIN_KERNEL(greater_equal_raw,
                           intel_hpu,
                           ALL_LAYOUT,
                           custom_kernel::GreaterEqualRawKernel,
+                          phi::dtype::bfloat16,
                           float,
-                          double,
                           uint8_t,
-                          int16_t,
                           int32_t,
                           int64_t,
                           bool) {}

--- a/backends/intel_hpu/kernels/compare_kernel.cc
+++ b/backends/intel_hpu/kernels/compare_kernel.cc
@@ -345,7 +345,7 @@ void LessThanRawKernel(const Context& dev_ctx,
   if (recipe == nullptr) {
     if (x.dtype() == phi::DataType::INT64) {
       CompareCast op;
-      op.AddNodeCast(ct, params);
+      op.AddNode(ct, params);
       op.Compile();
       op_info.setOp(op);
       recipe = op_info.GetRecipe();
@@ -396,7 +396,7 @@ void LessEqualRawKernel(const Context& dev_ctx,
   if (recipe == nullptr) {
     if (x.dtype() == phi::DataType::INT64) {
       CompareCast op;
-      op.AddNodeCast(ct, params);
+      op.AddNode(ct, params);
       op.Compile();
       op_info.setOp(op);
       recipe = op_info.GetRecipe();
@@ -447,7 +447,7 @@ void GreaterThanRawKernel(const Context& dev_ctx,
   if (recipe == nullptr) {
     if (x.dtype() == phi::DataType::INT64) {
       CompareCast op;
-      op.AddNodeCast(ct, params);
+      op.AddNode(ct, params);
       op.Compile();
       op_info.setOp(op);
       recipe = op_info.GetRecipe();
@@ -498,7 +498,7 @@ void GreaterEqualRawKernel(const Context& dev_ctx,
   if (recipe == nullptr) {
     if (x.dtype() == phi::DataType::INT64) {
       CompareCast op;
-      op.AddNodeCast(ct, params);
+      op.AddNode(ct, params);
       op.Compile();
       op_info.setOp(op);
       recipe = op_info.GetRecipe();

--- a/backends/intel_hpu/kernels/funcs.h
+++ b/backends/intel_hpu/kernels/funcs.h
@@ -34,6 +34,8 @@ inline synDataType PDDataTypeToSynDataType(phi::DataType type) {
     return syn_type_bf16;
   } else if (type == phi::DataType::INT32) {
     return syn_type_int32;
+  } else if (type == phi::DataType::INT16) {
+    return syn_type_int16;
   } else if (type == phi::DataType::INT8 || type == phi::DataType::BOOL) {
     return syn_type_int8;
   } else if (type == phi::DataType::UINT8) {

--- a/backends/intel_hpu/kernels/scale_kernel.cc
+++ b/backends/intel_hpu/kernels/scale_kernel.cc
@@ -300,7 +300,7 @@ class ScaleCast : public HpuOperator {
              status);
 
     std::vector<synTensor> final_cast_in;
-    final_cast_in.push_back(x_tensor);
+    final_cast_in.push_back(x_add);
 
     std::vector<synTensor> final_cast_out;
     auto out_tensor = createTensor(outputs[0].dims.size(),
@@ -344,13 +344,8 @@ void ScaleKernel(const Context& dev_ctx,
   std::vector<DIMS> inputs_dims = ct.GetDims();
 
   ScaleParams params;
-  auto scale = in_scale.to<T>();
-  auto bias = in_bias.to<T>();
-  if ((x.dtype() == phi::DataType::INT32) ||
-      (x.dtype() == phi::DataType::INT64)) {
-    scale = in_scale.to<float>();
-    bias = in_bias.to<float>();
-  }
+  auto scale = in_scale.to<float>();
+  auto bias = in_bias.to<float>();
 
   if (!bias_after_scale) {
     bias = bias * scale;
@@ -363,7 +358,7 @@ void ScaleKernel(const Context& dev_ctx,
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    if (typeid(T).name() != typeid(scale).name()) {
+    if (x.dtype() != phi::DataType::FLOAT32) {
       ScaleCast op;
 
       op.AddNode(ct, params);

--- a/backends/intel_hpu/kernels/scale_kernel.cc
+++ b/backends/intel_hpu/kernels/scale_kernel.cc
@@ -12,35 +12,320 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "habanalabs/perf_lib_layer_params.h"
 #include "kernels/funcs.h"
 #include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
 
 namespace custom_kernel {
 
-template <typename T, typename Context>
-void AddKernel(const Context& dev_ctx,
-               const phi::DenseTensor& x,
-               const phi::DenseTensor& y,
-               phi::DenseTensor* out);
+struct ScaleParams {
+  ns_ConstantKernel::Params scalerParams;
+  ns_ConstantKernel::Params biasParams;
+};
 
-template <typename T, typename Context>
-void MultKernel(const Context& dev_ctx,
-                const phi::DenseTensor& x,
-                const phi::DenseTensor& y,
-                phi::DenseTensor* out);
+class Scale : public HpuOperator {
+ public:
+  Scale() : HpuOperator("scale_", false) {}
 
-template <typename T, typename Context>
-void FullKernel(const Context& dev_ctx,
-                const phi::IntArray& shape,
-                const phi::Scalar& val,
-                phi::DataType dtype,
-                phi::DenseTensor* out);
+  void AddNode(ConvertTensors& ct, ScaleParams& params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
 
-template <typename T, typename Context>
-void CastKernel(const Context& dev_ctx,
-                const phi::DenseTensor& x,
-                phi::DataType dtype,
-                phi::DenseTensor* out);
+    std::string guid_full = "constant_f32";
+    std::string name_scaler = guid_ + "full_scaler";
+    std::string name_bias = guid_ + "full_bias";
+
+    std::string guid_mul = "mult_fwd_f32";
+    std::string name_mul = guid_ + "mul";
+
+    std::string guid_add = "add_fwd_f32";
+    std::string name_add = guid_ + "add";
+
+    std::vector<int64_t> scaler_dims = {1};
+
+    std::vector<synTensor> scaler_out;
+    auto scaler_tensor = createTensor(scaler_dims.size(),
+                                      syn_type_single,
+                                      scaler_dims,
+                                      false,
+                                      "scaler_tensor");
+    scaler_out.push_back(scaler_tensor);
+
+    std::vector<synTensor> bias_out;
+    auto bias_tensor = createTensor(
+        scaler_dims.size(), syn_type_single, scaler_dims, false, "bias_tensor");
+    bias_out.push_back(bias_tensor);
+
+    synStatus status = synFail;
+
+    status = synNodeCreate(graphHandle_,
+                           nullptr,
+                           scaler_out.data(),
+                           0,
+                           scaler_out.size(),
+                           &params.scalerParams,
+                           sizeof(params.scalerParams),
+                           guid_full.c_str(),
+                           name_scaler.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/full_scaler) failed = ",
+             status);
+
+    status = synNodeCreate(graphHandle_,
+                           nullptr,
+                           bias_out.data(),
+                           0,
+                           bias_out.size(),
+                           &params.biasParams,
+                           sizeof(params.biasParams),
+                           guid_full.c_str(),
+                           name_bias.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/full_bias) failed = ",
+             status);
+
+    std::vector<synTensor> mul_in;
+    auto x_tensor = createTensor(inputs[0].dims.size(),
+                                 inputs[0].type,
+                                 inputs[0].dims,
+                                 true,
+                                 inputs[0].name);
+    mul_in.push_back(x_tensor);
+    mul_in.push_back(scaler_tensor);
+
+    std::vector<synTensor> mul_out;
+    auto x_mul = createTensor(
+        inputs[0].dims.size(), syn_type_single, inputs[0].dims, false, "x_mul");
+    mul_out.push_back(x_mul);
+
+    status = synNodeCreate(graphHandle_,
+                           mul_in.data(),
+                           mul_out.data(),
+                           2,
+                           1,
+                           nullptr,
+                           0,
+                           guid_mul.c_str(),
+                           name_mul.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/mul) failed = ",
+             status);
+
+    std::vector<synTensor> add_in;
+    add_in.push_back(x_mul);
+    add_in.push_back(bias_tensor);
+
+    std::vector<synTensor> add_out;
+    auto out_tensor = createTensor(outputs[0].dims.size(),
+                                   outputs[0].type,
+                                   outputs[0].dims,
+                                   true,
+                                   outputs[0].name);
+    add_out.push_back(out_tensor);
+
+    status = synNodeCreate(graphHandle_,
+                           add_in.data(),
+                           add_out.data(),
+                           2,
+                           1,
+                           nullptr,
+                           0,
+                           guid_add.c_str(),
+                           name_add.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/mul) failed = ",
+             status);
+  }
+};
+
+class ScaleCast : public HpuOperator {
+ public:
+  ScaleCast() : HpuOperator("scale_", false) {}
+  void AddNode(ConvertTensors& ct, ScaleParams& params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    std::string guid_full = "constant_f32";
+    std::string name_scaler = guid_ + "full_scaler";
+    std::string name_bias = guid_ + "full_bias";
+
+    std::string guid_cast = "cast_";
+    std::string guid_cast_i = guid_cast + SynDataTypeToStr(inputs[0].type) +
+                              "_to_" + SynDataTypeToStr(syn_type_single);
+    std::string guid_cast_o = guid_cast + SynDataTypeToStr(syn_type_single) +
+                              "_to_" + SynDataTypeToStr(inputs[0].type);
+    std::string name_cast_i = guid_ + "cast_in";
+    std::string name_cast_o = guid_ + "cast_out";
+
+    std::string guid_mul = "mult_fwd_f32";
+    std::string name_mul = guid_ + "mul";
+
+    std::string guid_add = "add_fwd_f32";
+    std::string name_add = guid_ + "add";
+
+    std::vector<int64_t> scaler_dims = {1};
+
+    std::vector<synTensor> scaler_out;
+    auto scaler_tensor = createTensor(scaler_dims.size(),
+                                      syn_type_single,
+                                      scaler_dims,
+                                      false,
+                                      "scaler_tensor");
+    scaler_out.push_back(scaler_tensor);
+
+    std::vector<synTensor> bias_out;
+    auto bias_tensor = createTensor(
+        scaler_dims.size(), syn_type_single, scaler_dims, false, "bias_tensor");
+    bias_out.push_back(bias_tensor);
+
+    synStatus status = synFail;
+
+    status = synNodeCreate(graphHandle_,
+                           nullptr,
+                           scaler_out.data(),
+                           0,
+                           scaler_out.size(),
+                           &params.scalerParams,
+                           sizeof(params.scalerParams),
+                           guid_full.c_str(),
+                           name_scaler.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/full_scaler) failed = ",
+             status);
+
+    status = synNodeCreate(graphHandle_,
+                           nullptr,
+                           bias_out.data(),
+                           0,
+                           bias_out.size(),
+                           &params.biasParams,
+                           sizeof(params.biasParams),
+                           guid_full.c_str(),
+                           name_bias.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/full_bias) failed = ",
+             status);
+
+    std::vector<synTensor> cast_in;
+    auto x_tensor = createTensor(inputs[0].dims.size(),
+                                 inputs[0].type,
+                                 inputs[0].dims,
+                                 true,
+                                 inputs[0].name);
+    cast_in.push_back(x_tensor);
+
+    std::vector<synTensor> cast_out;
+    auto x_cast = createTensor(inputs[0].dims.size(),
+                               syn_type_single,
+                               inputs[0].dims,
+                               false,
+                               "x_cast");
+    cast_out.push_back(x_cast);
+
+    status = synNodeCreate(graphHandle_,
+                           cast_in.data(),
+                           cast_out.data(),
+                           cast_in.size(),
+                           cast_out.size(),
+                           nullptr,
+                           0,
+                           guid_cast_i.c_str(),
+                           name_cast_i.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/cast_in) failed = ",
+             status);
+
+    std::vector<synTensor> mul_in;
+    mul_in.push_back(x_cast);
+    mul_in.push_back(scaler_tensor);
+
+    std::vector<synTensor> mul_out;
+    auto x_mul = createTensor(
+        inputs[0].dims.size(), syn_type_single, inputs[0].dims, false, "x_mul");
+    mul_out.push_back(x_mul);
+
+    status = synNodeCreate(graphHandle_,
+                           mul_in.data(),
+                           mul_out.data(),
+                           2,
+                           1,
+                           nullptr,
+                           0,
+                           guid_mul.c_str(),
+                           name_mul.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/mul) failed = ",
+             status);
+
+    std::vector<synTensor> add_in;
+    add_in.push_back(x_mul);
+    add_in.push_back(bias_tensor);
+
+    std::vector<synTensor> add_out;
+    auto x_add = createTensor(
+        inputs[0].dims.size(), syn_type_single, inputs[0].dims, false, "x_add");
+    add_out.push_back(x_add);
+
+    status = synNodeCreate(graphHandle_,
+                           add_in.data(),
+                           add_out.data(),
+                           2,
+                           1,
+                           nullptr,
+                           0,
+                           guid_add.c_str(),
+                           name_add.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/mul) failed = ",
+             status);
+
+    std::vector<synTensor> final_cast_in;
+    final_cast_in.push_back(x_tensor);
+
+    std::vector<synTensor> final_cast_out;
+    auto out_tensor = createTensor(outputs[0].dims.size(),
+                                   outputs[0].type,
+                                   outputs[0].dims,
+                                   true,
+                                   outputs[0].name);
+    final_cast_out.push_back(out_tensor);
+
+    status = synNodeCreate(graphHandle_,
+                           final_cast_in.data(),
+                           final_cast_out.data(),
+                           final_cast_in.size(),
+                           final_cast_out.size(),
+                           nullptr,
+                           0,
+                           guid_cast_o.c_str(),
+                           name_cast_o.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (scale/cast_in) failed = ",
+             status);
+  }
+};
 
 template <typename T, typename Context>
 void ScaleKernel(const Context& dev_ctx,
@@ -49,43 +334,57 @@ void ScaleKernel(const Context& dev_ctx,
                  const phi::Scalar& in_bias,
                  bool bias_after_scale,
                  phi::DenseTensor* out) {
-  phi::DenseTensor scale_tensor;
-  phi::DenseTensorMeta tensor_meta({phi::DataType::FLOAT32, {1}});
-  scale_tensor.set_meta(tensor_meta);
-  std::vector<int64_t> shape_vec = {1};
-  phi::IntArray scalar_shape(shape_vec);
-  custom_kernel::FullKernel<float, Context>(
-      dev_ctx, scalar_shape, in_scale, phi::DataType::FLOAT32, &scale_tensor);
+  VLOG(6) << "call HPU ScaleKernel";
 
-  phi::DenseTensor x_f32;
-  phi::DenseTensorMeta x_f32_meta({phi::DataType::FLOAT32, x.dims()});
-  x_f32.set_meta(x_f32_meta);
-  custom_kernel::CastKernel<T, Context>(
-      dev_ctx, x, phi::DataType::FLOAT32, &x_f32);
+  dev_ctx.template Alloc<T>(out);
 
-  phi::DenseTensor mul_out;
-  phi::DenseTensorMeta out_meta({x_f32.dtype(), x_f32.dims()});
-  mul_out.set_meta(out_meta);
-  custom_kernel::MultKernel<float, Context>(
-      dev_ctx, x_f32, scale_tensor, &mul_out);
+  ConvertTensors ct;
+  ct.Add(x);
+  ct.Add(out, false);
+  std::vector<DIMS> inputs_dims = ct.GetDims();
 
-  phi::DenseTensor bias_tensor;
-  bias_tensor.set_meta(tensor_meta);
-  auto scale = in_scale.to<float>();
-  auto bias = in_bias.to<float>();
+  ScaleParams params;
+  auto scale = in_scale.to<T>();
+  auto bias = in_bias.to<T>();
+  if ((x.dtype() == phi::DataType::INT32) ||
+      (x.dtype() == phi::DataType::INT64)) {
+    scale = in_scale.to<float>();
+    bias = in_bias.to<float>();
+  }
+
   if (!bias_after_scale) {
     bias = bias * scale;
   }
-  auto bias_scalar = phi::Scalar(bias);
-  custom_kernel::FullKernel<float, Context>(
-      dev_ctx, scalar_shape, bias_scalar, phi::DataType::FLOAT32, &bias_tensor);
+  params.scalerParams.constant.f = scale;
+  params.biasParams.constant.f = bias;
 
-  phi::DenseTensor add_out;
-  add_out.set_meta(out_meta);
-  custom_kernel::AddKernel<float, Context>(
-      dev_ctx, mul_out, bias_tensor, &add_out);
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, ScaleParams>("scaleKernel", inputs_dims, &params);
+  auto recipe = op_info.GetRecipe();
 
-  custom_kernel::CastKernel<float, Context>(dev_ctx, add_out, x.dtype(), out);
+  if (recipe == nullptr) {
+    if (typeid(T).name() != typeid(scale).name()) {
+      ScaleCast op;
+
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+
+      recipe = op_info.GetRecipe();
+    } else {
+      Scale op;
+
+      op.AddNode(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+
+      recipe = op_info.GetRecipe();
+    }
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
 }
 
 }  // namespace custom_kernel
@@ -95,6 +394,7 @@ PD_REGISTER_PLUGIN_KERNEL(scale,
                           ALL_LAYOUT,
                           custom_kernel::ScaleKernel,
                           float,
+                          int32_t,
                           int64_t,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {}

--- a/backends/intel_hpu/runtime/runtime.cc
+++ b/backends/intel_hpu/runtime/runtime.cc
@@ -326,6 +326,13 @@ class RuntimeManager {
                status);
 
     } else if (flag == 1) {
+      if (stream_d2h == nullptr) {
+        status = synStreamCreateGeneric(
+            reinterpret_cast<synStreamHandle *>(&stream_d2h), device->id, 0);
+        PD_CHECK(status == synSuccess,
+                 "[RUNTIME] synStreamCreateGeneric() failed = ",
+                 status);
+      }
       // addCache(device, dst, size);
       void *ptr = getCachedHostMem(device, size);
       status = synMemCopyAsync(reinterpret_cast<synStreamHandle>(stream),

--- a/backends/intel_hpu/tests/unittests/test_index_select.py
+++ b/backends/intel_hpu/tests/unittests/test_index_select.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+from tests.op_test import OpTest
+import paddle
+
+paddle.enable_static()
+SEED = 2021
+
+
+class TestHPUIndexSelect(OpTest):
+    def setUp(self):
+        self.set_hpu()
+        self.op_type = "index_select"
+        self.config()
+
+        x_np = np.random.random(self.x_shape).astype(self.x_type)
+        index_np = np.random.randint(
+            low=0,
+            high=self.x_shape[self.dim],
+            size=self.index_size,
+            dtype=self.index_type,
+        )
+
+        # compute real output as baseline.
+        outer_loop = np.prod(self.x_shape[: self.dim])
+        outer_loop = outer_loop.astype(self.index_type)
+        x_reshape = [outer_loop] + list(self.x_shape[self.dim :])
+        x_np_reshape = np.reshape(x_np, tuple(x_reshape))
+
+        out_list = []
+        for i in range(outer_loop):
+            for j in range(self.index_size):
+                out_list.append(x_np_reshape[i, index_np[j]])
+        self.out_shape = list(self.x_shape)
+        self.out_shape[self.dim] = self.index_size
+        self.out_shape = tuple(self.out_shape)
+        out = np.reshape(out_list, self.out_shape)
+
+        self.inputs = {"X": x_np, "Index": index_np}
+        self.attrs = {"dim": self.dim}
+        self.outputs = {"Out": out}
+
+    def set_hpu(self):
+        self.__class__.use_custom_device = True
+        self.__class__.no_need_check_grad = True
+        self.place = paddle.CustomPlace("intel_hpu", 0)
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def config(self):
+        self.x_shape = (100, 4, 5)
+        self.x_type = np.float32
+        self.dim = 1
+        self.index_size = 100
+        self.index_type = np.int64
+
+
+class TestHPUIndexSelectCase2(TestHPUIndexSelect):
+    def config(self):
+        self.dim = -2
+        self.x_type = np.float32
+        self.index_type = np.int32
+        self.x_shape = (10, 10, 4, 10)
+        self.index_size = 10
+
+
+class TestHPUIndexSelectCase3(TestHPUIndexSelect):
+    def config(self):
+        self.dim = 0
+        self.x_type = np.float32
+        self.index_type = np.int32
+        self.x_shape = (10, 10, 4, 10)
+        self.index_size = 10
+
+
+class TestHPUIndexSelectCase4(TestHPUIndexSelect):
+    def config(self):
+        self.dim = -1
+        self.x_type = np.float32
+        self.index_type = np.int32
+        self.x_shape = (10, 10, 4, 10)
+        self.index_size = 10
+
+
+class TestHPUIndexSelectDouble(TestHPUIndexSelect):
+    def config(self):
+        self.x_shape = (100, 4, 5)
+        self.x_type = np.double
+        self.dim = 1
+        self.index_size = 100
+        self.index_type = np.int64
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/intel_hpu/tests/unittests/test_scale.py
+++ b/backends/intel_hpu/tests/unittests/test_scale.py
@@ -53,12 +53,13 @@ class TestHpuScaleOp(OpTest):
     def init_input(self):
         self.scale = 2.8
         self.bias = 3.2
-        self.bias_after_scale = False
+        self.bias_after_scale = True
         np.random.seed(1024)
         self.x = np.random.random((2, 3, 4)).astype(self.dtype)
-        self.out = self.x * self.scale + (
-            self.bias if self.bias_after_scale else self.scale * self.bias
-        )
+        self.out = (
+            self.x * self.scale
+            + (self.bias if self.bias_after_scale else self.scale * self.bias)
+        ).astype(self.dtype)
 
 
 class TestFP16Scale(TestHpuScaleOp):

--- a/backends/intel_hpu/utils/utils.h
+++ b/backends/intel_hpu/utils/utils.h
@@ -120,6 +120,9 @@ class OpCacheOperator {
     } else if (std::is_same<T, phi::dtype::float8_e4m3fn>::value) {
       datatype_ = syn_type_fp8_143;
       guid_ = guid_prefix + "_hf8";
+    } else if (std::is_same<T, int16_t>::value) {
+      datatype_ = syn_type_int16;
+      guid_ = guid_prefix + "_i16";
     } else if (std::is_same<T, int32_t>::value) {
       datatype_ = syn_type_int32;
       guid_ = guid_prefix + "_i32";


### PR DESCRIPTION
1.  arange kernel 
   add int64 dtype support
   add float step supprt

2.  compare kernel
    using one recipe to handle >, <, !=
    add int64 dtype support

3.  add index_select kernel
     add index_select UT

4. scale kernel
    using one recipe to handle
    calc with fp32 and cast to T
    fix scale UT bug

5. refine runtime
