### PR TITLE
[MLU][NPU] Fix unittests in pir mode

### DIFF
--- a/backends/mlu/tests/unittests/test_merged_momentum_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_merged_momentum_op_mlu.py
@@ -17,6 +17,7 @@ import paddle
 import numpy as np
 from paddle.base.layer_helper import LayerHelper
 from collections import OrderedDict
+from paddle.pir_utils import OldIrGuard
 
 
 def run_momentum_op(
@@ -32,117 +33,132 @@ def run_momentum_op(
     use_merged=False,
     use_nesterov=True,
 ):
-    assert len(params) == len(grads)
-    assert len(params) == len(velocitys)
-    if multi_precision:
-        assert len(params) == len(master_params)
-    op_type = "merged_momentum" if use_merged else "momentum"
-    main = paddle.static.Program()
-    startup = paddle.static.Program()
-    with paddle.static.program_guard(main, startup):
-        helper = LayerHelper(op_type, **locals())
-
-        param_vars = [
-            helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-            for p in params
-        ]
-        grad_vars = [
-            helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
-        ]
-        velocity_vars = [
-            helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
-            for v in velocitys
-        ]
-        lr_var = helper.create_variable(
-            persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
-        )
-
-        feed_dict = OrderedDict()
-
-        feed_dict.update(
-            OrderedDict(
-                [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
-            )
-        )
-        feed_dict.update(
-            OrderedDict(
-                [(v_var.name, v_val) for v_var, v_val in zip(velocity_vars, velocitys)]
-            )
-        )
-        fetch_list = list(feed_dict.keys())
-
-        feed_dict.update(
-            OrderedDict([(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)])
-        )
-        feed_dict.update({lr_var.name: learning_rate})
-
+    with OldIrGuard():
+        assert len(params) == len(grads)
+        assert len(params) == len(velocitys)
         if multi_precision:
-            master_param_vars = [
+            assert len(params) == len(master_params)
+        op_type = "merged_momentum" if use_merged else "momentum"
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            helper = LayerHelper(op_type, **locals())
+
+            param_vars = [
                 helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-                for p in master_params
+                for p in params
             ]
+            grad_vars = [
+                helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
+            ]
+            velocity_vars = [
+                helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
+                for v in velocitys
+            ]
+            lr_var = helper.create_variable(
+                persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
+            )
+
+            feed_dict = OrderedDict()
+
+            feed_dict.update(
+                OrderedDict(
+                    [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
+                )
+            )
             feed_dict.update(
                 OrderedDict(
                     [
-                        (mp_var.name, mp_val)
-                        for mp_var, mp_val in zip(master_param_vars, master_params)
+                        (v_var.name, v_val)
+                        for v_var, v_val in zip(velocity_vars, velocitys)
                     ]
                 )
             )
-            # CPUPlace does not use MasterParam
-            if isinstance(place, paddle.CUDAPlace):
-                fetch_list = fetch_list + [mp_var.name for mp_var in master_param_vars]
-        else:
-            master_param_vars = None
+            fetch_list = list(feed_dict.keys())
 
-        if not use_merged:
-            for i, (p, g, v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
+            feed_dict.update(
+                OrderedDict(
+                    [(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)]
+                )
+            )
+            feed_dict.update({lr_var.name: learning_rate})
+
+            if multi_precision:
+                master_param_vars = [
+                    helper.create_variable(
+                        persistable=True, shape=p.shape, dtype=p.dtype
+                    )
+                    for p in master_params
+                ]
+                feed_dict.update(
+                    OrderedDict(
+                        [
+                            (mp_var.name, mp_val)
+                            for mp_var, mp_val in zip(master_param_vars, master_params)
+                        ]
+                    )
+                )
+                # CPUPlace does not use MasterParam
+                if isinstance(place, paddle.CUDAPlace):
+                    fetch_list = fetch_list + [
+                        mp_var.name for mp_var in master_param_vars
+                    ]
+            else:
+                master_param_vars = None
+
+            if not use_merged:
+                for i, (p, g, v) in enumerate(
+                    zip(param_vars, grad_vars, velocity_vars)
+                ):
+                    inputs = {
+                        "Param": p,
+                        "Grad": g,
+                        "Velocity": v,
+                        "LearningRate": lr_var,
+                    }
+                    outputs = {"ParamOut": p, "VelocityOut": v}
+                    if multi_precision:
+                        inputs["MasterParam"] = master_param_vars[i]
+                        outputs["MasterParamOut"] = master_param_vars[i]
+                    attrs = {
+                        "mu": mu,
+                        "multi_precision": multi_precision,
+                        "rescale_grad": rescale_grad,
+                        "use_nesterov": use_nesterov,
+                        "regularization_method": "l2_decay",
+                        "regularization_coeff": 2.0,
+                    }
+                    helper.append_op(
+                        type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
+                    )
+            else:
                 inputs = {
-                    "Param": p,
-                    "Grad": g,
-                    "Velocity": v,
+                    "Param": param_vars,
+                    "Grad": grad_vars,
+                    "Velocity": velocity_vars,
                     "LearningRate": lr_var,
                 }
-                outputs = {"ParamOut": p, "VelocityOut": v}
+                outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
                 if multi_precision:
-                    inputs["MasterParam"] = master_param_vars[i]
-                    outputs["MasterParamOut"] = master_param_vars[i]
+                    inputs["MasterParam"] = master_param_vars
+                    outputs["MasterParamOut"] = master_param_vars
                 attrs = {
                     "mu": mu,
                     "multi_precision": multi_precision,
                     "rescale_grad": rescale_grad,
                     "use_nesterov": use_nesterov,
-                    "regularization_method": "l2_decay",
-                    "regularization_coeff": 2.0,
+                    "regularization_method": [
+                        "l2_decay" for i in range(len(param_vars))
+                    ],
+                    "regularization_coeff": [2.0 for i in range(len(param_vars))],
                 }
                 helper.append_op(
                     type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
                 )
-        else:
-            inputs = {
-                "Param": param_vars,
-                "Grad": grad_vars,
-                "Velocity": velocity_vars,
-                "LearningRate": lr_var,
-            }
-            outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
-            if multi_precision:
-                inputs["MasterParam"] = master_param_vars
-                outputs["MasterParamOut"] = master_param_vars
-            attrs = {
-                "mu": mu,
-                "multi_precision": multi_precision,
-                "rescale_grad": rescale_grad,
-                "use_nesterov": use_nesterov,
-                "regularization_method": ["l2_decay" for i in range(len(param_vars))],
-                "regularization_coeff": [2.0 for i in range(len(param_vars))],
-            }
-            helper.append_op(type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
-
-    exe = paddle.static.Executor(place)
-    with paddle.static.scope_guard(paddle.static.Scope()):
-        exe.run(startup)
-        return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
+        exe = paddle.static.Executor(place)
+        with paddle.static.scope_guard(paddle.static.Scope()):
+            exe.run(startup)
+            return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
 
 
 class TestMergedMomentum(unittest.TestCase):

--- a/backends/mlu/tests/unittests/test_momentum_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_momentum_op_mlu.py
@@ -177,14 +177,17 @@ class TestMomentumV2(unittest.TestCase):
             rms_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
+            train_reader = paddle.io.DataLoader(
+                paddle.text.datasets.UCIHousing(mode="train"),
+                batch_size=1,
+                places=place,
+                feed_list=[x, y],
+                return_list=False,
             )
-            feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+                exe.run(main, feed=data, fetch_list=fetch_list)
 
     def test_raise_error(self):
         self.assertRaises(ValueError, paddle.optimizer.Momentum, learning_rate=None)
@@ -301,14 +304,18 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
             momentum_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
+            train_reader = paddle.io.DataLoader(
+                paddle.text.datasets.UCIHousing(mode="train"),
+                batch_size=1,
+                places=place,
+                feed_list=[x, y],
+                return_list=False,
             )
             feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+                exe.run(main, feed=data, fetch_list=fetch_list)
 
 
 class TestFusedMomentumWithDecayAPI(unittest.TestCase):
@@ -341,12 +348,18 @@ class TestFusedMomentumWithDecayAPI(unittest.TestCase):
         )
         program = self.get_program(weight_attr, bias_attr=False)
         ops = program.global_block().ops
-
-        self.assertEqual(ops[-1].attr("regularization_method"), "l2_decay")
-        self.assertEqual(ops[-1].attr("regularization_coeff"), np.float32(0.1))
-        for i in range(len(ops)):
-            self.assertTrue("sum" not in ops[i].type)
-            self.assertTrue("scale" not in ops[i].type)
+        if paddle.framework.use_pir_api():
+            self.assertEqual(ops[-1].attrs()["regularization_method"], "l2_decay")
+            self.assertEqual(ops[-1].attrs()["regularization_coeff"], np.float32(0.1))
+            for i in range(len(ops)):
+                self.assertTrue("pd_op.add_n" not in ops[i].name())
+                self.assertTrue("pd_op.scale" not in ops[i].name())
+        else:
+            self.assertEqual(ops[-1].attr("regularization_method"), "l2_decay")
+            self.assertEqual(ops[-1].attr("regularization_coeff"), np.float32(0.1))
+            for i in range(len(ops)):
+                self.assertTrue("sum" not in ops[i].type)
+                self.assertTrue("scale" not in ops[i].type)
 
     def test_param_has_l1decay(self):
         paddle.enable_static()
@@ -362,29 +375,56 @@ class TestFusedMomentumWithDecayAPI(unittest.TestCase):
         )
         program = self.get_program(weight_attr, bias_attr)
         ops = program.global_block().ops
-
-        self.assertEqual(ops[-1].type, "momentum")
-        self.assertEqual(ops[-2].type, "momentum")
-        self.assertEqual(ops[-3].type, "sum")
-        self.assertEqual(ops[-4].type, "scale")
-        self.assertEqual(ops[-5].type, "sign")
-        self.assertEqual(ops[-6].type, "matmul_v2_grad")
-        if "weight" in ops[-1].input("Param"):
-            self.assertEqual(ops[-1].attr("regularization_method"), "")
-            self.assertEqual(ops[-1].attr("regularization_coeff"), 0)
-        if "bias" in ops[-2].input("Param"):
-            self.assertEqual(ops[-2].attr("regularization_method"), "l2_decay")
-            self.assertEqual(ops[-2].attr("regularization_coeff"), np.float32(0.5))
+        if paddle.framework.use_pir_api():
+            op_names = [
+                "pd_op.momentum_",
+                "pd_op.momentum_",
+                "pd_op.add_n",
+                "builtin.combine",
+                "pd_op.scale",
+                "pd_op.full",
+                "pd_op.sign",
+                "pd_op.matmul_grad",
+            ]
+            for i, name in enumerate(op_names):
+                self.assertEqual(ops[-(i + 1)].name(), name)
+            if "weight" == ops[-1].operand_source(0).name:
+                self.assertEqual(ops[-1].attrs()["regularization_method"], "")
+                self.assertEqual(ops[-1].attrs()["regularization_coeff"], 0)
+            if "bias" == ops[-2].operand_source(0).name:
+                self.assertEqual(ops[-2].attrs()["regularization_method"], "l2_decay")
+                self.assertEqual(
+                    ops[-2].attrs()["regularization_coeff"], np.float32(0.5)
+                )
+        else:
+            self.assertEqual(ops[-1].type, "momentum")
+            self.assertEqual(ops[-2].type, "momentum")
+            self.assertEqual(ops[-3].type, "sum")
+            self.assertEqual(ops[-4].type, "scale")
+            self.assertEqual(ops[-5].type, "sign")
+            self.assertEqual(ops[-6].type, "matmul_v2_grad")
+            if "weight" in ops[-1].input("Param"):
+                self.assertEqual(ops[-1].attr("regularization_method"), "")
+                self.assertEqual(ops[-1].attr("regularization_coeff"), 0)
+            if "bias" in ops[-2].input("Param"):
+                self.assertEqual(ops[-2].attr("regularization_method"), "l2_decay")
+                self.assertEqual(ops[-2].attr("regularization_coeff"), np.float32(0.5))
 
     def test_param_has_no_regularizer(self):
         paddle.enable_static()
         program = self.get_program(weight_attr=None)
         ops = program.global_block().ops
-        self.assertEqual(ops[-1].attr("regularization_method"), "l2_decay")
-        self.assertEqual(ops[-1].attr("regularization_coeff"), np.float32(0.5))
-        for i in range(len(ops)):
-            self.assertTrue("sum" not in ops[i].type)
-            self.assertTrue("scale" not in ops[i].type)
+        if paddle.framework.use_pir_api():
+            self.assertEqual(ops[-1].attrs()["regularization_method"], "l2_decay")
+            self.assertEqual(ops[-1].attrs()["regularization_coeff"], np.float32(0.5))
+            for i in range(len(ops)):
+                self.assertTrue("pd_op.add_n" not in ops[i].name())
+                self.assertTrue("pd_op.scale" not in ops[i].name())
+        else:
+            self.assertEqual(ops[-1].attr("regularization_method"), "l2_decay")
+            for i in range(len(ops)):
+                self.assertTrue("sum" not in ops[i].type)
+                self.assertTrue("scale" not in ops[i].type)
 
 
 class TestMomentumOpVsMomentumOpWithDecayAPI(unittest.TestCase):

--- a/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_pool2d_op_mlu.py
@@ -1040,7 +1040,7 @@ class TestPool2DAPI(unittest.TestCase):
             padding=[0, 0],
             data_format="NHWC",
         )
-        assert out_9.shape == (2, -1, 3, 3)
+        assert tuple(out_9.shape) == (2, -1, 3, 3)
 
         # test negetive
         out_10 = paddle.nn.functional.avg_pool2d(
@@ -1050,7 +1050,7 @@ class TestPool2DAPI(unittest.TestCase):
             padding=[0, 0],
             data_format="NCHW",
         )
-        assert out_10.shape == (2, 3, -1, -1)
+        assert tuple(out_10.shape) == (2, 3, -1, -1)
 
         exe = base.Executor(place=paddle.CustomPlace("mlu", 0))
 

--- a/backends/mlu/tests/unittests/test_randperm_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_randperm_op_mlu.py
@@ -102,9 +102,29 @@ class TestRandpermOpFloat64(TestRandpermOp):
 class TestRandpermOpError(unittest.TestCase):
     def test_errors(self):
         paddle.set_device("mlu")
-        with program_guard(Program(), Program()):
-            self.assertRaises(ValueError, paddle.randperm, -3)
-            self.assertRaises(TypeError, paddle.randperm, 10, "int8")
+        if paddle.framework.use_pir_api():
+
+            def test_invalid_n():
+                with program_guard(Program(), Program()):
+                    paddle.randperm(-3)
+                    exe = paddle.static.Executor()
+                    exe.run(paddle.static.default_startup_program())
+                    exe.run(paddle.static.default_main_program())
+
+            self.assertRaises(RuntimeError, test_invalid_n)
+
+            def test_invalid_dtype():
+                with program_guard(Program(), Program()):
+                    paddle.randperm(10, "int8")
+                    exe = paddle.static.Executor()
+                    exe.run(paddle.static.default_startup_program())
+                    exe.run(paddle.static.default_main_program())
+
+            self.assertRaises(TypeError, test_invalid_dtype)
+        else:
+            with program_guard(Program(), Program()):
+                self.assertRaises(ValueError, paddle.randperm, -3)
+                self.assertRaises(TypeError, paddle.randperm, 10, "int8")
 
 
 class TestRandpermAPI(unittest.TestCase):

--- a/backends/mlu/tests/unittests/test_roll_op_mlu.py
+++ b/backends/mlu/tests/unittests/test_roll_op_mlu.py
@@ -133,7 +133,9 @@ class TestRollInt32OpCase3(TestRollInt32):
 
 class TestRollAPI(unittest.TestCase):
     def input_data(self):
-        self.data_x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        self.data_x = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        ).astype("float32")
 
     def test_roll_op_api(self):
         self.input_data()
@@ -142,11 +144,10 @@ class TestRollAPI(unittest.TestCase):
         # case 1:
         with program_guard(Program(), Program()):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
-            x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1)
             exe = base.Executor(paddle.CustomPlace("mlu", 0))
             (res,) = exe.run(
-                feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
+                feed={"x": self.data_x}, fetch_list=[z], return_numpy=False
             )
             expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
             np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -154,11 +155,10 @@ class TestRollAPI(unittest.TestCase):
         # case 2:
         with program_guard(Program(), Program()):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
-            x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1, axis=0)
             exe = base.Executor(paddle.CustomPlace("mlu", 0))
             (res,) = exe.run(
-                feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
+                feed={"x": self.data_x}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)

