### PR TITLE
[Intel HPU] UT PR testing support sub testcase name match

### DIFF
--- a/backends/intel_hpu/tests/junitxml.py
+++ b/backends/intel_hpu/tests/junitxml.py
@@ -101,19 +101,23 @@ class jTestSuite(jXMLBase):
         super().__init__("testsuite")
         self.setName(name)
         self._case_lst = list()
-        for i in ["disabled", "tests", "passed", "errors", "failures", "skipped"]:
+        for i in ["tested", "passed", "errors", "failed", "skipped", "disabled"]:
             self._attr_dict[i] = 0
         self._attr_dict["kernel"] = subprocess.getoutput("uname -r")
         self._attr_dict["os"] = (
             "wsl" if "microsoft" in platform.platform().lower() else "linux"
         )
 
+    def print_attr_dict(self):
+        for k, v in self._attr_dict.items():
+            print(f"{k} : {v}")
+
     def setPlatform(self, platform):
         self._attr_dict["platform"] = platform
 
     def addCase(self, case: jTestCase):
         if case.result == jResult.FAIL:
-            self._attr_dict["failures"] += 1
+            self._attr_dict["failed"] += 1
         elif case.result == jResult.ERROR:
             self._attr_dict["errors"] += 1
         elif case.result == jResult.SKIP:
@@ -125,7 +129,7 @@ class jTestSuite(jXMLBase):
         self._case_lst.append(case)
 
     def covertET(self) -> et:
-        self._attr_dict["tests"] = len(self._case_lst)
+        self._attr_dict["tested"] = len(self._case_lst)
         elem = super().covertET()
         for jxml in self._case_lst:
             elem.append(jxml.covertET())


### PR DESCRIPTION
PR test script add sub testcase match support
1, PR test script can support match sub testcase name
for example: below cmd line will only run sub test cases of test_scatter_fp32_no_ow_2 in test_scatter_hpu
    python pr-test-run.py --test_path /workspace/pdpd_ci/PaddleCustomDevice/backends/intel_hpu/tests/unittests/  \
     --junit test_result.xml --platform gaudi2 \
    --k test_scatter_hpu:test_scatter_fp32_no_ow_2