### PR TITLE
[NPU][MLU] Fix test_LeNet_MNIST on NPU & MLU

### DIFF
--- a/backends/mlu/tests/test_LeNet_MNIST.py
+++ b/backends/mlu/tests/test_LeNet_MNIST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import os
-import shutil
 import time
 import argparse
 import datetime
+import tempfile
 import numpy as np
 
 import paddle
@@ -67,13 +67,9 @@ def test(epoch_id, test_loader, model, cost):
     )
 
 
-def infer(model_dir):
-    # model file
-    params_file = os.path.join(model_dir, "model.pdiparams")
-    model_file = os.path.join(model_dir, "model.pdmodel")
-
+def infer(model_dir, prefix):
     # create config
-    config = paddle_infer.Config(model_file, params_file)
+    config = paddle_infer.Config(model_dir, prefix)
     config.enable_custom_device("mlu")
 
     # create predictor
@@ -203,11 +199,13 @@ def main(args):
         model,
         input_spec=[paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype="float32")],
     )
-    paddle.jit.save(model, "output/model")
 
-    # infernece and clear
-    infer("output")
-    shutil.rmtree("output")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        prefix = "test_LeNet_MNIST"
+        paddle.jit.save(model, os.path.join(temp_dir, prefix))
+
+        # infernece and clear
+        infer(temp_dir, prefix)
 
 
 class AverageMeter(object):

--- a/backends/npu/tests/test_LeNet_MNIST.py
+++ b/backends/npu/tests/test_LeNet_MNIST.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import os
-import shutil
 import time
 import argparse
 import datetime
+import tempfile
 import numpy as np
 
 import paddle
@@ -67,13 +67,9 @@ def test(epoch_id, test_loader, model, cost):
     )
 
 
-def infer(model_dir):
-    # model file
-    params_file = os.path.join(model_dir, "model.pdiparams")
-    model_file = os.path.join(model_dir, "model.pdmodel")
-
+def infer(model_dir, prefix):
     # create config
-    config = paddle_infer.Config(model_file, params_file)
+    config = paddle_infer.Config(model_dir, prefix)
     config.enable_custom_device("npu")
 
     # create predictor
@@ -203,11 +199,12 @@ def main(args):
         model,
         input_spec=[paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype="float32")],
     )
-    paddle.jit.save(model, "output/model")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        prefix = "test_LeNet_MNIST"
+        paddle.jit.save(model, os.path.join(temp_dir, prefix))
 
-    # infernece and clear
-    infer("output")
-    shutil.rmtree("output")
+        # infernece and clear
+        infer(temp_dir, prefix)
 
 
 class AverageMeter(object):


### PR DESCRIPTION
1. 修复 NPU & MLU 平台上 test_LeNet_MNIST
2. 使用 tempfile 模块管理临时文件

错误原因：PIR 下`paddle.jit.save`导出格式为.json & .pdiparams，原文件硬编码为.pdmodel