--- a/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
@@ -19,6 +19,7 @@ import unittest
 
 import paddle
 from paddle.base.layer_helper import LayerHelper
+from paddle.pir_utils import OldIrGuard
 from collections import OrderedDict
 
 paddle.enable_static()
@@ -36,106 +37,120 @@ def run_momentum_op(
     rescale_grad=0.01,
     use_merged=False,
 ):
-    assert len(params) == len(grads)
-    assert len(params) == len(velocitys)
-    if multi_precision:
-        assert len(params) == len(master_params)
-    op_type = "merged_momentum" if use_merged else "momentum"
-    main = paddle.static.Program()
-    startup = paddle.static.Program()
-    with paddle.static.program_guard(main, startup):
-        helper = LayerHelper(op_type, **locals())
-        attrs = {
-            "mu": mu,
-            "multi_precision": multi_precision,
-            "rescale_grad": rescale_grad,
-        }
-
-        param_vars = [
-            helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-            for p in params
-        ]
-        grad_vars = [
-            helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
-        ]
-        velocity_vars = [
-            helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
-            for v in velocitys
-        ]
-        lr_var = helper.create_variable(
-            persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
-        )
-
-        feed_dict = OrderedDict()
-
-        feed_dict.update(
-            OrderedDict(
-                [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
-            )
-        )
-        feed_dict.update(
-            OrderedDict(
-                [(v_var.name, v_val) for v_var, v_val in zip(velocity_vars, velocitys)]
-            )
-        )
-        fetch_list = list(feed_dict.keys())
-
-        feed_dict.update(
-            OrderedDict([(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)])
-        )
-        feed_dict.update({lr_var.name: learning_rate})
-
+    with OldIrGuard():
+        assert len(params) == len(grads)
+        assert len(params) == len(velocitys)
         if multi_precision:
-            master_param_vars = [
+            assert len(params) == len(master_params)
+        op_type = "merged_momentum" if use_merged else "momentum"
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            helper = LayerHelper(op_type, **locals())
+            attrs = {
+                "mu": mu,
+                "multi_precision": multi_precision,
+                "rescale_grad": rescale_grad,
+            }
+
+            param_vars = [
                 helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-                for p in master_params
+                for p in params
             ]
+            grad_vars = [
+                helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
+            ]
+            velocity_vars = [
+                helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
+                for v in velocitys
+            ]
+            lr_var = helper.create_variable(
+                persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
+            )
+
+            feed_dict = OrderedDict()
+
+            feed_dict.update(
+                OrderedDict(
+                    [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
+                )
+            )
             feed_dict.update(
                 OrderedDict(
                     [
-                        (mp_var.name, mp_val)
-                        for mp_var, mp_val in zip(master_param_vars, master_params)
+                        (v_var.name, v_val)
+                        for v_var, v_val in zip(velocity_vars, velocitys)
                     ]
                 )
             )
-            # CPUPlace does not use MasterParam
-            if isinstance(place, paddle.CUDAPlace):
-                fetch_list = fetch_list + [mp_var.name for mp_var in master_param_vars]
-        else:
-            master_param_vars = None
+            fetch_list = list(feed_dict.keys())
 
-        if not use_merged:
-            for i, (p, g, v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
+            feed_dict.update(
+                OrderedDict(
+                    [(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)]
+                )
+            )
+            feed_dict.update({lr_var.name: learning_rate})
+
+            if multi_precision:
+                master_param_vars = [
+                    helper.create_variable(
+                        persistable=True, shape=p.shape, dtype=p.dtype
+                    )
+                    for p in master_params
+                ]
+                feed_dict.update(
+                    OrderedDict(
+                        [
+                            (mp_var.name, mp_val)
+                            for mp_var, mp_val in zip(master_param_vars, master_params)
+                        ]
+                    )
+                )
+                # CPUPlace does not use MasterParam
+                if isinstance(place, paddle.CUDAPlace):
+                    fetch_list = fetch_list + [
+                        mp_var.name for mp_var in master_param_vars
+                    ]
+            else:
+                master_param_vars = None
+
+            if not use_merged:
+                for i, (p, g, v) in enumerate(
+                    zip(param_vars, grad_vars, velocity_vars)
+                ):
+                    inputs = {
+                        "Param": p,
+                        "Grad": g,
+                        "Velocity": v,
+                        "LearningRate": lr_var,
+                    }
+                    outputs = {"ParamOut": p, "VelocityOut": v}
+                    if multi_precision:
+                        inputs["MasterParam"] = master_param_vars[i]
+                        outputs["MasterParamOut"] = master_param_vars[i]
+                    helper.append_op(
+                        type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
+                    )
+            else:
                 inputs = {
-                    "Param": p,
-                    "Grad": g,
-                    "Velocity": v,
+                    "Param": param_vars,
+                    "Grad": grad_vars,
+                    "Velocity": velocity_vars,
                     "LearningRate": lr_var,
                 }
-                outputs = {"ParamOut": p, "VelocityOut": v}
+                outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
                 if multi_precision:
-                    inputs["MasterParam"] = master_param_vars[i]
-                    outputs["MasterParamOut"] = master_param_vars[i]
+                    inputs["MasterParam"] = master_param_vars
+                    outputs["MasterParamOut"] = master_param_vars
                 helper.append_op(
                     type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
                 )
-        else:
-            inputs = {
-                "Param": param_vars,
-                "Grad": grad_vars,
-                "Velocity": velocity_vars,
-                "LearningRate": lr_var,
-            }
-            outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
-            if multi_precision:
-                inputs["MasterParam"] = master_param_vars
-                outputs["MasterParamOut"] = master_param_vars
-            helper.append_op(type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
 
-    exe = paddle.static.Executor(place)
-    with paddle.static.scope_guard(paddle.static.Scope()):
-        exe.run(startup)
-        return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
+        exe = paddle.static.Executor(place)
+        with paddle.static.scope_guard(paddle.static.Scope()):
+            exe.run(startup)
+            return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
 
 
 def run_momentum_op2(
@@ -151,117 +166,133 @@ def run_momentum_op2(
     use_merged=False,
     use_nesterov=True,
 ):
-    assert len(params) == len(grads)
-    assert len(params) == len(velocitys)
-    if multi_precision:
-        assert len(params) == len(master_params)
-    op_type = "merged_momentum" if use_merged else "momentum"
-    main = paddle.static.Program()
-    startup = paddle.static.Program()
-    with paddle.static.program_guard(main, startup):
-        helper = LayerHelper(op_type, **locals())
-
-        param_vars = [
-            helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-            for p in params
-        ]
-        grad_vars = [
-            helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
-        ]
-        velocity_vars = [
-            helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
-            for v in velocitys
-        ]
-        lr_var = helper.create_variable(
-            persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
-        )
-
-        feed_dict = OrderedDict()
-
-        feed_dict.update(
-            OrderedDict(
-                [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
-            )
-        )
-        feed_dict.update(
-            OrderedDict(
-                [(v_var.name, v_val) for v_var, v_val in zip(velocity_vars, velocitys)]
-            )
-        )
-        fetch_list = list(feed_dict.keys())
-
-        feed_dict.update(
-            OrderedDict([(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)])
-        )
-        feed_dict.update({lr_var.name: learning_rate})
-
+    with OldIrGuard():
+        assert len(params) == len(grads)
+        assert len(params) == len(velocitys)
         if multi_precision:
-            master_param_vars = [
+            assert len(params) == len(master_params)
+        op_type = "merged_momentum" if use_merged else "momentum"
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            helper = LayerHelper(op_type, **locals())
+
+            param_vars = [
                 helper.create_variable(persistable=True, shape=p.shape, dtype=p.dtype)
-                for p in master_params
+                for p in params
             ]
+            grad_vars = [
+                helper.create_variable(shape=g.shape, dtype=g.dtype) for g in grads
+            ]
+            velocity_vars = [
+                helper.create_variable(persistable=True, shape=v.shape, dtype=v.dtype)
+                for v in velocitys
+            ]
+            lr_var = helper.create_variable(
+                persistable=True, shape=learning_rate.shape, dtype=learning_rate.dtype
+            )
+
+            feed_dict = OrderedDict()
+
+            feed_dict.update(
+                OrderedDict(
+                    [(p_var.name, p_val) for p_var, p_val in zip(param_vars, params)]
+                )
+            )
             feed_dict.update(
                 OrderedDict(
                     [
-                        (mp_var.name, mp_val)
-                        for mp_var, mp_val in zip(master_param_vars, master_params)
+                        (v_var.name, v_val)
+                        for v_var, v_val in zip(velocity_vars, velocitys)
                     ]
                 )
             )
-            # CPUPlace does not use MasterParam
-            if isinstance(place, paddle.CUDAPlace):
-                fetch_list = fetch_list + [mp_var.name for mp_var in master_param_vars]
-        else:
-            master_param_vars = None
+            fetch_list = list(feed_dict.keys())
 
-        if not use_merged:
-            for i, (p, g, v) in enumerate(zip(param_vars, grad_vars, velocity_vars)):
+            feed_dict.update(
+                OrderedDict(
+                    [(g_var.name, g_val) for g_var, g_val in zip(grad_vars, grads)]
+                )
+            )
+            feed_dict.update({lr_var.name: learning_rate})
+
+            if multi_precision:
+                master_param_vars = [
+                    helper.create_variable(
+                        persistable=True, shape=p.shape, dtype=p.dtype
+                    )
+                    for p in master_params
+                ]
+                feed_dict.update(
+                    OrderedDict(
+                        [
+                            (mp_var.name, mp_val)
+                            for mp_var, mp_val in zip(master_param_vars, master_params)
+                        ]
+                    )
+                )
+                # CPUPlace does not use MasterParam
+                if isinstance(place, paddle.CUDAPlace):
+                    fetch_list = fetch_list + [
+                        mp_var.name for mp_var in master_param_vars
+                    ]
+            else:
+                master_param_vars = None
+
+            if not use_merged:
+                for i, (p, g, v) in enumerate(
+                    zip(param_vars, grad_vars, velocity_vars)
+                ):
+                    inputs = {
+                        "Param": p,
+                        "Grad": g,
+                        "Velocity": v,
+                        "LearningRate": lr_var,
+                    }
+                    outputs = {"ParamOut": p, "VelocityOut": v}
+                    if multi_precision:
+                        inputs["MasterParam"] = master_param_vars[i]
+                        outputs["MasterParamOut"] = master_param_vars[i]
+                    attrs = {
+                        "mu": mu,
+                        "multi_precision": multi_precision,
+                        "rescale_grad": rescale_grad,
+                        "use_nesterov": use_nesterov,
+                        "regularization_method": "l2_decay",
+                        "regularization_coeff": 2.0,
+                    }
+                    helper.append_op(
+                        type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
+                    )
+            else:
                 inputs = {
-                    "Param": p,
-                    "Grad": g,
-                    "Velocity": v,
+                    "Param": param_vars,
+                    "Grad": grad_vars,
+                    "Velocity": velocity_vars,
                     "LearningRate": lr_var,
                 }
-                outputs = {"ParamOut": p, "VelocityOut": v}
+                outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
                 if multi_precision:
-                    inputs["MasterParam"] = master_param_vars[i]
-                    outputs["MasterParamOut"] = master_param_vars[i]
+                    inputs["MasterParam"] = master_param_vars
+                    outputs["MasterParamOut"] = master_param_vars
                 attrs = {
                     "mu": mu,
                     "multi_precision": multi_precision,
                     "rescale_grad": rescale_grad,
                     "use_nesterov": use_nesterov,
-                    "regularization_method": "l2_decay",
-                    "regularization_coeff": 2.0,
+                    "regularization_method": [
+                        "l2_decay" for i in range(len(param_vars))
+                    ],
+                    "regularization_coeff": [2.0 for i in range(len(param_vars))],
                 }
                 helper.append_op(
                     type=op_type, inputs=inputs, outputs=outputs, attrs=attrs
                 )
-        else:
-            inputs = {
-                "Param": param_vars,
-                "Grad": grad_vars,
-                "Velocity": velocity_vars,
-                "LearningRate": lr_var,
-            }
-            outputs = {"ParamOut": param_vars, "VelocityOut": velocity_vars}
-            if multi_precision:
-                inputs["MasterParam"] = master_param_vars
-                outputs["MasterParamOut"] = master_param_vars
-            attrs = {
-                "mu": mu,
-                "multi_precision": multi_precision,
-                "rescale_grad": rescale_grad,
-                "use_nesterov": use_nesterov,
-                "regularization_method": ["l2_decay" for i in range(len(param_vars))],
-                "regularization_coeff": [2.0 for i in range(len(param_vars))],
-            }
-            helper.append_op(type=op_type, inputs=inputs, outputs=outputs, attrs=attrs)
 
-    exe = paddle.static.Executor(place)
-    with paddle.static.scope_guard(paddle.static.Scope()):
-        exe.run(startup)
-        return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
+        exe = paddle.static.Executor(place)
+        with paddle.static.scope_guard(paddle.static.Scope()):
+            exe.run(startup)
+            return exe.run(main, feed=feed_dict, fetch_list=fetch_list)
 
 
 class TestMergedMomentum(unittest.TestCase):
@@ -322,7 +353,7 @@ class TestMergedMomentum(unittest.TestCase):
                 self.assertTrue(np.allclose(out1, out2, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace("npu", 0)
+        self.place = paddle.CustomPlace("npu", 7)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places
@@ -400,7 +431,7 @@ class TestMergedMomentum2(unittest.TestCase):
                 self.assertTrue(np.allclose(out3, out4, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace("npu", 0)
+        self.place = paddle.CustomPlace("npu", 7)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places

--- a/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_merged_momentum_op_npu.py
@@ -353,7 +353,7 @@ class TestMergedMomentum(unittest.TestCase):
                 self.assertTrue(np.allclose(out1, out2, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace("npu", 7)
+        self.place = paddle.CustomPlace("npu", 0)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places
@@ -431,7 +431,7 @@ class TestMergedMomentum2(unittest.TestCase):
                 self.assertTrue(np.allclose(out3, out4, atol=1e-7))
 
     def get_places(self):
-        self.place = paddle.CustomPlace("npu", 7)
+        self.place = paddle.CustomPlace("npu", 0)
         self.__class__.use_custom_device = True
         places = [self.place]
         return places

--- a/backends/npu/tests/unittests/test_momentum_op_npu.py
+++ b/backends/npu/tests/unittests/test_momentum_op_npu.py
@@ -143,14 +143,17 @@ class TestMomentumV2(unittest.TestCase):
             rms_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
+            train_reader = paddle.io.DataLoader(
+                paddle.text.datasets.UCIHousing(mode="train"),
+                batch_size=1,
+                places=place,
+                feed_list=[x, y],
+                return_list=False,
             )
-            feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+                exe.run(main, feed=data, fetch_list=fetch_list)
 
     def test_raise_error(self):
         self.assertRaises(ValueError, paddle.optimizer.Momentum, learning_rate=None)
@@ -267,14 +270,17 @@ class TestMomentumOpWithDecayAPI(unittest.TestCase):
             momentum_optimizer.minimize(avg_cost)
 
             fetch_list = [avg_cost]
-            train_reader = paddle.batch(
-                paddle.dataset.uci_housing.train(), batch_size=1
+            train_reader = paddle.io.DataLoader(
+                paddle.text.datasets.UCIHousing(mode="train"),
+                batch_size=1,
+                places=place,
+                feed_list=[x, y],
+                return_list=False,
             )
-            feeder = base.DataFeeder(place=place, feed_list=[x, y])
             exe = base.Executor(place)
             exe.run(base.default_startup_program())
             for data in train_reader():
-                exe.run(main, feed=feeder.feed(data), fetch_list=fetch_list)
+                exe.run(main, feed=data, fetch_list=fetch_list)
 
 
 class TestMomentumOpVsMomentumOpWithDecayAPI(unittest.TestCase):

--- a/backends/npu/tests/unittests/test_randperm_op_npu.py
+++ b/backends/npu/tests/unittests/test_randperm_op_npu.py
@@ -108,9 +108,30 @@ class TestRandpermOpFloat64(TestRandpermOp):
 
 class TestRandpermOpError(unittest.TestCase):
     def test_errors(self):
-        with program_guard(Program(), Program()):
-            self.assertRaises(ValueError, paddle.randperm, -3)
-            self.assertRaises(TypeError, paddle.randperm, 10, "int8")
+        paddle.set_device("npu")
+        if paddle.framework.use_pir_api():
+
+            def test_invalid_n():
+                with program_guard(Program(), Program()):
+                    paddle.randperm(-3)
+                    exe = paddle.static.Executor()
+                    exe.run(paddle.static.default_startup_program())
+                    exe.run(paddle.static.default_main_program())
+
+            self.assertRaises(RuntimeError, test_invalid_n)
+
+            def test_invalid_dtype():
+                with program_guard(Program(), Program()):
+                    paddle.randperm(10, "int8")
+                    exe = paddle.static.Executor()
+                    exe.run(paddle.static.default_startup_program())
+                    exe.run(paddle.static.default_main_program())
+
+            self.assertRaises(TypeError, test_invalid_dtype)
+        else:
+            with program_guard(Program(), Program()):
+                self.assertRaises(ValueError, paddle.randperm, -3)
+                self.assertRaises(TypeError, paddle.randperm, 10, "int8")
 
 
 class TestRandpermAPI(unittest.TestCase):

--- a/backends/npu/tests/unittests/test_roll_op_npu.py
+++ b/backends/npu/tests/unittests/test_roll_op_npu.py
@@ -133,7 +133,9 @@ class TestRollInt32OpCase3(TestRollInt32):
 
 class TestRollAPI(unittest.TestCase):
     def input_data(self):
-        self.data_x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        self.data_x = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
+        ).astype("float32")
 
     def test_roll_op_api(self):
         self.input_data()
@@ -142,11 +144,10 @@ class TestRollAPI(unittest.TestCase):
         # case 1:
         with program_guard(Program(), Program()):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
-            x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1)
             exe = base.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
-                feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
+                feed={"x": self.data_x}, fetch_list=[z], return_numpy=False
             )
             expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])
             np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
@@ -154,11 +155,10 @@ class TestRollAPI(unittest.TestCase):
         # case 2:
         with program_guard(Program(), Program()):
             x = paddle.static.data(name="x", shape=[-1, 3], dtype="float32")
-            x.desc.set_need_check_feed(False)
             z = paddle.roll(x, shifts=1, axis=0)
             exe = base.Executor(paddle.CustomPlace("npu", 0))
             (res,) = exe.run(
-                feed={"x": self.data_x}, fetch_list=[z.name], return_numpy=False
+                feed={"x": self.data_x}, fetch_list=[z], return_numpy=False
             )
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)


### PR DESCRIPTION
## test_merged_momentum_op
### 截图
MLU:
![image](https://github.com/user-attachments/assets/1798df39-3c1a-4f29-a5d5-77de881d8afe)

NPU:
![image](https://github.com/user-attachments/assets/24db04bd-f2b8-4094-9542-220e6f51f9f9)


## test_momentum
### 改动和修复
1. 使用了被弃用的 API `paddle.dataset.uci_housing`
### 截图
MLU:
![image](https://github.com/user-attachments/assets/277b4364-7bad-4c74-bf2a-1f5882ae4bc7)

NPU:
![image](https://github.com/user-attachments/assets/e0424ed0-90d2-4dd9-900e-6c4a2b2fc806)

## test_pool_2d
### 截图
MLU:
![image](https://github.com/user-attachments/assets/fdaf66f8-1d3c-4050-b028-96555ae71590)

## test_randperm_op
### 截图
MLU:
![image](https://github.com/user-attachments/assets/d3483b3e-df8f-49fe-95e6-28b7e96ff4ed)

NPU:
![image](https://github.com/user-attachments/assets/76e94a8c-89b7-4b7f-bad8-01b5f47156e4)


## test_roll_op
### 截图
MLU:
![image](https://github.com/user-attachments/assets/1174ff56-64fa-4cb1-b081-29454f222e0b)

NPU:
![image](https://github.com/user-attachments/assets/273b81d3-d9e4-4a02-a403-b3ab4fff4363)





