### PR TITLE
[NPU][MLU] Fix test_batch_nrom_op on NPU & MLU

### DIFF
--- a/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_batch_norm_op_mlu.py
@@ -478,81 +478,82 @@ class TestBatchNormOpTraining(unittest.TestCase):
             ]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = base.Program()
-            with base.program_guard(program):
-                block = program.global_block()
-                for name in ground_truth:
-                    block.create_var(
-                        name=name, dtype="float32", shape=ground_truth[name].shape
+            with paddle.pir_utils.OldIrGuard():
+                program = base.Program()
+                with base.program_guard(program):
+                    block = program.global_block()
+                    for name in ground_truth:
+                        block.create_var(
+                            name=name, dtype="float32", shape=ground_truth[name].shape
+                        )
+                    inputs = {
+                        "X": block.var("x"),
+                        "Scale": block.var("scale"),
+                        "Bias": block.var("bias"),
+                        "Mean": block.var("mean"),
+                        "Variance": block.var("variance"),
+                    }
+                    attrs = {
+                        "epsilon": epsilon,
+                        "is_test": False,
+                        "data_layout": data_layout,
+                        "use_mkldnn": False,
+                        "fuse_with_relu": self.fuse_with_relu,
+                        "use_global_stats": self.use_global_stats,
+                    }
+                    if self.use_momentum_variable:
+                        inputs["MomentumTensor"] = block.var("momentum_var")
+                    else:
+                        attrs["momentum"] = momentum
+
+                    outputs = {
+                        "Y": block.var("y"),
+                        "MeanOut": block.var("mean"),  # share memory
+                        "VarianceOut": block.var("variance"),  # share memory
+                        "SavedMean": block.var("saved_mean"),
+                        "SavedVariance": block.var("saved_variance"),
+                    }
+                    block.create_var(name="reserve_space", dtype="float32")
+                    outputs["ReserveSpace"] = block.var("reserve_space")
+                    bn_op = block.append_op(
+                        type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
                     )
-                inputs = {
-                    "X": block.var("x"),
-                    "Scale": block.var("scale"),
-                    "Bias": block.var("bias"),
-                    "Mean": block.var("mean"),
-                    "Variance": block.var("variance"),
-                }
-                attrs = {
-                    "epsilon": epsilon,
-                    "is_test": False,
-                    "data_layout": data_layout,
-                    "use_mkldnn": False,
-                    "fuse_with_relu": self.fuse_with_relu,
-                    "use_global_stats": self.use_global_stats,
-                }
-                if self.use_momentum_variable:
-                    inputs["MomentumTensor"] = block.var("momentum_var")
-                else:
-                    attrs["momentum"] = momentum
+                    block.create_var(name="y@GRAD", dtype="float32", shape=y.shape)
 
-                outputs = {
-                    "Y": block.var("y"),
-                    "MeanOut": block.var("mean"),  # share memory
-                    "VarianceOut": block.var("variance"),  # share memory
-                    "SavedMean": block.var("saved_mean"),
-                    "SavedVariance": block.var("saved_variance"),
-                }
-                block.create_var(name="reserve_space", dtype="float32")
-                outputs["ReserveSpace"] = block.var("reserve_space")
-                bn_op = block.append_op(
-                    type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
-                )
-                block.create_var(name="y@GRAD", dtype="float32", shape=y.shape)
+                    # generate backward op_desc
+                    grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
+                        bn_op.desc, self.no_grad_set, []
+                    )
+                    grad_op_desc = grad_op_desc_list[0]
+                    new_op_desc = block.desc.append_op()
+                    new_op_desc.copy_from(grad_op_desc)
+                    for var_name in grad_op_desc.output_arg_names():
+                        block.desc.var(var_name.encode("ascii"))
+                    grad_op_desc.infer_var_type(block.desc)
+                    grad_op_desc.infer_shape(block.desc)
+                    for arg in grad_op_desc.output_arg_names():
+                        grad_var = block.desc.find_var(arg.encode("ascii"))
+                        grad_var.set_dtype(core.VarDesc.VarType.FP32)
 
-                # generate backward op_desc
-                grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
-                    bn_op.desc, self.no_grad_set, []
-                )
-                grad_op_desc = grad_op_desc_list[0]
-                new_op_desc = block.desc.append_op()
-                new_op_desc.copy_from(grad_op_desc)
-                for var_name in grad_op_desc.output_arg_names():
-                    block.desc.var(var_name.encode("ascii"))
-                grad_op_desc.infer_var_type(block.desc)
-                grad_op_desc.infer_shape(block.desc)
-                for arg in grad_op_desc.output_arg_names():
-                    grad_var = block.desc.find_var(arg.encode("ascii"))
-                    grad_var.set_dtype(core.VarDesc.VarType.FP32)
+                    program._sync_with_cpp()
 
