### PR TITLE
【NPU】 fix input is nullptr error.

### DIFF
--- a/backends/npu/kernels/concat_kernel.cc
+++ b/backends/npu/kernels/concat_kernel.cc
@@ -126,9 +126,15 @@ void ConcatKernel(const Context& dev_ctx,
                   const std::vector<const phi::DenseTensor*>& ins,
                   const phi::Scalar& axis_scalar,
                   phi::DenseTensor* out) {
+  dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) {
+    return;
+  }
+
   DO_COMPATIBILITY(aclnnCat,
                    (custom_kernel::AclopConcatKernel<T, Context>(
                        dev_ctx, ins, axis_scalar, out)));
+
   int axis = axis_scalar.to<int>();
   axis = ComputeAxis(static_cast<int64_t>(axis),
                      static_cast<int64_t>(ins[0]->dims().size()));
@@ -140,7 +146,6 @@ void ConcatKernel(const Context& dev_ctx,
       continue;
     }
   }
-  dev_ctx.template Alloc<T>(out);
   EXEC_NPU_CMD(aclnnCat, dev_ctx, inputs, axis, *out);
 }
 

--- a/backends/npu/kernels/masked_select_kernel.cc
+++ b/backends/npu/kernels/masked_select_kernel.cc
@@ -88,13 +88,21 @@ void MaskedSelectKernel(const Context& dev_ctx,
                         const phi::DenseTensor& x,
                         const phi::DenseTensor& mask,
                         phi::DenseTensor* out) {
+  if (x.numel() == 0 || mask.numel() == 0) {
+    out->Resize({0});
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
   DO_COMPATIBILITY(aclnnMaskedSelect,
                    (custom_kernel::AclopMaskedSelectKernel<T, Context>(
                        dev_ctx, x, mask, out)));
+
   if (x.storage_properties_initialized()) {
     custom_kernel::AclopMaskedSelectKernel<T, Context>(dev_ctx, x, mask, out);
     return;
   }
+
   auto input_dim = x.dims();
   auto mask_dim = mask.dims();
   PADDLE_ENFORCE_EQ(input_dim,

--- a/backends/npu/kernels/roi_align_kernel.cc
+++ b/backends/npu/kernels/roi_align_kernel.cc
@@ -190,14 +190,19 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                         int sampling_ratio,
                         bool aligned,
                         phi::DenseTensor* dx) {
-  auto in_dims = x.dims();
-  int rois_num = boxes.dims()[0];
-  auto stream = dev_ctx.stream();
-
   if (!dx) {
     return;
   }
   dev_ctx.template Alloc<T>(dx);
+
+  if (x.numel() == 0 || boxes.numel() == 0) {
+    EXEC_NPU_CMD(aclnnInplaceZero, dev_ctx, *dx);
+    return;
+  }
+
+  auto in_dims = x.dims();
+  int rois_num = boxes.dims()[0];
+  auto stream = dev_ctx.stream();
 
   PADDLE_ENFORCE_EQ(
       aligned,


### PR DESCRIPTION
The modification of the Paddle code caused some operators to have nullptr as inputs. 
We added logic to handle these cases. 

The link to the Paddle modification is: https://github.com/PaddlePaddle/Paddle/commit/a4acffdb747b5a4c5ffe31cc5716001dfceafc54#diff-0293f43b582590b1fb69fe530e9fd18dd5055c800b698f4fd2ff54ab6feb9b65