### PR TITLE
[INTEL_HPU] fix top_p_sampling ut failures in synapse 1.19

### DIFF
--- a/backends/intel_hpu/kernels/top_p_hpu.cc
+++ b/backends/intel_hpu/kernels/top_p_hpu.cc
@@ -303,7 +303,7 @@ class TopP : public HpuOperator {
     params.seed = seed;
 
     std::string node_guid =
-        "random_multinomial_fwd_" + SynDataTypeToStr(outputs[0].type);
+        "random_multinomial_pt_fwd_" + SynDataTypeToStr(outputs[0].type);
 
     synStatus status = synNodeCreate(graphHandle_,
                                      syn_inputs,


### PR DESCRIPTION
From synapse 1.19, multinomial kernel has been renamed to "random_multinomial_pt_fwd_".