### PR TITLE
[INTEL_HPU] pr test add filter support

### DIFF
--- a/backends/intel_hpu/tests/config.py
+++ b/backends/intel_hpu/tests/config.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+skip_case_lst = {}
+
+# when filter passwdown 'stable' will load this list
+# this list for the unstable test case to skip
+skip_case_lst = [
+    "test_reduce_prod.py",
+    "test_reduce_mean.py",
+    "test_index_select.py",
+    "test_activation_op.py",
+    "test_pow.py",
+    "test_top_p_sampling.py",
+    "test_reduce_max.py",
+]


### PR DESCRIPTION
--filter stable : will run all pass test cases
  skip test cases defined in config.py skip list
--filter unstable: will run all fail test cases
  only run test cases defined in config.py skip list
--filter all: [default] run all test cases

test cmdline:
python pr-test-run.py --test_path /workspace_pdpd/repo/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --junit test_result.xml --platform gaudi2
python pr-test-run.py --test_path /workspace_pdpd/repo/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --filter all --junit test_result.xml --platform gaudi2
python pr-test-run.py --test_path /workspace_pdpd/repo/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --filter stable --junit test_result.xml --platform gaudi2
python pr-test-run.py --test_path /workspace_pdpd/repo/PaddleCustomDevice/backends/intel_hpu/tests/unittests/ --filter unstable --junit test_result.xml --platform gaudi2