-                program._sync_with_cpp()
-
-                exe = base.Executor(place)
-                out = exe.run(
-                    program,
-                    feed={
-                        name: var_dict[name]
-                        for name in [
-                            "x",
-                            "scale",
-                            "bias",
-                            "mean",
-                            "variance",
-                            "y@GRAD",
-                            "momentum_var",
-                        ]
-                    },
-                    fetch_list=self.fetch_list,
-                )
+                    exe = base.Executor(place)
+                    out = exe.run(
+                        program,
+                        feed={
+                            name: var_dict[name]
+                            for name in [
+                                "x",
+                                "scale",
+                                "bias",
+                                "mean",
+                                "variance",
+                                "y@GRAD",
+                                "momentum_var",
+                            ]
+                        },
+                        fetch_list=self.fetch_list,
+                    )
 
             for id, name in enumerate(self.fetch_list):
                 if name == "variance":

--- a/backends/npu/tests/unittests/test_batch_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_batch_norm_op_npu.py
@@ -247,41 +247,42 @@ class TestBatchNormOpInference(unittest.TestCase):
         ground_truth["saved_mean"] = mean
         ground_truth["saved_variance"] = variance
 
-        program = base.Program()
-        with base.program_guard(program):
-            block = program.global_block()
-            for name in ground_truth:
-                block.create_var(
-                    name=name, dtype="float32", shape=ground_truth[name].shape
+        with paddle.pir_utils.OldIrGuard():
+            program = base.Program()
+            with base.program_guard(program):
+                block = program.global_block()
+                for name in ground_truth:
+                    block.create_var(
+                        name=name, dtype="float32", shape=ground_truth[name].shape
+                    )
+                inputs = {
+                    "X": block.var("x"),
+                    "Scale": block.var("scale"),
+                    "Bias": block.var("bias"),
+                    "Mean": block.var("mean"),
+                    "Variance": block.var("variance"),
+                }
+                attrs = {
+                    "epsilon": epsilon,
+                    "is_test": True,
+                    "data_layout": data_layout,
+                    "use_mkldnn": False,
+                    "fuse_with_relu": False,
+                }
+                outputs = {
+                    "Y": block.var("y"),
+                    "MeanOut": block.var("mean"),  # share memory
+                    "VarianceOut": block.var("variance"),  # share memory
+                    "SavedMean": block.var("saved_mean"),
+                    "SavedVariance": block.var("saved_variance"),
+                }
+                block.create_var(name="reserve_space", dtype="float32")
+                outputs["ReserveSpace"] = block.var("reserve_space")
+                bn_op = block.append_op(
+                    type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
                 )
-            inputs = {
-                "X": block.var("x"),
-                "Scale": block.var("scale"),
-                "Bias": block.var("bias"),
-                "Mean": block.var("mean"),
-                "Variance": block.var("variance"),
-            }
-            attrs = {
-                "epsilon": epsilon,
-                "is_test": True,
-                "data_layout": data_layout,
-                "use_mkldnn": False,
-                "fuse_with_relu": False,
-            }
-            outputs = {
-                "Y": block.var("y"),
-                "MeanOut": block.var("mean"),  # share memory
-                "VarianceOut": block.var("variance"),  # share memory
-                "SavedMean": block.var("saved_mean"),
-                "SavedVariance": block.var("saved_variance"),
-            }
-            block.create_var(name="reserve_space", dtype="float32")
-            outputs["ReserveSpace"] = block.var("reserve_space")
-            bn_op = block.append_op(
-                type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
-            )
 
-            program._sync_with_cpp()
+                program._sync_with_cpp()
 
             exe = base.Executor(place)
             out = exe.run(
@@ -483,81 +484,82 @@ class TestBatchNormOpTraining(unittest.TestCase):
             ]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = base.Program()
-            with base.program_guard(program):
-                block = program.global_block()
-                for name in ground_truth:
-                    block.create_var(
-                        name=name, dtype="float32", shape=ground_truth[name].shape
+            with paddle.pir_utils.OldIrGuard():
+                program = base.Program()
+                with base.program_guard(program):
+                    block = program.global_block()
+                    for name in ground_truth:
+                        block.create_var(
+                            name=name, dtype="float32", shape=ground_truth[name].shape
+                        )
+                    inputs = {
+                        "X": block.var("x"),
+                        "Scale": block.var("scale"),
+                        "Bias": block.var("bias"),
+                        "Mean": block.var("mean"),
+                        "Variance": block.var("variance"),
+                    }
+                    attrs = {
+                        "epsilon": epsilon,
+                        "is_test": False,
+                        "data_layout": data_layout,
+                        "use_mkldnn": self.use_mkldnn,
+                        "fuse_with_relu": self.fuse_with_relu,
+                        "use_global_stats": self.use_global_stats,
+                    }
+                    if self.use_momentum_variable:
+                        inputs["MomentumTensor"] = block.var("momentum_var")
+                    else:
+                        attrs["momentum"] = momentum
+
+                    outputs = {
+                        "Y": block.var("y"),
+                        "MeanOut": block.var("mean"),  # share memory
+                        "VarianceOut": block.var("variance"),  # share memory
+                        "SavedMean": block.var("saved_mean"),
+                        "SavedVariance": block.var("saved_variance"),
+                    }
+                    block.create_var(name="reserve_space", dtype="float32")
+                    outputs["ReserveSpace"] = block.var("reserve_space")
+                    bn_op = block.append_op(
+                        type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
                     )
-                inputs = {
-                    "X": block.var("x"),
-                    "Scale": block.var("scale"),
-                    "Bias": block.var("bias"),
-                    "Mean": block.var("mean"),
-                    "Variance": block.var("variance"),
-                }
-                attrs = {
-                    "epsilon": epsilon,
-                    "is_test": False,
-                    "data_layout": data_layout,
-                    "use_mkldnn": self.use_mkldnn,
-                    "fuse_with_relu": self.fuse_with_relu,
-                    "use_global_stats": self.use_global_stats,
-                }
-                if self.use_momentum_variable:
-                    inputs["MomentumTensor"] = block.var("momentum_var")
-                else:
-                    attrs["momentum"] = momentum
+                    block.create_var(name="y@GRAD", dtype=self.dtype, shape=y.shape)
 
-                outputs = {
-                    "Y": block.var("y"),
-                    "MeanOut": block.var("mean"),  # share memory
-                    "VarianceOut": block.var("variance"),  # share memory
-                    "SavedMean": block.var("saved_mean"),
-                    "SavedVariance": block.var("saved_variance"),
-                }
-                block.create_var(name="reserve_space", dtype="float32")
-                outputs["ReserveSpace"] = block.var("reserve_space")
-                bn_op = block.append_op(
-                    type="batch_norm", inputs=inputs, outputs=outputs, attrs=attrs
-                )
-                block.create_var(name="y@GRAD", dtype=self.dtype, shape=y.shape)
+                    # generate backward op_desc
+                    grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
+                        bn_op.desc, self.no_grad_set, []
+                    )
+                    grad_op_desc = grad_op_desc_list[0]
+                    new_op_desc = block.desc.append_op()
+                    new_op_desc.copy_from(grad_op_desc)
+                    for var_name in grad_op_desc.output_arg_names():
+                        block.desc.var(var_name.encode("ascii"))
+                    grad_op_desc.infer_var_type(block.desc)
+                    grad_op_desc.infer_shape(block.desc)
+                    for arg in grad_op_desc.output_arg_names():
+                        grad_var = block.desc.find_var(arg.encode("ascii"))
+                        grad_var.set_dtype(core.VarDesc.VarType.FP32)
 
-                # generate backward op_desc
-                grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
-                    bn_op.desc, self.no_grad_set, []
-                )
-                grad_op_desc = grad_op_desc_list[0]
-                new_op_desc = block.desc.append_op()
-                new_op_desc.copy_from(grad_op_desc)
-                for var_name in grad_op_desc.output_arg_names():
-                    block.desc.var(var_name.encode("ascii"))
-                grad_op_desc.infer_var_type(block.desc)
-                grad_op_desc.infer_shape(block.desc)
-                for arg in grad_op_desc.output_arg_names():
-                    grad_var = block.desc.find_var(arg.encode("ascii"))
-                    grad_var.set_dtype(core.VarDesc.VarType.FP32)
+                    program._sync_with_cpp()
 
