### PR TITLE
[GCU] Update TopsRider

### DIFF
--- a/backends/gcu/backend/executor/cast_runner.cc
+++ b/backends/gcu/backend/executor/cast_runner.cc
@@ -29,7 +29,7 @@
 #include "backend/executor/tops_compiler.h"
 #include "backend/utils/gcu_op_desc.h"
 #include "backend/utils/utils.h"
-#include "gcu/hlir_builder/hlir_builder.h"
+#include "gcu/hlir/builder/hlir_builder.h"
 #include "runtime/runtime.h"
 
 namespace backend {

--- a/backends/gcu/backend/register/register.h
+++ b/backends/gcu/backend/register/register.h
@@ -25,7 +25,7 @@ limitations under the License. */
 
 #include "backend/utils/gcu_op_desc.h"
 #include "backend/utils/types.h"
-#include "gcu/hlir_builder/hlir_builder.h"
+#include "gcu/hlir/builder/hlir_builder.h"
 
 using GcuOp = ::builder::Op;
 using GcuOpPtr = std::shared_ptr<GcuOp>;

--- a/backends/gcu/backend/utils/types.h
+++ b/backends/gcu/backend/utils/types.h
@@ -18,7 +18,7 @@ limitations under the License. */
 #include <unordered_map>
 #include <vector>
 
-#include "gcu/hlir_builder/hlir_builder.h"
+#include "gcu/hlir/builder/hlir_builder.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/utils/blank.h"
 #include "paddle/utils/variant.h"

--- a/backends/gcu/backend/utils/utils.h
+++ b/backends/gcu/backend/utils/utils.h
@@ -25,7 +25,7 @@ limitations under the License. */
 #include <vector>
 
 #include "backend/utils/types.h"
-#include "gcu/hlir_builder/hlir_builder.h"
+#include "gcu/hlir/builder/hlir_builder.h"
 #include "gcu/umd/dtu_assembler_def.h"
 #include "paddle/phi/common/data_type.h"
 

--- a/backends/gcu/custom_engine/ir_translator/utils/utils.h
+++ b/backends/gcu/custom_engine/ir_translator/utils/utils.h
@@ -17,7 +17,7 @@
 #include <tops/tops_ext.h>
 
 #include "common/utils.h"
-#include "gcu/hlir_builder/hlir_builder.h"
+#include "gcu/hlir/builder/hlir_builder.h"
 #include "paddle/phi/common/data_type.h"
 
 using GcuOp = ::builder::Op;


### PR DESCRIPTION
1. 使能推理网络`ch_ppocr_mobile_v2.0_cls`，增加`custom_engine`整网用例；
2. 该网络计算量小，调度开销大，适合使能`custom_engine`；
3. 使能后相对于非子图引擎场景，当前端到端性能达到`200%`以上。