### PR TITLE
[NPU] [MLU] Fix test_layer_norm_op & test_index_select_op & test_memcpy_op on NPU

### DIFF
--- a/backends/mlu/tests/unittests/test_index_select_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_index_select_op_mlu.py
@@ -142,7 +142,7 @@ class TestMLUIndexSelectAPI(unittest.TestCase):
             exe = paddle.static.Executor(paddle.CustomPlace("mlu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x, "index": self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(
@@ -158,7 +158,7 @@ class TestMLUIndexSelectAPI(unittest.TestCase):
             exe = paddle.static.Executor(paddle.CustomPlace("mlu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x, "index": self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(

--- a/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_layer_norm_op_mlu.py
@@ -26,6 +26,7 @@ from tests.op_test import _set_use_system_allocator
 from paddle.static.amp.fp16_utils import (
     _keep_layer_norm_scale_bias_to_fp32,
 )
+from paddle.pir_utils import OldIrGuard
 
 paddle.enable_static()
 
@@ -170,8 +171,10 @@ class TestLayerNormOp(unittest.TestCase):
                 var_names += ["bias"]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = base.Program()
-            with base.program_guard(program):
+            with OldIrGuard():
+                program = base.Program()
+                old_program_guard = base.program_guard
+            with old_program_guard(program):
                 block = program.global_block()
                 for name in ground_truth:
                     block.create_var(
@@ -221,14 +224,15 @@ class TestLayerNormOp(unittest.TestCase):
 
                 program._sync_with_cpp()
                 exe = base.Executor(place)
-                out = exe.run(
-                    program,
-                    feed={
-                        name: var_dict[name]
-                        for name in ["x", "scale", "bias", "y@GRAD"]
-                    },
-                    fetch_list=fetch_list,
-                )
+                with OldIrGuard():
+                    out = exe.run(
+                        program,
+                        feed={
+                            name: var_dict[name]
+                            for name in ["x", "scale", "bias", "y@GRAD"]
+                        },
+                        fetch_list=fetch_list,
+                    )
 
                 self.__assert_close(y, out[0], "y")
                 self.__assert_close(mean, out[1], "mean")

--- a/backends/npu/tests/unittests/test_index_select_op_npu.py
+++ b/backends/npu/tests/unittests/test_index_select_op_npu.py
@@ -141,7 +141,7 @@ class TestNPUIndexSelectAPI(unittest.TestCase):
             exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x, "index": self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(
@@ -157,7 +157,7 @@ class TestNPUIndexSelectAPI(unittest.TestCase):
             exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
                 feed={"x": self.data_x, "index": self.data_index},
-                fetch_list=[z.name],
+                fetch_list=[z],
                 return_numpy=False,
             )
         expect_out = np.array(

--- a/backends/npu/tests/unittests/test_layer_norm_op_npu.py
+++ b/backends/npu/tests/unittests/test_layer_norm_op_npu.py
@@ -24,6 +24,8 @@ import paddle.base as base
 import paddle.base.core as core
 import paddle_custom_device
 
+from paddle.pir_utils import OldIrGuard
+
 paddle.enable_static()
 
 SEED = 2021
@@ -180,8 +182,10 @@ class TestLayerNormOp(unittest.TestCase):
                 var_names += ["bias"]
             ground_truth = {name: var_dict[name] for name in var_names}
 
-            program = base.Program()
-            with base.program_guard(program):
+            with OldIrGuard():
+                program = base.Program()
+                old_program_guard = base.program_guard
+            with old_program_guard(program):
                 block = program.global_block()
                 for name in ground_truth:
                     block.create_var(
@@ -231,14 +235,15 @@ class TestLayerNormOp(unittest.TestCase):
 
                 program._sync_with_cpp()
                 exe = base.Executor(place)
-                out = exe.run(
-                    program,
-                    feed={
-                        name: var_dict[name]
-                        for name in ["x", "scale", "bias", "y@GRAD"]
-                    },
-                    fetch_list=fetch_list,
-                )
+                with OldIrGuard():
+                    out = exe.run(
+                        program,
+                        feed={
+                            name: var_dict[name]
+                            for name in ["x", "scale", "bias", "y@GRAD"]
+                        },
+                        fetch_list=fetch_list,
+                    )
                 # CANN 7.0 changes the output mode of variance
                 if int(paddle_custom_device.npu.version()["cann"].split(".")[0]) >= 7:
                     out[2] = (1 / out[2]) ** 2 - epsilon

--- a/backends/npu/tests/unittests/test_memcpy_op_npu.py
+++ b/backends/npu/tests/unittests/test_memcpy_op_npu.py
@@ -19,7 +19,8 @@ import unittest
 
 import paddle
 import paddle.base as base
-from paddle.base import Program, program_guard
+
+from paddle.pir_utils import OldIrGuard
 
 paddle.enable_static()
 SEED = 2021
@@ -29,8 +30,11 @@ class TestMemcpy_FillConstant(unittest.TestCase):
     def get_prog(self):
         self.__class__.use_custom_device = True
         paddle.enable_static()
-        main_program = Program()
-        with program_guard(main_program):
+
+        with OldIrGuard():
+            main_program = base.Program()
+            old_program_guard = base.program_guard
+        with old_program_guard(main_program):
             cpu_var_name = "tensor@Cpu"
             npu_var_name = "tensor@Npu"
             cpu_var = main_program.global_block().create_var(
@@ -79,9 +83,8 @@ class TestMemcpy_FillConstant(unittest.TestCase):
         )
         place = paddle.CustomPlace("npu", 0)
         exe = base.Executor(place)
-        npu_, cpu_ = exe.run(
-            main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
-        )
+        with OldIrGuard():
+            npu_, cpu_ = exe.run(main_program, feed={}, fetch_list=[npu_var, cpu_var])
         np.testing.assert_allclose(npu_, cpu_)
         np.testing.assert_allclose(cpu_, np.ones((10, 10)))
 
@@ -96,9 +99,8 @@ class TestMemcpy_FillConstant(unittest.TestCase):
         )
         place = paddle.CustomPlace("npu", 0)
         exe = base.Executor(place)
-        npu_, cpu_ = exe.run(
-            main_program, feed={}, fetch_list=[npu_var.name, cpu_var.name]
-        )
+        with OldIrGuard():
+            npu_, cpu_ = exe.run(main_program, feed={}, fetch_list=[npu_var, cpu_var])
         np.testing.assert_allclose(npu_, cpu_)
         np.testing.assert_allclose(npu_, np.zeros((10, 10)))
 


### PR DESCRIPTION
## 改动与修复
1. 使用了不兼容的API `create_var` 
 
## 测试截图
### test_index_select_op
NPU：
![image](https://github.com/user-attachments/assets/940906e9-a37c-4324-b149-87584665043b)

MLU：
![image](https://github.com/user-attachments/assets/05bf76a6-3472-46f2-a3ac-be782f005da4)


### test_layer_norm_op
NPU：
![image](https://github.com/user-attachments/assets/938c1f77-0026-4a59-806c-30e03a62cce6)

MLU：
![image](https://github.com/user-attachments/assets/8cbc8fb1-9935-4df0-9f4d-c9e467c41e00)

### test_memcpy_op
NPU：
![image](https://github.com/user-attachments/assets/13a7fdb7-d636-46ae-b98c-7745d6ab1db5)

MLU 无对应单测
