### PR TITLE
[NPU] Fix test_elementwise_sub_op on NPU

### DIFF
--- a/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
@@ -134,12 +134,13 @@ class TestElementwiseSubOpInt64(TestElementwiseSubOp):
 
 class TestSubtractAPI(unittest.TestCase):
     def test_name(self):
-        with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
+        with paddle.pir_utils.OldIrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
-            y_1 = paddle.subtract(x, y, name="add_res")
-            self.assertEqual(("add_res" in y_1.name), True)
+                y_1 = paddle.subtract(x, y, name="add_res")
+                self.assertEqual(("add_res" in y_1.name), True)
 
     def test_static(self):
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
## 修复 NPU 平台 test_elementwise_mod_op 单测
1. 使用了不兼容的 API `name`

## 测试截图
NPU 平台：
![35f1ed20-df77-4567-b856-f4ed90cfbbf5](https://github.com/user-attachments/assets/66dbb249-d3ae-4586-b24c-e0e1ff49b0f1)

MLU 平台没问题：
![image](https://github.com/user-attachments/assets/ba5bbab2-8dad-4820-a458-56225a49204f)
