### PR TITLE
【NPU】fix Arange kernel / cast kernel bug

### DIFF
--- a/backends/npu/kernels/arange_kernel.cc
+++ b/backends/npu/kernels/arange_kernel.cc
@@ -114,9 +114,6 @@ void AclopArangeKernel(const Context& dev_ctx,
   int64_t size = 0;
   GetSize(start_value, end_value, step_value, &size);
 
-  out->Resize(phi::make_ddim({size}));
-  dev_ctx.template Alloc<T>(out);
-
   std::vector<T> odata;
   T value = start_value;
   for (int64_t i = 0; i < size; ++i) {
@@ -136,7 +133,16 @@ void ArangeKernel(const Context& dev_ctx,
   DO_COMPATIBILITY(aclnnArange,
                    (custom_kernel::AclopArangeKernel<T, Context>(
                        dev_ctx, start, end, step, out)));
+  T start_value = start.to<T>();
+  T end_value = end.to<T>();
+  T step_value = step.to<T>();
+
+  int64_t size = 0;
+  GetSize(start_value, end_value, step_value, &size);
+
+  out->Resize(phi::make_ddim({size}));
   dev_ctx.template Alloc<T>(out);
+
   EXEC_NPU_CMD(aclnnArange, dev_ctx, start, end, step, *out);
 }
 

--- a/backends/npu/kernels/cast_kernel.cc
+++ b/backends/npu/kernels/cast_kernel.cc
@@ -93,13 +93,20 @@ void CastKernel(const Context& dev_ctx,
   DO_COMPATIBILITY(
       aclnnCast,
       (custom_kernel::AclopCastKernel<T, Context>(dev_ctx, x, dtype, out)));
-
+  out->Resize((x.dims()));
   if (x.dtype() == dtype) {
+    if (x.dims() == phi::make_ddim({-1})) {
+      *out = x;
+      return;
+    }
     dev_ctx.template Alloc<T>(out);
     TensorCopy(dev_ctx, x, false, out);
     return;
   }
-
+  if (x.dims() == phi::make_ddim({-1})) {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "canot cast tensor with unknown shape for diffrent dtype"));
+  }
   int aclDtype = ConvertToNpuDtype(dtype);
 
   if (dtype == phi::DataType::FLOAT32) {


### PR DESCRIPTION
解决json 推理报错
arange问题是没有计算out 的dim 就进行alloc
<img width="1006" alt="截屏2025-03-24 15 48 48" src="https://github.com/user-attachments/assets/77f45a13-90ef-4ee6-927c-34bbd56e8b4b" />

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/a5d5ec75-5c52-4b87-a99e-1a300f1ff900" />



cast kernel 问题是模型把不必要的结果做了cast ,由-1 shape cast 到-1 shape， 当cast 前后dtype  一致时选择把原始值返回，不一致时报错
<img width="1337" alt="image" src="https://github.com/user-attachments/assets/23b52ccf-0c7c-47dd-99ab-1ec8743fd49d" />
