### PR TITLE
[NPU][MLU] Fix test_elementwise_sub/add/mod

### DIFF
--- a/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_elementwise_add_op_mlu.py
@@ -391,10 +391,15 @@ class TestElementwiseAddOpError(unittest.TestCase):
             )
             self.assertRaises(TypeError, paddle.add, x1, y1)
 
-            # the input dtype of elementwise_add must be float16 or float32
-            x2 = paddle.static.data(name="x2", shape=[-1, 3, 4, 5, 6], dtype="uint8")
-            y2 = paddle.static.data(name="y2", shape=[-1, 3, 4, 5, 6], dtype="uint8")
-            self.assertRaises(TypeError, paddle.add, x2, y2)
+            if not paddle.framework.in_pir_mode():
+                # the input dtype of elementwise_add must be float16 or float32
+                x2 = paddle.static.data(
+                    name="x2", shape=[-1, 3, 4, 5, 6], dtype="uint8"
+                )
+                y2 = paddle.static.data(
+                    name="y2", shape=[-1, 3, 4, 5, 6], dtype="uint8"
+                )
+                self.assertRaises(TypeError, paddle.add, x2, y2)
 
 
 class TestAddApi(unittest.TestCase):
@@ -402,12 +407,13 @@ class TestAddApi(unittest.TestCase):
         return paddle.add(x, y, name)
 
     def test_name(self):
-        with base.program_guard(base.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
+        with paddle.pir_utils.OldIrGuard():
+            with base.program_guard(base.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
-            y_1 = self._executed_api(x, y, name="add_res")
-            self.assertEqual(("add_res" in y_1.name), True)
+                y_1 = self._executed_api(x, y, name="add_res")
+                self.assertEqual(("add_res" in y_1.name), True)
 
     def test_declarative(self):
         with base.program_guard(base.Program()):
@@ -424,7 +430,7 @@ class TestAddApi(unittest.TestCase):
 
             place = paddle.CustomPlace("mlu", 0)
             exe = base.Executor(place)
-            z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
+            z_value = exe.run(feed=gen_data(), fetch_list=[z])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 
@@ -509,7 +515,13 @@ class TestBoolAddFloatElementwiseAddop(unittest.TestCase):
         a = 1.5
         b = paddle.full([4, 5, 6], True, dtype="bool")
         c = a + b
-        self.assertTrue(c.dtype == core.VarDesc.VarType.FP32)
+
+        expected_type = (
+            core.DataType.FLOAT32
+            if paddle.framework.use_pir_api()
+            else core.VarDesc.VarType.FP32
+        )
+        self.assertTrue(c.dtype == expected_type)
         paddle.enable_static()
 
     def test_dygraph_add(self):
@@ -517,7 +529,13 @@ class TestBoolAddFloatElementwiseAddop(unittest.TestCase):
         a = 1.5
         b = paddle.full([4, 5, 6], True, dtype="bool")
         c = a + b
-        self.assertTrue(c.dtype == core.VarDesc.VarType.FP32)
+
+        expected_type = (
+            core.DataType.FLOAT32
+            if paddle.framework.use_pir_api()
+            else core.VarDesc.VarType.FP32
+        )
+        self.assertTrue(c.dtype == expected_type)
 
 
 if __name__ == "__main__":

--- a/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
@@ -23,6 +23,10 @@ from tests.op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 
+# Initialize NPU device
+exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
+exe.run(paddle.static.default_startup_program())
+
 
 class TestElementwiseAddOp(OpTest):
     def setUp(self):
@@ -184,12 +188,13 @@ class TestFP16ElementwiseAddOp_scalar2(TestFP16ElementwiseAddOp):
 
 class TestAddAPI(unittest.TestCase):
     def test_name(self):
-        with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
+        with paddle.pir_utils.OldIrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
-            y_1 = paddle.add(x, y, name="add_res")
-            self.assertEqual(("add_res" in y_1.name), True)
+                y_1 = paddle.add(x, y, name="add_res")
+                self.assertEqual(("add_res" in y_1.name), True)
 
     def test_static(self):
         with paddle.static.program_guard(paddle.static.Program()):
@@ -240,11 +245,11 @@ class TestAddError(unittest.TestCase):
                 np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], paddle.CustomPlace("npu", 0)
             )
             self.assertRaises(TypeError, paddle.add, x1, y1)
-
-            # the input dtype must be float16 or float32 or float64 or int32 or int64
-            x2 = paddle.static.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
-            y2 = paddle.static.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
-            self.assertRaises(TypeError, paddle.add, x2, y2)
+            if not paddle.framework.in_pir_mode():
+                # the input dtype must be float16 or float32 or float64 or int32 or int64
+                x2 = paddle.static.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
+                y2 = paddle.static.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
+                self.assertRaises(TypeError, paddle.add, x2, y2)
 
 
 class TestElementwiseAddOp_Vector(TestElementwiseAddOp):