-                program._sync_with_cpp()
-
-                exe = base.Executor(place)
-                out = exe.run(
-                    program,
-                    feed={
-                        name: var_dict[name]
-                        for name in [
-                            "x",
-                            "scale",
-                            "bias",
-                            "mean",
-                            "variance",
-                            "y@GRAD",
-                            "momentum_var",
-                        ]
-                    },
-                    fetch_list=self.fetch_list,
-                )
+                    exe = base.Executor(place)
+                    out = exe.run(
+                        program,
+                        feed={
+                            name: var_dict[name]
+                            for name in [
+                                "x",
+                                "scale",
+                                "bias",
+                                "mean",
+                                "variance",
+                                "y@GRAD",
+                                "momentum_var",
+                            ]
+                        },
+                        fetch_list=self.fetch_list,
+                    )
 
             for id, name in enumerate(self.fetch_list):
                 if name == "variance":


### PR DESCRIPTION
1. 修复 NPU & MLU 平台下 test_batch_nrom_op 单测

错误原因：使用了不兼容的 API `block.create_var`

NPU 平台测试截图：
![image](https://github.com/user-attachments/assets/2fff2e7a-8710-4628-a8cb-259674a8484c)

MLU 平台测试截图：
![image](https://github.com/user-attachments/assets/5968a48d-1a08-4700-9a97-05db10eb2c34)
