### PR TITLE
[INTEL_HPU] Fetching custom_tpc_lib during cmake process

### DIFF
--- a/backends/intel_hpu/CMakeLists.txt
+++ b/backends/intel_hpu/CMakeLists.txt
@@ -36,6 +36,7 @@ include(paddle)
 include(generic)
 include(version)
 include(external/synapse)
+include(external/custom_tpc_lib)
 
 include_directories(${PADDLE_INC_DIR} ${CMAKE_SOURCE_DIR}
                     ${CMAKE_SOURCE_DIR}/kernels /usr/include/habanalabs)

--- a/backends/intel_hpu/README.md
+++ b/backends/intel_hpu/README.md
@@ -33,6 +33,8 @@ make -j8
 
 # using pip to install the output
 pip install dist/paddle_intel_hpu*.whl
+# set TPC kernel library path for Habana runtime. please note the path is a Python version-dependent path.
+export GC_KERNEL_PATH=/usr/local/lib/python3.10/dist-packages/paddle_custom_device/intel_hpu/libcustom_tpc_perf_lib.so:$GC_KERNEL_PATH
 ```
 
 ## Verification

--- a/backends/intel_hpu/cmake/external/custom_tpc_lib.cmake
+++ b/backends/intel_hpu/cmake/external/custom_tpc_lib.cmake
@@ -1,0 +1,13 @@
+set(DOWNLOAD_URL "https://paddle-ci.cdn.bcebos.com/libcustom_tpc_perf_lib.so")
+set(TARGET_DIR "${CMAKE_BINARY_DIR}/python/paddle_custom_device/intel_hpu")
+set(TARGET_PATH "${TARGET_DIR}/libcustom_tpc_perf_lib.so")
+
+file(MAKE_DIRECTORY ${TARGET_DIR})
+file(DOWNLOAD ${DOWNLOAD_URL} ${TARGET_PATH} STATUS download_status)
+
+list(GET download_status 0 download_success)
+if(NOT (download_success EQUAL 0))
+  message(FATAL_ERROR "Failed to download ${DOWNLOAD_URL} to ${TARGET_PATH}")
+endif()
+
+message(STATUS "Downloaded ${DOWNLOAD_URL} to ${TARGET_PATH}")


### PR DESCRIPTION
This commit lets cmake process fetch libcustom_tpc_perf_lib.so from paddle-ci.cdn.bcebos.com directly. So file will be put to build folder.