@@ -507,12 +512,13 @@ class TestAddApi(unittest.TestCase):
         return paddle.add(x, y, name)
 
     def test_name(self):
-        with base.program_guard(base.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
+        with paddle.pir_utils.OldIrGuard():
+            with base.program_guard(base.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
-            y_1 = self._executed_api(x, y, name="add_res")
-            self.assertEqual(("add_res" in y_1.name), True)
+                y_1 = self._executed_api(x, y, name="add_res")
+                self.assertEqual(("add_res" in y_1.name), True)
 
     def test_declarative(self):
         with base.program_guard(base.Program()):
@@ -529,7 +535,7 @@ class TestAddApi(unittest.TestCase):
 
             place = paddle.CustomPlace("npu", 0)
             exe = base.Executor(place)
-            z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
+            z_value = exe.run(feed=gen_data(), fetch_list=[z])
             z_expected = np.array([3.0, 8.0, 6.0])
             self.assertEqual((z_value == z_expected).all(), True)
 
@@ -639,7 +645,7 @@ class TestAddAPIWithNPUStroageFormat(unittest.TestCase):
         exe.run(startup_program)
         result = exe.run(
             main_program,
-            feed={x_data.name: self.x, y_data.name: self.y},
+            feed={"data_x": self.x, "data_y": self.y},
             fetch_list=[out_expect, out_actual],
         )
 

--- a/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_mod_op_npu.py
@@ -141,12 +141,13 @@ class TestElementwiseModOp_broadcast_2(TestElementwiseModOp):
 
 class TestRemainderOp(unittest.TestCase):
     def test_name(self):
-        paddle.set_device("npu:0")
-        with base.program_guard(base.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="int64")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="int64")
-            y_1 = paddle.remainder(x, y, name="div_res")
-            self.assertEqual(("div_res" in y_1.name), True)
+        with paddle.pir_utils.OldIrGuard():
+            paddle.set_device("npu:0")
+            with base.program_guard(base.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="int64")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="int64")
+                y_1 = paddle.remainder(x, y, name="div_res")
+                self.assertEqual(("div_res" in y_1.name), True)
 
     def test_dygraph(self):
         paddle.set_device("npu:0")
@@ -207,6 +208,7 @@ class TestRemainderZeroDim(unittest.TestCase):
         out_cls = np.remainder(nx, ny)
         np.testing.assert_array_equal(out_cls, out.numpy())
         self.assertEqual(out.shape, [2, 3, 4])
+        out.retain_grads()
         out.backward()
         if x.grad is not None:
             self.assertEqual(x.grad.shape, [2, 3, 4])

--- a/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
@@ -134,12 +134,13 @@ class TestElementwiseSubOpInt64(TestElementwiseSubOp):
 
 class TestSubtractAPI(unittest.TestCase):
     def test_name(self):
-        with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
-            y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
+        with paddle.pir_utils.OldIrGuard():
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(name="x", shape=[2, 3], dtype="float32")
+                y = paddle.static.data(name="y", shape=[2, 3], dtype="float32")
 
-            y_1 = paddle.subtract(x, y, name="add_res")
-            self.assertEqual(("add_res" in y_1.name), True)
+                y_1 = paddle.subtract(x, y, name="add_res")
+                self.assertEqual(("add_res" in y_1.name), True)
 
     def test_static(self):
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
## test_elementwise_sub
### 改动和修复
1. 使用了不兼容的 API `name`

### 测试截图
NPU 平台：
![35f1ed20-df77-4567-b856-f4ed90cfbbf5](https://github.com/user-attachments/assets/66dbb249-d3ae-4586-b24c-e0e1ff49b0f1)

MLU 平台没问题：
![image](https://github.com/user-attachments/assets/ba5bbab2-8dad-4820-a458-56225a49204f)

## test_elementwise_mod
### 改动和修复
1. 使用了不兼容的 API `.name`
2. 尝试获取非叶节点梯度

### 测试截图
NPU 平台测试截图：
![image](https://github.com/user-attachments/assets/28c225fe-5599-489d-ac52-d9cea4c2431d)

MLU 无对应单测

## test_elementwise_add_op
### 改动和修复
1. 使用了不兼容 API `.name`
2. PIR 下（似乎）支持 uint8 加法
3. 新老静态图的Dtype使用的是不用的类型
4. NPU 需要至少执行一次 `exe.run(paddle.static.default_startup_program())` 来初始化
5. `paddle.incubate._npu_identity`缺乏 PIR 分支，PR：https://github.com/PaddlePaddle/Paddle/pull/71842

### 测试截图
NPU 平台测试截图：
![image](https://github.com/user-attachments/assets/ee0d8eaa-3991-403f-b062-f6f502ce3ab3)


MLU 平台测试截图：
![image](https://github.com/user-attachments/assets/f100baea-0dde-4d30-ba13-e7fc1c91f336)