### PR TITLE
[MLU] Fix test_accuracy_op, test_gather_op, test_logical_op & test_static_print 

### DIFF
--- a/backends/mlu/kernels/gather_kernel.cc
+++ b/backends/mlu/kernels/gather_kernel.cc
@@ -25,6 +25,20 @@ void GatherKernel(const Context& dev_ctx,
                   phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
 
+  PADDLE_ENFORCE_EQ(
+      axis.dtype() == DataType::INT32 || axis.dtype() == DataType::INT64,
+      true,
+      phi::errors::InvalidArgument(
+          "The axis should be INT32 or INT64, but we get %s",
+          DataTypeToString(axis.dtype())));
+
+  PADDLE_ENFORCE_EQ(
+      index.dtype() == DataType::INT32 || index.dtype() == DataType::INT64,
+      true,
+      phi::errors::InvalidArgument(
+          "The index should be INT32 or INT64, but we get %s",
+          DataTypeToString(index.dtype())));
+
   const auto index_dims = index.dims();
   if (index_dims.size() == 2) {
     PADDLE_ENFORCE_EQ(
@@ -116,6 +130,10 @@ PD_REGISTER_PLUGIN_KERNEL(gather,
                           ALL_LAYOUT,
                           custom_kernel::GatherKernel,
                           float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int32_t,
                           phi::dtype::float16) {}
 
 PD_REGISTER_PLUGIN_KERNEL(gather_grad,
@@ -123,4 +141,8 @@ PD_REGISTER_PLUGIN_KERNEL(gather_grad,
                           ALL_LAYOUT,
                           custom_kernel::GatherGradKernel,
                           float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int32_t,
                           phi::dtype::float16) {}

--- a/backends/mlu/tests/unittests/test_accuracy_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_accuracy_op_mlu.py
@@ -83,7 +83,7 @@ class TestAccuracyAPI1(unittest.TestCase):
         exe = paddle.static.Executor()
         (result,) = exe.run(
             feed={"predictions": self.input_predictions, "labels": self.input_labels},
-            fetch_list=[self.result.name],
+            fetch_list=[self.result],
         )
         self.assertEqual((result == self.expect_value).all(), True)
 

--- a/backends/mlu/tests/unittests/test_gather_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_gather_op_mlu.py
@@ -17,7 +17,6 @@ import unittest
 from tests.op_test import OpTest
 
 import numpy as np
-import paddle.base as base
 import paddle
 
 paddle.enable_static()
@@ -120,60 +119,119 @@ class API_TestDygraphGather(unittest.TestCase):
 
 
 class TestGathertError(unittest.TestCase):
+    def setUp(self) -> None:
+        self.place = paddle.CustomPlace("mlu", 0)
+        paddle.set_device("mlu:0")
+
     def test_error1(self):
-        with paddle.static.program_guard(
-            paddle.static.Program(), paddle.static.Program()
-        ):
+        paddle.enable_static()
+        if not paddle.framework.use_pir_api():
+            with paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ):
+
+                input_shape = [8, 9, 6]
+                index_shape = [4]
+                x_int8 = paddle.static.data(
+                    shape=input_shape, dtype="int8", name="x_int8"
+                )
+                x_float32 = paddle.static.data(
+                    shape=input_shape, dtype="float32", name="x_float32"
+                )
+                axis = paddle.static.data(shape=[1], dtype="float32", name="axis")
+                index = paddle.static.data(
+                    shape=index_shape, dtype="int32", name="index"
+                )
+                index_float = paddle.static.data(
+                    shape=index_shape, dtype="float32", name="index_float"
+                )
+
+                def test_x_type():
+                    paddle.gather(x_int8, index)
+
+                self.assertRaises(TypeError, test_x_type)
+
+                def test_index_type():
+                    paddle.gather(x_float32, index_float)
+
+                self.assertRaises(TypeError, test_index_type)
+
+                def test_axis_dtype():
+                    paddle.gather(x_float32, index, axis=1.11)
+
+                self.assertRaises(TypeError, test_axis_dtype)
+
+                def test_axis_dtype1():
+                    paddle.gather(x_float32, index, axis=axis)
+
+                self.assertRaises(TypeError, test_axis_dtype1)
+        else:
             paddle.set_device("mlu")
-
-            shape = [8, 9, 6]
-            x = paddle.static.data(shape=shape, dtype="int8", name="x")
-            axis = paddle.static.data(shape=[1], dtype="float32", name="axis")
-            index = paddle.static.data(shape=shape, dtype="int32", name="index")
-            index_float = paddle.static.data(
-                shape=shape, dtype="float32", name="index_float"
-            )
-
-            def test_x_type():
-                paddle.gather(x, index)
-
-            self.assertRaises(TypeError, test_x_type)
+            input_shape = [8, 9, 6]
+            index_shape = [4]
 
             def test_index_type():
-                paddle.gather(x, index_float)
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    x = paddle.static.data(shape=input_shape, dtype="float32", name="x")
+                    index = paddle.static.data(
+                        shape=index_shape, dtype="float32", name="index_float"
+                    )
+                    out = paddle.gather(x, index)
+                    exe = paddle.static.Executor(place=self.place)
+                    exe.run(paddle.static.default_startup_program())
+                    self.assertRaises(
+                        ValueError,
+                        exe.run,
+                        paddle.static.default_main_program(),
+                        feed={
+                            "x": np.random.random(input_shape).astype("float32"),
+                            "index_float": np.random.random(index_shape).astype(
+                                "float32"
+                            ),
+                        },
+                    )
 
-            self.assertRaises(TypeError, test_index_type)
+            def test_axis_scalar_dtype():
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    x = paddle.static.data(shape=input_shape, dtype="float32", name="x")
+                    index = paddle.static.data(
+                        shape=index_shape, dtype="int32", name="index"
+                    )
+                    axis = paddle.static.data(shape=[1], dtype="int32", name="axis")
+                    self.assertRaises(TypeError, paddle.gather, x, index, axis=1.11)
 
-            def test_axis_dtype():
-                paddle.gather(x, index, axis=1.11)
+            def test_axis_tensor_dtype():
+                with paddle.static.program_guard(
+                    paddle.static.Program(), paddle.static.Program()
+                ):
+                    x = paddle.static.data(shape=input_shape, dtype="float32", name="x")
+                    index = paddle.static.data(
+                        shape=index_shape, dtype="int32", name="index"
+                    )
+                    axis = paddle.static.data(shape=[1], dtype="float32", name="axis")
+                    y = paddle.gather(x, index, axis=axis)
+                    exe = paddle.static.Executor(place=self.place)
+                    exe.run(paddle.static.default_startup_program())
+                    self.assertRaises(
+                        ValueError,
+                        exe.run,
+                        paddle.static.default_main_program(),
+                        feed={
+                            "x": np.random.random(input_shape).astype("float32"),
+                            "index": np.random.randint(0, 8, index_shape).astype(
+                                "int32"
+                            ),
+                            "axis": np.array([1.11]).astype("float32"),
+                        },
+                    )
 
-            self.assertRaises(TypeError, test_axis_dtype)
-
-            def test_axis_dtype1():
-                paddle.gather(x, index, axis=axis)
-
-            self.assertRaises(TypeError, test_axis_dtype1)
-
-    def test_error2(self):
-        with base.program_guard(base.Program(), base.Program()):
-            paddle.set_device("mlu")
-
-            shape = [8, 9, 6]
-            x = paddle.static.data(shape=shape, dtype="int8", name="x")
-            index = paddle.static.data(shape=shape, dtype="int32", name="mask")
-            index_float = paddle.static.data(
-                shape=shape, dtype="float32", name="index_float"
-            )
-
-            def test_x_type():
-                paddle.gather(x, index)
-
-            self.assertRaises(TypeError, test_x_type)
-
-            def test_index_type():
-                paddle.gather(x, index_float)
-
-            self.assertRaises(TypeError, test_index_type)
+            test_index_type()
+            test_axis_scalar_dtype()
+            test_axis_tensor_dtype()
 
 
 if __name__ == "__main__":

--- a/backends/mlu/tests/unittests/test_logical_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_logical_op_mlu.py
@@ -127,18 +127,17 @@ def test(unit_test, use_mlu=False, test_error=False):
 
 def test_type_error(unit_test, use_mlu, type_str_map):
     def check_type(op_str, x, y, binary_op):
-        op = getattr(paddle, op_str)
-        error_type = ValueError
-        if isinstance(x, np.ndarray):
-            x = paddle.to_tensor(x)
-            y = paddle.to_tensor(y)
-            error_type = BaseException
-        if binary_op:
-            if not paddle.in_dynamic_mode():
+        if not paddle.framework.in_dynamic_or_pir_mode():
+            op = getattr(paddle, op_str)
+            error_type = ValueError
+            if isinstance(x, np.ndarray):
+                x = paddle.to_tensor(x)
+                y = paddle.to_tensor(y)
+                error_type = BaseException
+            if binary_op:
                 error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, y=y, out=1)
-        else:
-            if not paddle.in_dynamic_mode():
+            else:
                 error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, out=1)
 

--- a/backends/mlu/tests/unittests/test_static_print_mlu.py
+++ b/backends/mlu/tests/unittests/test_static_print_mlu.py
@@ -39,7 +39,7 @@ class TestNewIrPrint(unittest.TestCase):
                 z = x + y
                 z = paddle.static.Print(z)
 
-            out = exe.run(main_program, {}, fetch_list=[z.name])
+            out = exe.run(main_program, {}, fetch_list=[z])
 
         gold_res = np.ones([2, 2], dtype="float32") * 2
 


### PR DESCRIPTION
## test_accuracy_op
![image](https://github.com/user-attachments/assets/1fb561f4-9d62-45e7-865d-642ae8e46efd)

## test_gather_op
1. 修改 gather_kernel，支持 int 和 uint 输入
2. 修改 test_gather_kernel，原测试中存在无效测试和错误输入

![image](https://github.com/user-attachments/assets/29e1c5b7-5c0a-4012-920f-82a6f001a62a)

## test_logical_op
![image](https://github.com/user-attachments/assets/99e92a97-17e7-471d-9a35-0e5f5a26ce92)
