### PR TITLE
[INTEL_HPU] Add Fused BlockAttention OPs

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
@@ -1,0 +1,1184 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+struct FusedFlatPaParams {
+  ns_ConstantKernel::Params const_params;
+  ns_GatherKernel::Params index_select_params;
+  ns_Reduction::Params reduce_params;
+  ns_IndexReduce::Params index_reduce_params;
+};
+
+class FusedFlatPaMHAProj : public HpuFusedOperator {
+ public:
+  explicit FusedFlatPaMHAProj(synDataType dtype)
+      : HpuFusedOperator("fused_flatpa_proj_fwd_", false), dtype_(dtype) {}
+  template <typename T>
+  void AddNode(ConvertTensors& ct, FusedFlatPaParams params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    std::vector<int64_t> q_dims = std::vector<int64_t>(inputs[0].dims);
+    std::vector<int64_t> kv_dims = std::vector<int64_t>(inputs[1].dims);
+    std::vector<int64_t> block_list_dims = std::vector<int64_t>(inputs[4].dims);
+    std::vector<int64_t> linear_weights_dims =
+        std::vector<int64_t>(inputs[7].dims);
+    int64_t batch_size = q_dims[0];
+    int64_t num_head = q_dims[1];
+    int64_t head_dim = q_dims[3];
+    int64_t block_size = kv_dims[2];
+    int64_t num_of_block = block_list_dims[0];
+    int64_t hidden_size = linear_weights_dims[0];
+
+    synGEMMParams gemm_params_f_f;
+    gemm_params_f_f.transpose_a = false;
+    gemm_params_f_f.transpose_b = false;
+
+    synGEMMParams gemm_params_t_f;
+    gemm_params_t_f.transpose_a = true;
+    gemm_params_t_f.transpose_b = false;
+
+    synGEMMParams gemm_params_f_t;
+    gemm_params_f_t.transpose_a = false;
+    gemm_params_f_t.transpose_b = true;
+
+    std::vector<int64_t> scaler_dims = {1};
+    auto scaler_tensor =
+        createTensorNoPresist("scaler_tensor", syn_type_bf16, scaler_dims);
+    std::vector<synTensor> scaler;
+    scaler.push_back(scaler_tensor);
+    AddNodeFull<T>(scaler, params.const_params, guid_ + "full_scale");
+
+    auto q_tensor = createTensorFromCT(ct, 0);
+    std::vector<synTensor> scaled_q_in;
+    scaled_q_in.push_back(q_tensor);
+    scaled_q_in.push_back(scaler_tensor);
+
+    auto scaled_q =
+        createTensorNoPresist("scaled_q", inputs[0].type, inputs[0].dims);
+    std::vector<synTensor> scaled_q_out;
+    scaled_q_out.push_back(scaled_q);
+
+    AddNodeMultiply<T>(scaled_q_in, scaled_q_out, guid_ + "mul_scale_q");
+
+    std::vector<int64_t> reshape_q_dims;
+    reshape_q_dims.push_back(batch_size);
+    reshape_q_dims.push_back(hidden_size);
+
+    auto reshaped_q =
+        createTensorNoPresist("reshaped_q", dtype_, reshape_q_dims);
+    std::vector<synTensor> reshape_q_out;
+    reshape_q_out.push_back(reshaped_q);
+
+    AddNodeReshape(scaled_q_out, reshape_q_out, guid_ + "reshape_scale_q");
+
+    /*******************************/
+
+    std::vector<synTensor> map_q_in;
+    auto block_mapping = createTensorFromCT(ct, 5);
+    map_q_in.push_back(block_mapping);
+    map_q_in.push_back(reshaped_q);
+
+    std::vector<int64_t> map_q_dims;
+    map_q_dims.push_back(num_of_block);
+    map_q_dims.push_back(hidden_size);
+    auto mapped_q = createTensorNoPresist("mapped_q", dtype_, map_q_dims);
+    std::vector<synTensor> map_q_out;
+    map_q_out.push_back(mapped_q);
+
+    AddNodeGemm(map_q_in, map_q_out, gemm_params_f_f, guid_ + "gemm_map_q");
+
+    std::vector<int64_t> reshape_map_q_dims;
+    reshape_map_q_dims.push_back(num_of_block);
+    reshape_map_q_dims.push_back(num_head);
+    reshape_map_q_dims.push_back(1);
+    reshape_map_q_dims.push_back(head_dim);
+
+    auto reshaped_map_q =
+        createTensorNoPresist("reshaped_map_q", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> reshape_map_q_out;
+    reshape_map_q_out.push_back(reshaped_map_q);
+
+    AddNodeReshape(map_q_out, reshape_map_q_out, guid_ + "reshape_map_q");
+
+    /*******************************/
+
+    std::vector<synTensor> index_select_k_in;
+    std::vector<synTensor> index_select_v_in;
+    auto key_cache = createTensorFromCT(ct, 1);
+    auto value_cache = createTensorFromCT(ct, 2);
+    auto block_list = createTensorFromCT(ct, 4);
+
+    index_select_k_in.push_back(key_cache);
+    index_select_v_in.push_back(value_cache);
+    index_select_k_in.push_back(block_list);
+    index_select_v_in.push_back(block_list);
+
+    std::vector<int64_t> index_selected_dims;
+    index_selected_dims.push_back(num_of_block);
+    index_selected_dims.push_back(num_head);
+    index_selected_dims.push_back(block_size);
+    index_selected_dims.push_back(head_dim);
+
+    auto index_select_k =
+        createTensorNoPresist("index_select_k", dtype_, index_selected_dims);
+    auto index_select_v =
+        createTensorNoPresist("index_select_v", dtype_, index_selected_dims);
+    std::vector<synTensor> index_select_k_out;
+    index_select_k_out.push_back(index_select_k);
+    std::vector<synTensor> index_select_v_out;
+    index_select_v_out.push_back(index_select_v);
+
+    AddNodeIndexSelect<T>(index_select_k_in,
+                          index_select_k_out,
+                          params.index_select_params,
+
+                          guid_ + "index_select_k");
+    AddNodeIndexSelect<T>(index_select_v_in,
+                          index_select_v_out,
+                          params.index_select_params,
+
+                          guid_ + "index_select_v");
+
+    std::vector<synTensor> q_k_in;
+    q_k_in.push_back(reshaped_map_q);
+    q_k_in.push_back(index_select_k);
+
+    std::vector<int64_t> q_k_dims;
+    q_k_dims.push_back(num_of_block);
+    q_k_dims.push_back(num_head);
+    q_k_dims.push_back(1);
+    q_k_dims.push_back(block_size);
+    auto q_k = createTensorNoPresist("q_k", dtype_, q_k_dims);
+    std::vector<synTensor> q_k_out;
+    q_k_out.push_back(q_k);
+
+    AddNodeBatchGemm(q_k_in, q_k_out, gemm_params_f_t, guid_ + "batchgemm_q_k");
+
+    /*******************************/
+
+    auto block_bias = createTensorFromCT(ct, 6);
+    std::vector<synTensor> block_bias_in;
+    block_bias_in.push_back(block_bias);
+
+    std::vector<int64_t> reshaped_bias_dims;
+    reshaped_bias_dims.push_back(num_of_block);
+    reshaped_bias_dims.push_back(1);
+    reshaped_bias_dims.push_back(1);
+    reshaped_bias_dims.push_back(block_size);
+
+    auto reshaped_bias =
+        createTensorNoPresist("reshaped_bias", dtype_, reshaped_bias_dims);
+    std::vector<synTensor> block_bias_out;
+    block_bias_out.push_back(reshaped_bias);
+
+    AddNodeReshape(block_bias_in, block_bias_out, guid_ + "reshaped_bias");
+
+    std::vector<synTensor> add_bias_in;
+    add_bias_in.push_back(q_k);
+    add_bias_in.push_back(reshaped_bias);
+
+    auto add_bias = createTensorNoPresist("add_bias", dtype_, q_k_dims);
+    std::vector<synTensor> add_bias_out;
+    add_bias_out.push_back(add_bias);
+
+    AddNodeAdd<T>(add_bias_in, add_bias_out, guid_ + "add_bias");
+    /*******************************/
+
+    std::vector<int64_t> block_max_dims;
+    block_max_dims.push_back(num_of_block);
+    block_max_dims.push_back(num_head);
+    block_max_dims.push_back(1);
+    block_max_dims.push_back(1);
+
+    auto block_max = createTensorNoPresist("block_max", dtype_, block_max_dims);
+    std::vector<synTensor> block_max_out;
+    block_max_out.push_back(block_max);
+
+    AddNodeReduceMax<T>(
+        add_bias_out, block_max_out, params.reduce_params, guid_ + "reduceMax");
+
+    /**************************************************************/
+
+    std::vector<int64_t> sum_adjusted_dims;
+    sum_adjusted_dims.push_back(num_of_block);
+    sum_adjusted_dims.push_back(num_head);
+
+    auto block_max_2D =
+        createTensorNoPresist("block_max_2D", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_max_2D_out;
+    block_max_2D_out.push_back(block_max_2D);
+
+    AddNodeReshape(
+        block_max_out, block_max_2D_out, guid_ + "squeeze_block_max");
+
+    std::vector<int64_t> group_max_dims;
+    group_max_dims.push_back(batch_size + 1);
+    group_max_dims.push_back(num_head);
+
+    auto group_max = createTensorNoPresist("group_max", dtype_, group_max_dims);
+    std::vector<synTensor> group_max_tensor;
+    group_max_tensor.push_back(group_max);
+
+    params.const_params.constant.f = -std::numeric_limits<float>::infinity();
+
+    AddNodeFull<T>(group_max_tensor, params.const_params, guid_ + "full_inf");
+
+    auto block_groups = createTensorFromCT(ct, 3);
+    std::vector<synTensor> index_reduce_in;
+    index_reduce_in.push_back(group_max);
+    index_reduce_in.push_back(block_groups);
+    index_reduce_in.push_back(block_max_2D);
+
+    auto reduced_group_max =
+        createTensorNoPresist("reduced_group_max", dtype_, group_max_dims);
+    std::vector<synTensor> index_reduce_out;
+    index_reduce_out.push_back(reduced_group_max);
+
+    AddNodeIndexReduce<T>(index_reduce_in,
+                          index_reduce_out,
+                          params.index_reduce_params,
+                          guid_ + "index_reduce_amax");
+
+    std::vector<synTensor> index_select_groupmax_in;
+    index_select_groupmax_in.push_back(reduced_group_max);
+    index_select_groupmax_in.push_back(block_groups);
+
+    auto selected_group_max =
+        createTensorNoPresist("selected_group_max", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> index_select_groupmax_out;
+    index_select_groupmax_out.push_back(selected_group_max);
+    params.index_select_params.axis = 1;
+    AddNodeIndexSelect<T>(index_select_groupmax_in,
+                          index_select_groupmax_out,
+                          params.index_select_params,
+                          guid_ + "index_select_groupmax");
+
+    std::vector<synTensor> sub_group_max_in;
+    sub_group_max_in.push_back(block_max_2D);
+    sub_group_max_in.push_back(selected_group_max);
+
+    auto sub_group_max =
+        createTensorNoPresist("sub_group_max", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> sub_group_max_out;
+    sub_group_max_out.push_back(sub_group_max);
+
+    AddNodeSub<T>(sub_group_max_in, sub_group_max_out, guid_ + "sub_group_max");
+
+    auto block_adjustment =
+        createTensorNoPresist("block_adjustment", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_adjustment_out;
+    block_adjustment_out.push_back(block_adjustment);
+    AddNodeExp<T>(sub_group_max_out,
+                  block_adjustment_out,
+                  guid_ + "exp_block_adjustment");
+
+    /**************************************************************/
+
+    std::vector<synTensor> sub_block_max_in;
+    sub_block_max_in.push_back(add_bias);
+    sub_block_max_in.push_back(block_max);
+
+    auto sub_block_max =
+        createTensorNoPresist("sub_block_max", dtype_, q_k_dims);
+    std::vector<synTensor> sub_block_max_out;
+    sub_block_max_out.push_back(sub_block_max);
+    AddNodeSub<T>(sub_block_max_in, sub_block_max_out, guid_ + "sub_block_max");
+
+    auto score = createTensorNoPresist("score", dtype_, q_k_dims);
+    std::vector<synTensor> score_out;
+    score_out.push_back(score);
+    AddNodeExp<T>(sub_block_max_out, score_out, guid_ + "exp_score");
+
+    /*******************************/
+
+    std::vector<synTensor> score_v_in;
+    score_v_in.push_back(score);
+    score_v_in.push_back(index_select_v);
+
+    auto score_v = createTensorNoPresist("score_v", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> score_v_out;
+    score_v_out.push_back(score_v);
+
+    AddNodeBatchGemm(
+        score_v_in, score_v_out, gemm_params_f_f, guid_ + "batchgemm_score_v");
+
+    auto reduceSum = createTensorNoPresist("reduceSum", dtype_, block_max_dims);
+    std::vector<synTensor> reduceSum_out;
+    reduceSum_out.push_back(reduceSum);
+
+    AddNodeReduceSum<T>(
+        score_out, reduceSum_out, params.reduce_params, guid_ + "reduceSum");
+
+    auto block_sums_2D =
+        createTensorNoPresist("block_sums_2D", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_sums_2D_out;
+    block_sums_2D_out.push_back(block_sums_2D);
+
+    AddNodeReshape(
+        reduceSum_out, block_sums_2D_out, guid_ + "squeeze_block_sums");
+
+    std::vector<synTensor> sum_adjusted_in;
+    sum_adjusted_in.push_back(block_sums_2D);
+    sum_adjusted_in.push_back(block_adjustment);
+
+    auto sum_adjusted =
+        createTensorNoPresist("sum_adjusted", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> sum_adjusted_out;
+    sum_adjusted_out.push_back(sum_adjusted);
+
+    AddNodeMultiply<T>(
+        sum_adjusted_in, sum_adjusted_out, guid_ + "mul_sum_adjusted");
+    /***************************************************************/
+
+    std::vector<synTensor> map_sum_adjusted_in;
+    map_sum_adjusted_in.push_back(block_mapping);
+    map_sum_adjusted_in.push_back(sum_adjusted);
+
+    std::vector<int64_t> map_sum_adjusted_dims;
+    map_sum_adjusted_dims.push_back(batch_size);
+    map_sum_adjusted_dims.push_back(num_head);
+    auto mapped_sum_adjusted = createTensorNoPresist(
+        "mapped_sum_adjusted", dtype_, map_sum_adjusted_dims);
+    std::vector<synTensor> map_sum_adjusted_out;
+    map_sum_adjusted_out.push_back(mapped_sum_adjusted);
+
+    AddNodeGemm(map_sum_adjusted_in,
+                map_sum_adjusted_out,
+                gemm_params_t_f,
+                guid_ + "gemm_map_sum_adjusted");
+
+    std::vector<synTensor> group_sum_adjusted_in;
+    group_sum_adjusted_in.push_back(block_mapping);
+    group_sum_adjusted_in.push_back(mapped_sum_adjusted);
+
+    auto group_sum_adjusted =
+        createTensorNoPresist("group_sum_adjusted", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> group_sum_adjusted_out;
+    group_sum_adjusted_out.push_back(group_sum_adjusted);
+
+    AddNodeGemm(group_sum_adjusted_in,
+                group_sum_adjusted_out,
+                gemm_params_f_f,
+                guid_ + "gemm_group_sum_adjusted");
+
+    /*******************************/
+
+    auto reshaped_group_sum_adjusted = createTensorNoPresist(
+        "reshaped_group_sum_adjusted", dtype_, block_max_dims);
+    std::vector<synTensor> group_sum_adjusted_4D;
+    group_sum_adjusted_4D.push_back(reshaped_group_sum_adjusted);
+
+    AddNodeReshape(group_sum_adjusted_out,
+                   group_sum_adjusted_4D,
+                   guid_ + "reshaped_group_sum_adjusted");
+
+    auto reshaped_sum_adjusted =
+        createTensorNoPresist("reshaped_sum_adjusted", dtype_, block_max_dims);
+    std::vector<synTensor> sum_adjusted_4D;
+    sum_adjusted_4D.push_back(reshaped_sum_adjusted);
+
+    AddNodeReshape(
+        sum_adjusted_out, sum_adjusted_4D, guid_ + "reshaped_sum_adjusted");
+
+    auto reshaped_block_adjustment = createTensorNoPresist(
+        "reshaped_block_adjustment", dtype_, block_max_dims);
+    std::vector<synTensor> block_adjustment_4D;
+    block_adjustment_4D.push_back(reshaped_block_adjustment);
+
+    AddNodeReshape(block_adjustment_out,
+                   block_adjustment_4D,
+                   guid_ + "reshaped_block_adjustment");
+
+    std::vector<synTensor> max_sum_adjust_in;
+    max_sum_adjust_in.push_back(reshaped_group_sum_adjusted);
+    max_sum_adjust_in.push_back(reshaped_sum_adjusted);
+    auto max_sum_adjust =
+        createTensorNoPresist("max_sum_adjust", dtype_, block_max_dims);
+    std::vector<synTensor> max_sum_adjust_out;
+    max_sum_adjust_out.push_back(max_sum_adjust);
+
+    AddNodeMaximum<T>(
+        max_sum_adjust_in, max_sum_adjust_out, guid_ + "max_sum_adjust");
+
+    std::vector<synTensor> rescale_in;
+    rescale_in.push_back(reshaped_block_adjustment);
+    rescale_in.push_back(max_sum_adjust);
+    auto rescale = createTensorNoPresist("rescale", dtype_, block_max_dims);
+    std::vector<synTensor> rescale_out;
+    rescale_out.push_back(rescale);
+    AddNodeDivide<T>(rescale_in, rescale_out, guid_ + "div_rescale");
+
+    std::vector<synTensor> rescale_v_in;
+    rescale_v_in.push_back(rescale);
+    rescale_v_in.push_back(score_v);
+
+    auto rescale_v =
+        createTensorNoPresist("rescale_v", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> rescale_v_out;
+    rescale_v_out.push_back(rescale_v);
+
+    AddNodeMultiply<T>(rescale_v_in, rescale_v_out, guid_ + "mul_rescale_v");
+
+    auto reshape_attn =
+        createTensorNoPresist("reshape_attn", dtype_, map_q_dims);
+    std::vector<synTensor> reshape_attn_out;
+    reshape_attn_out.push_back(reshape_attn);
+
+    AddNodeReshape(rescale_v_out, reshape_attn_out, guid_ + "reshape_attn");
+
+    std::vector<synTensor> map_attn_in;
+    map_attn_in.push_back(block_mapping);
+    map_attn_in.push_back(reshape_attn);
+
+    auto mapped_attn =
+        createTensorNoPresist("mapped_attn", dtype_, reshape_q_dims);
+    std::vector<synTensor> map_attn_out;
+    map_attn_out.push_back(mapped_attn);
+
+    AddNodeGemm(
+        map_attn_in, map_attn_out, gemm_params_t_f, guid_ + "gemm_map_attn");
+
+    auto attn = createTensorNoPresist("attn", dtype_, outputs[0].dims);
+    std::vector<synTensor> attn_out;
+    attn_out.push_back(attn);
+
+    AddNodeReshape(map_attn_out, attn_out, guid_ + "attn");
+
+    std::vector<synTensor> proj_in;
+    auto linear_weights = createTensorFromCT(ct, 7);
+    proj_in.push_back(attn);
+    proj_in.push_back(linear_weights);
+
+    auto linear_out = createTensorFromCT(ct, 0, false);
+    std::vector<synTensor> proj_out;
+    proj_out.push_back(linear_out);
+
+    AddNodeBatchGemm(
+        proj_in, proj_out, gemm_params_f_f, guid_ + "batchgemm_proj");
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+class FusedFlatPaGQAProj : public HpuFusedOperator {
+ public:
+  explicit FusedFlatPaGQAProj(synDataType dtype)
+      : HpuFusedOperator("fused_flatpa_proj_fwd_", false), dtype_(dtype) {}
+  template <typename T>
+  void AddNode(ConvertTensors& ct, FusedFlatPaParams params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    std::vector<int64_t> q_dims = std::vector<int64_t>(inputs[0].dims);
+    std::vector<int64_t> kv_dims = std::vector<int64_t>(inputs[1].dims);
+    std::vector<int64_t> block_list_dims = std::vector<int64_t>(inputs[4].dims);
+    std::vector<int64_t> linear_weights_dims =
+        std::vector<int64_t>(inputs[7].dims);
+    int64_t batch_size = q_dims[0];
+    int64_t num_head = q_dims[1];
+    int64_t head_dim = q_dims[3];
+    int64_t num_kv_head = kv_dims[1];
+    int64_t block_size = kv_dims[2];
+    int64_t num_of_block = block_list_dims[0];
+    int64_t hidden_size = linear_weights_dims[0];
+    int64_t ngroups = num_head / num_kv_head;
+
+    synGEMMParams gemm_params_f_f;
+    gemm_params_f_f.transpose_a = false;
+    gemm_params_f_f.transpose_b = false;
+
+    synGEMMParams gemm_params_t_f;
+    gemm_params_t_f.transpose_a = true;
+    gemm_params_t_f.transpose_b = false;
+
+    synGEMMParams gemm_params_f_t;
+    gemm_params_f_t.transpose_a = false;
+    gemm_params_f_t.transpose_b = true;
+
+    std::vector<int64_t> scaler_dims = {1};
+    auto scaler_tensor =
+        createTensorNoPresist("scaler_tensor", syn_type_bf16, scaler_dims);
+    std::vector<synTensor> scaler;
+    scaler.push_back(scaler_tensor);
+    AddNodeFull<T>(scaler, params.const_params, guid_ + "full_scale");
+
+    auto q_tensor = createTensorFromCT(ct, 0);
+    std::vector<synTensor> scaled_q_in;
+    scaled_q_in.push_back(q_tensor);
+    scaled_q_in.push_back(scaler_tensor);
+
+    auto scaled_q =
+        createTensorNoPresist("scaled_q", inputs[0].type, inputs[0].dims);
+    std::vector<synTensor> scaled_q_out;
+    scaled_q_out.push_back(scaled_q);
+
+    AddNodeMultiply<T>(scaled_q_in, scaled_q_out, guid_ + "mul_scale_q");
+
+    std::vector<int64_t> reshape_q_dims;
+    reshape_q_dims.push_back(batch_size);
+    reshape_q_dims.push_back(hidden_size);
+
+    auto reshaped_q =
+        createTensorNoPresist("reshaped_q", dtype_, reshape_q_dims);
+    std::vector<synTensor> reshape_q_out;
+    reshape_q_out.push_back(reshaped_q);
+
+    AddNodeReshape(scaled_q_out, reshape_q_out, guid_ + "reshape_scale_q");
+
+    /*******************************/
+
+    std::vector<synTensor> map_q_in;
+    auto block_mapping = createTensorFromCT(ct, 5);
+    map_q_in.push_back(block_mapping);
+    map_q_in.push_back(reshaped_q);
+
+    std::vector<int64_t> map_q_dims;
+    map_q_dims.push_back(num_of_block);
+    map_q_dims.push_back(hidden_size);
+    auto mapped_q = createTensorNoPresist("mapped_q", dtype_, map_q_dims);
+    std::vector<synTensor> map_q_out;
+    map_q_out.push_back(mapped_q);
+
+    AddNodeGemm(map_q_in, map_q_out, gemm_params_f_f, guid_ + "gemm_map_q");
+
+    std::vector<int64_t> reshape_map_q_dims;
+    reshape_map_q_dims.push_back(num_of_block);
+    reshape_map_q_dims.push_back(num_kv_head);
+    reshape_map_q_dims.push_back(ngroups);
+    reshape_map_q_dims.push_back(1);
+    reshape_map_q_dims.push_back(head_dim);
+
+    auto reshaped_map_q =
+        createTensorNoPresist("reshaped_map_q", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> reshape_map_q_out;
+    reshape_map_q_out.push_back(reshaped_map_q);
+
+    AddNodeReshape(map_q_out, reshape_map_q_out, guid_ + "reshape_map_q");
+
+    /*******************************/
+
+    std::vector<synTensor> index_select_k_in;
+    std::vector<synTensor> index_select_v_in;
+    auto key_cache = createTensorFromCT(ct, 1);
+    auto value_cache = createTensorFromCT(ct, 2);
+    auto block_list = createTensorFromCT(ct, 4);
+
+    index_select_k_in.push_back(key_cache);
+    index_select_v_in.push_back(value_cache);
+    index_select_k_in.push_back(block_list);
+    index_select_v_in.push_back(block_list);
+
+    std::vector<int64_t> index_selected_dims;
+    index_selected_dims.push_back(num_of_block);
+    index_selected_dims.push_back(num_kv_head);
+    index_selected_dims.push_back(block_size);
+    index_selected_dims.push_back(head_dim);
+
+    auto index_select_k_i =
+        createTensorNoPresist("index_select_k_i", dtype_, index_selected_dims);
+    auto index_select_v_i =
+        createTensorNoPresist("index_select_v_i", dtype_, index_selected_dims);
+    std::vector<synTensor> index_select_k_out;
+    index_select_k_out.push_back(index_select_k_i);
+    std::vector<synTensor> index_select_v_out;
+    index_select_v_out.push_back(index_select_v_i);
+
+    AddNodeIndexSelect<T>(index_select_k_in,
+                          index_select_k_out,
+                          params.index_select_params,
+                          guid_ + "index_select_k_i");
+    AddNodeIndexSelect<T>(index_select_v_in,
+                          index_select_v_out,
+                          params.index_select_params,
+                          guid_ + "index_select_v_i");
+
+    std::vector<int64_t> reshape_kv_dims;
+    reshape_kv_dims.push_back(num_of_block);
+    reshape_kv_dims.push_back(num_kv_head);
+    reshape_kv_dims.push_back(1);
+    reshape_kv_dims.push_back(block_size);
+    reshape_kv_dims.push_back(head_dim);
+
+    auto index_select_k =
+        createTensorNoPresist("index_select_k", dtype_, reshape_kv_dims);
+    std::vector<synTensor> reshape_index_select_k;
+    reshape_index_select_k.push_back(index_select_k);
+
+    AddNodeReshape(
+        index_select_k_out, reshape_index_select_k, guid_ + "reshape_k");
+
+    auto index_select_v =
+        createTensorNoPresist("index_select_v", dtype_, reshape_kv_dims);
+    std::vector<synTensor> reshape_index_select_v;
+    reshape_index_select_v.push_back(index_select_v);
+
+    AddNodeReshape(
+        index_select_v_out, reshape_index_select_v, guid_ + "reshape_v");
+
+    std::vector<synTensor> q_k_in;
+    q_k_in.push_back(reshaped_map_q);
+    q_k_in.push_back(index_select_k);
+
+    std::vector<int64_t> q_k_dims;
+    q_k_dims.push_back(num_of_block);
+    q_k_dims.push_back(num_kv_head);
+    q_k_dims.push_back(ngroups);
+    q_k_dims.push_back(1);
+    q_k_dims.push_back(block_size);
+    auto q_k = createTensorNoPresist("q_k", dtype_, q_k_dims);
+    std::vector<synTensor> q_k_out;
+    q_k_out.push_back(q_k);
+
+    AddNodeBatchGemm(q_k_in, q_k_out, gemm_params_f_t, guid_ + "batchgemm_q_k");
+
+    /*******************************/
+
+    auto block_bias = createTensorFromCT(ct, 6);
+    std::vector<synTensor> block_bias_in;
+    block_bias_in.push_back(block_bias);
+
+    std::vector<int64_t> reshaped_bias_dims;
+    reshaped_bias_dims.push_back(num_of_block);
+    reshaped_bias_dims.push_back(1);
+    reshaped_bias_dims.push_back(1);
+    reshaped_bias_dims.push_back(1);
+    reshaped_bias_dims.push_back(block_size);
+
+    auto reshaped_bias =
+        createTensorNoPresist("reshaped_bias", dtype_, reshaped_bias_dims);
+    std::vector<synTensor> block_bias_out;
+    block_bias_out.push_back(reshaped_bias);
+
+    AddNodeReshape(block_bias_in, block_bias_out, guid_ + "reshaped_bias");
+
+    std::vector<synTensor> add_bias_in;
+    add_bias_in.push_back(q_k);
+    add_bias_in.push_back(reshaped_bias);
+
+    auto add_bias = createTensorNoPresist("add_bias", dtype_, q_k_dims);
+    std::vector<synTensor> add_bias_out;
+    add_bias_out.push_back(add_bias);
+
+    AddNodeAdd<T>(add_bias_in, add_bias_out, guid_ + "add_bias");
+    /*******************************/
+
+    std::vector<int64_t> block_max_dims;
+    block_max_dims.push_back(num_of_block);
+    block_max_dims.push_back(num_kv_head);
+    block_max_dims.push_back(ngroups);
+    block_max_dims.push_back(1);
+    block_max_dims.push_back(1);
+
+    auto block_max = createTensorNoPresist("block_max", dtype_, block_max_dims);
+    std::vector<synTensor> block_max_out;
+    block_max_out.push_back(block_max);
+
+    AddNodeReduceMax<T>(
+        add_bias_out, block_max_out, params.reduce_params, guid_ + "reduceMax");
+
+    /**************************************************************/
+
+    std::vector<int64_t> sum_adjusted_dims;
+    sum_adjusted_dims.push_back(num_of_block);
+    sum_adjusted_dims.push_back(num_kv_head);
+    sum_adjusted_dims.push_back(ngroups);
+
+    auto block_max_2D =
+        createTensorNoPresist("block_max_2D", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_max_2D_out;
+    block_max_2D_out.push_back(block_max_2D);
+
+    AddNodeReshape(
+        block_max_out, block_max_2D_out, guid_ + "squeeze_block_max");
+
+    std::vector<int64_t> group_max_dims;
+    group_max_dims.push_back(batch_size + 1);
+    group_max_dims.push_back(num_kv_head);
+    group_max_dims.push_back(ngroups);
+
+    auto group_max = createTensorNoPresist("group_max", dtype_, group_max_dims);
+    std::vector<synTensor> group_max_tensor;
+    group_max_tensor.push_back(group_max);
+
+    params.const_params.constant.f = -std::numeric_limits<float>::infinity();
+
+    AddNodeFull<T>(group_max_tensor, params.const_params, guid_ + "full_inf");
+
+    auto block_groups = createTensorFromCT(ct, 3);
+    std::vector<synTensor> index_reduce_in;
+    index_reduce_in.push_back(group_max);
+    index_reduce_in.push_back(block_groups);
+    index_reduce_in.push_back(block_max_2D);
+
+    auto reduced_group_max =
+        createTensorNoPresist("reduced_group_max", dtype_, group_max_dims);
+    std::vector<synTensor> index_reduce_out;
+    index_reduce_out.push_back(reduced_group_max);
+
+    AddNodeIndexReduce<T>(index_reduce_in,
+                          index_reduce_out,
+                          params.index_reduce_params,
+                          guid_ + "index_reduce_amax");
+
+    std::vector<synTensor> index_select_groupmax_in;
+    index_select_groupmax_in.push_back(reduced_group_max);
+    index_select_groupmax_in.push_back(block_groups);
+
+    auto selected_group_max =
+        createTensorNoPresist("selected_group_max", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> index_select_groupmax_out;
+    index_select_groupmax_out.push_back(selected_group_max);
+    params.index_select_params.axis = 2;
+    AddNodeIndexSelect<T>(index_select_groupmax_in,
+                          index_select_groupmax_out,
+                          params.index_select_params,
+
+                          guid_ + "index_select_groupmax");
+
+    std::vector<synTensor> sub_group_max_in;
+    sub_group_max_in.push_back(block_max_2D);
+    sub_group_max_in.push_back(selected_group_max);
+
+    auto sub_group_max =
+        createTensorNoPresist("sub_group_max", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> sub_group_max_out;
+    sub_group_max_out.push_back(sub_group_max);
+
+    AddNodeSub<T>(sub_group_max_in, sub_group_max_out, guid_ + "sub_group_max");
+
+    auto block_adjustment =
+        createTensorNoPresist("block_adjustment", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_adjustment_out;
+    block_adjustment_out.push_back(block_adjustment);
+    AddNodeExp<T>(sub_group_max_out,
+                  block_adjustment_out,
+                  guid_ + "exp_block_adjustment");
+
+    /**************************************************************/
+
+    std::vector<synTensor> sub_block_max_in;
+    sub_block_max_in.push_back(add_bias);
+    sub_block_max_in.push_back(block_max);
+
+    auto sub_block_max =
+        createTensorNoPresist("sub_block_max", dtype_, q_k_dims);
+    std::vector<synTensor> sub_block_max_out;
+    sub_block_max_out.push_back(sub_block_max);
+    AddNodeSub<T>(sub_block_max_in, sub_block_max_out, guid_ + "sub_block_max");
+
+    auto score = createTensorNoPresist("score", dtype_, q_k_dims);
+    std::vector<synTensor> score_out;
+    score_out.push_back(score);
+    AddNodeExp<T>(sub_block_max_out, score_out, guid_ + "exp_score");
+
+    /*******************************/
+
+    std::vector<synTensor> score_v_in;
+    score_v_in.push_back(score);
+    score_v_in.push_back(index_select_v);
+
+    auto score_v = createTensorNoPresist("score_v", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> score_v_out;
+    score_v_out.push_back(score_v);
+
+    AddNodeBatchGemm(
+        score_v_in, score_v_out, gemm_params_f_f, guid_ + "batchgemm_score_v");
+
+    auto reduceSum = createTensorNoPresist("reduceSum", dtype_, block_max_dims);
+    std::vector<synTensor> reduceSum_out;
+    reduceSum_out.push_back(reduceSum);
+
+    AddNodeReduceSum<T>(
+        score_out, reduceSum_out, params.reduce_params, guid_ + "reduceSum");
+
+    auto block_sums_2D =
+        createTensorNoPresist("block_sums_2D", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> block_sums_2D_out;
+    block_sums_2D_out.push_back(block_sums_2D);
+
+    AddNodeReshape(
+        reduceSum_out, block_sums_2D_out, guid_ + "squeeze_block_sums");
+
+    std::vector<synTensor> sum_adjusted_in;
+    sum_adjusted_in.push_back(block_sums_2D);
+    sum_adjusted_in.push_back(block_adjustment);
+
+    auto sum_adjusted =
+        createTensorNoPresist("sum_adjusted", dtype_, sum_adjusted_dims);
+    std::vector<synTensor> sum_adjusted_out;
+    sum_adjusted_out.push_back(sum_adjusted);
+
+    AddNodeMultiply<T>(
+        sum_adjusted_in, sum_adjusted_out, guid_ + "mul_sum_adjusted");
+    /***************************************************************/
+
+    std::vector<int64_t> reshaped_sum_adjusted_dims;
+    reshaped_sum_adjusted_dims.push_back(num_of_block);
+    reshaped_sum_adjusted_dims.push_back(num_head);
+
+    auto flatten_sum_adjusted = createTensorNoPresist(
+        "flatten_sum_adjusted", dtype_, reshaped_sum_adjusted_dims);
+    std::vector<synTensor> reshaped_sum_adjusted_out;
+    reshaped_sum_adjusted_out.push_back(flatten_sum_adjusted);
+
+    AddNodeReshape(sum_adjusted_out,
+                   reshaped_sum_adjusted_out,
+                   guid_ + "flatten_sum_adjusted");
+
+    std::vector<synTensor> map_sum_adjusted_in;
+    map_sum_adjusted_in.push_back(block_mapping);
+    map_sum_adjusted_in.push_back(flatten_sum_adjusted);
+
+    std::vector<int64_t> map_sum_adjusted_dims;
+    map_sum_adjusted_dims.push_back(batch_size);
+    map_sum_adjusted_dims.push_back(num_head);
+    auto mapped_sum_adjusted = createTensorNoPresist(
+        "mapped_sum_adjusted", dtype_, map_sum_adjusted_dims);
+    std::vector<synTensor> map_sum_adjusted_out;
+    map_sum_adjusted_out.push_back(mapped_sum_adjusted);
+
+    AddNodeGemm(map_sum_adjusted_in,
+                map_sum_adjusted_out,
+                gemm_params_t_f,
+                guid_ + "gemm_map_sum_adjusted");
+
+    std::vector<synTensor> group_sum_adjusted_in;
+    group_sum_adjusted_in.push_back(block_mapping);
+    group_sum_adjusted_in.push_back(mapped_sum_adjusted);
+
+    std::vector<int64_t> matmul_sum_adjusted_dims;
+    matmul_sum_adjusted_dims.push_back(num_of_block);
+    matmul_sum_adjusted_dims.push_back(num_head);
+    auto group_sum_adjusted = createTensorNoPresist(
+        "group_sum_adjusted", dtype_, matmul_sum_adjusted_dims);
+    std::vector<synTensor> group_sum_adjusted_out;
+    group_sum_adjusted_out.push_back(group_sum_adjusted);
+
+    AddNodeGemm(group_sum_adjusted_in,
+                group_sum_adjusted_out,
+                gemm_params_f_f,
+                guid_ + "gemm_group_sum_adjusted");
+
+    /*******************************/
+
+    auto reshaped_group_sum_adjusted = createTensorNoPresist(
+        "reshaped_group_sum_adjusted", dtype_, block_max_dims);
+    std::vector<synTensor> group_sum_adjusted_4D;
+    group_sum_adjusted_4D.push_back(reshaped_group_sum_adjusted);
+
+    AddNodeReshape(group_sum_adjusted_out,
+                   group_sum_adjusted_4D,
+                   guid_ + "reshaped_group_sum_adjusted");
+
+    auto reshaped_sum_adjusted =
+        createTensorNoPresist("reshaped_sum_adjusted", dtype_, block_max_dims);
+    std::vector<synTensor> sum_adjusted_4D;
+    sum_adjusted_4D.push_back(reshaped_sum_adjusted);
+
+    AddNodeReshape(
+        sum_adjusted_out, sum_adjusted_4D, guid_ + "reshaped_sum_adjusted");
+
+    auto reshaped_block_adjustment = createTensorNoPresist(
+        "reshaped_block_adjustment", dtype_, block_max_dims);
+    std::vector<synTensor> block_adjustment_4D;
+    block_adjustment_4D.push_back(reshaped_block_adjustment);
+
+    AddNodeReshape(block_adjustment_out,
+                   block_adjustment_4D,
+                   guid_ + "reshaped_block_adjustment");
+
+    std::vector<synTensor> max_sum_adjust_in;
+    max_sum_adjust_in.push_back(reshaped_group_sum_adjusted);
+    max_sum_adjust_in.push_back(reshaped_sum_adjusted);
+    auto max_sum_adjust =
+        createTensorNoPresist("max_sum_adjust", dtype_, block_max_dims);
+    std::vector<synTensor> max_sum_adjust_out;
+    max_sum_adjust_out.push_back(max_sum_adjust);
+
+    AddNodeMaximum<T>(
+        max_sum_adjust_in, max_sum_adjust_out, guid_ + "max_sum_adjust");
+
+    std::vector<synTensor> rescale_in;
+    rescale_in.push_back(reshaped_block_adjustment);
+    rescale_in.push_back(max_sum_adjust);
+    auto rescale = createTensorNoPresist("rescale", dtype_, block_max_dims);
+    std::vector<synTensor> rescale_out;
+    rescale_out.push_back(rescale);
+    AddNodeDivide<T>(rescale_in, rescale_out, guid_ + "div_rescale");
+
+    std::vector<synTensor> rescale_v_in;
+    rescale_v_in.push_back(rescale);
+    rescale_v_in.push_back(score_v);
+
+    auto rescale_v =
+        createTensorNoPresist("rescale_v", dtype_, reshape_map_q_dims);
+    std::vector<synTensor> rescale_v_out;
+    rescale_v_out.push_back(rescale_v);
+
+    AddNodeMultiply<T>(rescale_v_in, rescale_v_out, guid_ + "mul_rescale_v");
+
+    auto reshape_attn =
+        createTensorNoPresist("reshape_attn", dtype_, map_q_dims);
+    std::vector<synTensor> reshape_attn_out;
+    reshape_attn_out.push_back(reshape_attn);
+
+    AddNodeReshape(rescale_v_out, reshape_attn_out, guid_ + "reshape_attn");
+
+    std::vector<synTensor> map_attn_in;
+    map_attn_in.push_back(block_mapping);
+    map_attn_in.push_back(reshape_attn);
+
+    auto mapped_attn =
+        createTensorNoPresist("mapped_attn", dtype_, reshape_q_dims);
+    std::vector<synTensor> map_attn_out;
+    map_attn_out.push_back(mapped_attn);
+
+    AddNodeGemm(
+        map_attn_in, map_attn_out, gemm_params_t_f, guid_ + "gemm_map_attn");
+
+    auto attn = createTensorNoPresist("attn", dtype_, outputs[0].dims);
+    std::vector<synTensor> attn_out;
+    attn_out.push_back(attn);
+
+    AddNodeReshape(map_attn_out, attn_out, guid_ + "attn");
+
+    std::vector<synTensor> proj_in;
+    auto linear_weights = createTensorFromCT(ct, 7);
+    proj_in.push_back(attn);
+    proj_in.push_back(linear_weights);
+
+    auto linear_out = createTensorFromCT(ct, 0, false);
+    std::vector<synTensor> proj_out;
+    proj_out.push_back(linear_out);
+
+    AddNodeBatchGemm(
+        proj_in, proj_out, gemm_params_f_f, guid_ + "batchgemm_proj");
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedFlatPaProjKernel(const Context& dev_ctx,
+                           const phi::DenseTensor& query,
+                           const phi::DenseTensor& key_cache,
+                           const phi::DenseTensor& value_cache,
+                           const phi::DenseTensor& block_groups,
+                           const phi::DenseTensor& block_list,
+                           const phi::DenseTensor& block_mapping,
+                           const phi::DenseTensor& block_bias,
+                           const phi::DenseTensor& linear_weights,
+                           phi::DenseTensor* out_linear,
+                           const phi::Scalar& scaling_factor) {
+  ConvertTensors ct;
+  ct.Add(query);
+  ct.Add(key_cache);
+  ct.Add(value_cache);
+  ct.Add(block_groups);
+  std::vector<DIMS> inputs_dims = ct.GetDims();
+  ct.Add(block_list);
+  ct.Add(block_mapping);
+  ct.Add(block_bias);
+  ct.Add(linear_weights);
+  ct.Add(out_linear, false);
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_flatpa_proj_fwd_", inputs_dims, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedFlatPaParams params;
+    memset(reinterpret_cast<void*>(&params), 0x00, sizeof(FusedFlatPaParams));
+
+    params.const_params.constant.f = scaling_factor.to<float>();
+    params.index_select_params.axis = 3;
+    params.reduce_params.reductionDimension = 0;
+    params.index_reduce_params.mode = INDEX_REDUCE_AMAX;
+    params.index_reduce_params.include_self = true;
+    params.index_reduce_params.axis = 0;
+
+    std::vector<int64_t> query_dims = phi::vectorize<int64_t>(query.dims());
+    std::vector<int64_t> key_cache_dims =
+        phi::vectorize<int64_t>(key_cache.dims());
+    int64_t q_head = query_dims[1];
+    int64_t kv_head = key_cache_dims[1];
+
+    if (q_head == kv_head) {
+      FusedFlatPaMHAProj op(op_info.datatype_);
+      op.AddNode<T>(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+    } else {
+      FusedFlatPaGQAProj op(op_info.datatype_);
+      op.AddNode<T>(ct, params);
+      op.Compile();
+      op_info.setOp(op);
+    }
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedFlatPaProjKernel(const Context& dev_ctx,
+                               const phi::DenseTensor& query,
+                               const phi::DenseTensor& key_cache,
+                               const phi::DenseTensor& value_cache,
+                               const phi::DenseTensor& block_groups,
+                               const phi::DenseTensor& block_list,
+                               const phi::DenseTensor& block_mapping,
+                               const phi::DenseTensor& block_bias,
+                               const phi::DenseTensor& linear_weights,
+                               phi::DenseTensor* out_linear,
+                               const phi::Scalar& scaling_factor) {
+  if (query.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedFlatPaProjKernel<phi::dtype::float16>(dev_ctx,
+                                                              query,
+                                                              key_cache,
+                                                              value_cache,
+                                                              block_groups,
+                                                              block_list,
+                                                              block_mapping,
+                                                              block_bias,
+                                                              linear_weights,
+                                                              out_linear,
+                                                              scaling_factor);
+  } else if (query.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedFlatPaProjKernel<phi::dtype::bfloat16>(dev_ctx,
+                                                               query,
+                                                               key_cache,
+                                                               value_cache,
+                                                               block_groups,
+                                                               block_list,
+                                                               block_mapping,
+                                                               block_bias,
+                                                               linear_weights,
+                                                               out_linear,
+                                                               scaling_factor);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedFlatPaProjKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedFlatPaProj(
+    const paddle::Tensor& query,
+    const paddle::Tensor& key_cache,
+    const paddle::Tensor& value_cache,
+    const paddle::Tensor& block_groups,
+    const paddle::Tensor& block_list,
+    const paddle::Tensor& block_mapping,
+    const paddle::Tensor& block_bias,
+    const paddle::Tensor& linear_weights,
+    float scaling_factor) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(query.place()));
+  auto query_tensor = static_cast<const phi::DenseTensor*>(query.impl().get());
+  auto key_cache_tensor =
+      static_cast<const phi::DenseTensor*>(key_cache.impl().get());
+  auto value_cache_tensor =
+      static_cast<const phi::DenseTensor*>(value_cache.impl().get());
+  auto block_groups_tensor =
+      static_cast<const phi::DenseTensor*>(block_groups.impl().get());
+  auto block_list_tensor =
+      static_cast<const phi::DenseTensor*>(block_list.impl().get());
+  auto block_mapping_tensor =
+      static_cast<const phi::DenseTensor*>(block_mapping.impl().get());
+  auto block_bias_tensor =
+      static_cast<const phi::DenseTensor*>(block_bias.impl().get());
+  auto linear_weights_tensor =
+      static_cast<const phi::DenseTensor*>(linear_weights.impl().get());
+
+  // allocate memory on device.
+  int64_t batch_size = query.dims()[0];
+  int hidden_size = linear_weights.dims()[0];
+  // int64_t block_size = key_cache.dims()[2];
+  // int64_t num_of_block = block_mapping.dims()[0];
+
+  std::shared_ptr<phi::DenseTensor> out_linear =
+      std::make_shared<phi::DenseTensor>();
+  out_linear->Resize(phi::make_ddim({batch_size, 1, hidden_size}));
+
+  dev_ctx->Alloc(out_linear.get(), query_tensor->dtype());
+
+  CallFusedFlatPaProjKernel(*dev_ctx,
+                            *query_tensor,
+                            *key_cache_tensor,
+                            *value_cache_tensor,
+                            *block_groups_tensor,
+                            *block_list_tensor,
+                            *block_mapping_tensor,
+                            *block_bias_tensor,
+                            *linear_weights_tensor,
+                            out_linear.get(),
+                            phi::Scalar(scaling_factor));
+  return {paddle::Tensor(out_linear)};
+}
+
+std::vector<std::vector<int64_t>> FusedFlatPaProjShape(
+    const std::vector<int64_t>& query_shape,
+    const std::vector<int64_t>& key_cache_shape,
+    const std::vector<int64_t>& value_cache_shape,
+    const std::vector<int64_t>& block_groups_shape,
+    const std::vector<int64_t>& block_list_shape,
+    const std::vector<int64_t>& block_mapping_shape,
+    const std::vector<int64_t>& block_bias_shape,
+    const std::vector<int64_t>& linear_weights_shape) {
+  int64_t batch_size = query_shape[0];
+  int hidden_size = linear_weights_shape[0];
+  return {{batch_size, 1, hidden_size}};
+}
+
+std::vector<paddle::DataType> FusedFlatPaProjDtype(
+    const paddle::DataType& query_dtype,
+    const paddle::DataType& key_cache_dtype,
+    const paddle::DataType& value_cache_dtype,
+    const paddle::DataType& block_groups_dtype,
+    const paddle::DataType& block_list_dtype,
+    const paddle::DataType& block_mapping_dtype,
+    const paddle::DataType& block_bias_dtype,
+    const paddle::DataType& linear_weights_dtype) {
+  return {query_dtype};
+}
+
+PD_BUILD_OP(fused_flatpa_proj)
+    .Inputs({"query",
+             "key_cache",
+             "value_cache",
+             "block_groups",
+             "block_list",
+             "block_mapping",
+             "block_bias",
+             "linear_weights"})
+    .Outputs({"out_linear"})
+    .Attrs({"scaling_factor: float"})
+    .SetKernelFn(PD_KERNEL(FusedFlatPaProj))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFlatPaProjShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFlatPaProjDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
@@ -68,7 +68,7 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
     scaler.push_back(scaler_tensor);
     AddNodeFull<T>(scaler, params.const_params, guid_ + "full_scale");
 
-    auto q_tensor = createTensorFromCT(ct, 0);
+    auto q_tensor = createTensorFromCT(&ct, 0);
     std::vector<synTensor> scaled_q_in;
     scaled_q_in.push_back(q_tensor);
     scaled_q_in.push_back(scaler_tensor);
@@ -94,7 +94,7 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
     /*******************************/
 
     std::vector<synTensor> map_q_in;
-    auto block_mapping = createTensorFromCT(ct, 5);
+    auto block_mapping = createTensorFromCT(&ct, 5);
     map_q_in.push_back(block_mapping);
     map_q_in.push_back(reshaped_q);
 
@@ -124,9 +124,9 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
 
     std::vector<synTensor> index_select_k_in;
     std::vector<synTensor> index_select_v_in;
-    auto key_cache = createTensorFromCT(ct, 1);
-    auto value_cache = createTensorFromCT(ct, 2);
-    auto block_list = createTensorFromCT(ct, 4);
+    auto key_cache = createTensorFromCT(&ct, 1);
+    auto value_cache = createTensorFromCT(&ct, 2);
+    auto block_list = createTensorFromCT(&ct, 4);
 
     index_select_k_in.push_back(key_cache);
     index_select_v_in.push_back(value_cache);
@@ -176,7 +176,7 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
 
     /*******************************/
 
-    auto block_bias = createTensorFromCT(ct, 6);
+    auto block_bias = createTensorFromCT(&ct, 6);
     std::vector<synTensor> block_bias_in;
     block_bias_in.push_back(block_bias);
 
@@ -243,7 +243,7 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
 
     AddNodeFull<T>(group_max_tensor, params.const_params, guid_ + "full_inf");
 
-    auto block_groups = createTensorFromCT(ct, 3);
+    auto block_groups = createTensorFromCT(&ct, 3);
     std::vector<synTensor> index_reduce_in;
     index_reduce_in.push_back(group_max);
     index_reduce_in.push_back(block_groups);
@@ -465,11 +465,11 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
     AddNodeReshape(map_attn_out, attn_out, guid_ + "attn");
 
     std::vector<synTensor> proj_in;
-    auto linear_weights = createTensorFromCT(ct, 7);
+    auto linear_weights = createTensorFromCT(&ct, 7);
     proj_in.push_back(attn);
     proj_in.push_back(linear_weights);
 
-    auto linear_out = createTensorFromCT(ct, 0, false);
+    auto linear_out = createTensorFromCT(&ct, 0, false);
     std::vector<synTensor> proj_out;
     proj_out.push_back(linear_out);
 
@@ -523,7 +523,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     scaler.push_back(scaler_tensor);
     AddNodeFull<T>(scaler, params.const_params, guid_ + "full_scale");
 
-    auto q_tensor = createTensorFromCT(ct, 0);
+    auto q_tensor = createTensorFromCT(&ct, 0);
     std::vector<synTensor> scaled_q_in;
     scaled_q_in.push_back(q_tensor);
     scaled_q_in.push_back(scaler_tensor);
@@ -549,7 +549,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     /*******************************/
 
     std::vector<synTensor> map_q_in;
-    auto block_mapping = createTensorFromCT(ct, 5);
+    auto block_mapping = createTensorFromCT(&ct, 5);
     map_q_in.push_back(block_mapping);
     map_q_in.push_back(reshaped_q);
 
@@ -580,9 +580,9 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
 
     std::vector<synTensor> index_select_k_in;
     std::vector<synTensor> index_select_v_in;
-    auto key_cache = createTensorFromCT(ct, 1);
-    auto value_cache = createTensorFromCT(ct, 2);
-    auto block_list = createTensorFromCT(ct, 4);
+    auto key_cache = createTensorFromCT(&ct, 1);
+    auto value_cache = createTensorFromCT(&ct, 2);
+    auto block_list = createTensorFromCT(&ct, 4);
 
     index_select_k_in.push_back(key_cache);
     index_select_v_in.push_back(value_cache);
@@ -654,7 +654,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
 
     /*******************************/
 
-    auto block_bias = createTensorFromCT(ct, 6);
+    auto block_bias = createTensorFromCT(&ct, 6);
     std::vector<synTensor> block_bias_in;
     block_bias_in.push_back(block_bias);
 
@@ -725,7 +725,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
 
     AddNodeFull<T>(group_max_tensor, params.const_params, guid_ + "full_inf");
 
-    auto block_groups = createTensorFromCT(ct, 3);
+    auto block_groups = createTensorFromCT(&ct, 3);
     std::vector<synTensor> index_reduce_in;
     index_reduce_in.push_back(group_max);
     index_reduce_in.push_back(block_groups);
@@ -964,11 +964,11 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     AddNodeReshape(map_attn_out, attn_out, guid_ + "attn");
 
     std::vector<synTensor> proj_in;
-    auto linear_weights = createTensorFromCT(ct, 7);
+    auto linear_weights = createTensorFromCT(&ct, 7);
     proj_in.push_back(attn);
     proj_in.push_back(linear_weights);
 
-    auto linear_out = createTensorFromCT(ct, 0, false);
+    auto linear_out = createTensorFromCT(&ct, 0, false);
     std::vector<synTensor> proj_out;
     proj_out.push_back(linear_out);
 

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_sdpa_proj_v2.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_sdpa_proj_v2.cc
@@ -20,9 +20,9 @@
 
 namespace custom_kernel {
 
-class FusedSdpaProjV2 : public HpuOperator {
+class FusedSdpaProjMask : public HpuOperator {
  public:
-  explicit FusedSdpaProjV2(synDataType dtype)
+  explicit FusedSdpaProjMask(synDataType dtype)
       : HpuOperator("fused_sdpa_proj_", false), dtype_(dtype) {}
 
   void AddNode(ConvertTensors& ct, ns_Sdpa::ParamsV2 params) {
@@ -170,13 +170,13 @@ class FusedSdpaProjV2 : public HpuOperator {
                                        inputs[0].name));
     attn_inputs.push_back(key_states);
     attn_inputs.push_back(value_states);
-    // params.is_causal = true; ==> input[2] is not used
-    // input[2] is in use ==> params.is_causal = false;
-    attn_inputs.push_back(createTensor(inputs[2].dims.size(),
-                                       inputs[2].type,
-                                       inputs[2].dims,
+    // params.is_causal = true; ==> input[3] is not used
+    // input[3] is in use ==> params.is_causal = false;
+    attn_inputs.push_back(createTensor(inputs[3].dims.size(),
+                                       inputs[3].type,
+                                       inputs[3].dims,
                                        true,
-                                       inputs[2].name));
+                                       inputs[3].name));
     std::vector<synTensor> attn_outputs;
     auto attn = createTensor(
         inputs[0].dims.size(), inputs[0].type, inputs[0].dims, false, "attn");
@@ -259,11 +259,279 @@ class FusedSdpaProjV2 : public HpuOperator {
 
     std::vector<synTensor> mul_inputs;
     mul_inputs.push_back(attn_r);
-    mul_inputs.push_back(createTensor(inputs[3].dims.size(),
-                                      inputs[3].type,
-                                      inputs[3].dims,
+    mul_inputs.push_back(createTensor(inputs[2].dims.size(),
+                                      inputs[2].type,
+                                      inputs[2].dims,
                                       true,
-                                      inputs[3].name));
+                                      inputs[2].name));
+    std::vector<synTensor> mul_outputs;
+    mul_outputs.push_back(createTensor(outputs[0].dims.size(),
+                                       outputs[0].type,
+                                       outputs[0].dims,
+                                       true,
+                                       outputs[0].name));
+    synGEMMParams gemm_params;
+    gemm_params.transpose_a = false;
+    gemm_params.transpose_b = false;
+    status = synNodeCreate(graphHandle_,
+                           mul_inputs.data(),
+                           mul_outputs.data(),
+                           2,
+                           1,
+                           &gemm_params,
+                           sizeof(gemm_params),
+                           guid_gemm.c_str(),
+                           name_gemm.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (matmul) failed = ",
+             status);
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+class FusedSdpaProjCausal : public HpuOperator {
+ public:
+  explicit FusedSdpaProjCausal(synDataType dtype)
+      : HpuOperator("fused_sdpa_proj_", false), dtype_(dtype) {}
+
+  void AddNode(ConvertTensors& ct, ns_Sdpa::ParamsV2 params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    synStatus status = synFail;
+
+    std::string name_sdpa = guid_ + "sdpa";
+    std::string name_trans = guid_ + "transpose";
+    std::string name_reshape = guid_ + "reshape";
+    std::string name_gemm = guid_ + "gemm";
+
+    std::string guid_sdpa = "sdpa_recomp_fwd_";
+    std::string guid_reshape = "reshape";
+    std::string guid_trans = "transpose";
+    std::string guid_gemm = "gemm";
+
+    if (dtype_ == syn_type_fp16) {
+      guid_sdpa = guid_sdpa + "f16";
+    } else if (dtype_ == syn_type_bf16) {
+      guid_sdpa = guid_sdpa + "bf16";
+    }
+
+    std::vector<synTensor> kv_inputs;
+    kv_inputs.push_back(createTensor(inputs[1].dims.size(),
+                                     inputs[1].type,
+                                     inputs[1].dims,
+                                     true,
+                                     inputs[1].name));
+    auto k_v_dims = inputs[1].dims;
+    k_v_dims[0] = 1;
+
+    synSliceParamsV2 sliceParams;
+    for (uint64_t i = 0; i < k_v_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = k_v_dims[k_v_dims.size() - 1 - i];
+    }
+
+    std::string slice_guid = "slice";
+    std::string slice_name = guid_ + "slice";
+    std::string slice_name_k = slice_name + "_key";
+
+    std::vector<synTensor> k_slice;
+    auto k_split =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "k_split");
+    k_slice.push_back(k_split);
+
+    status = synNodeCreate(graphHandle_,
+                           kv_inputs.data(),
+                           k_slice.data(),
+                           kv_inputs.size(),
+                           k_slice.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_k.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/k) failed = ",
+        status);
+
+    std::vector<synTensor> v_slice;
+    auto v_split =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "v_split");
+    v_slice.push_back(v_split);
+    sliceParams.starts[k_v_dims.size() - 1] = 1;
+    sliceParams.ends[k_v_dims.size() - 1] = 2;
+    std::string slice_name_v = slice_name + "_value";
+    status = synNodeCreate(graphHandle_,
+                           kv_inputs.data(),
+                           v_slice.data(),
+                           kv_inputs.size(),
+                           v_slice.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_v.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/v) failed = ",
+        status);
+
+    synSqueezeParams squeezeParams;
+    squeezeParams.axis = 4;
+    std::string squeeze_guid = "squeeze";
+    std::string squeeze_name = guid_ + "squeeze";
+
+    k_v_dims.erase(k_v_dims.begin());
+
+    std::vector<synTensor> key_squeezed;
+    auto key_states =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "key_states");
+
+    key_squeezed.push_back(key_states);
+    std::string squeeze_name_key = squeeze_name + "_key";
+    status = synNodeCreate(graphHandle_,
+                           k_slice.data(),
+                           key_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_key.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (squeeze/key) failed = ",
+        status);
+
+    std::vector<synTensor> value_squeezed;
+    auto value_states =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "value_states");
+    value_squeezed.push_back(value_states);
+    std::string squeeze_name_value = squeeze_name + "_value";
+    status = synNodeCreate(graphHandle_,
+                           v_slice.data(),
+                           value_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_value.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (squeeze/value) "
+             "failed = ",
+             status);
+
+    std::vector<synTensor> attn_inputs;
+    attn_inputs.push_back(createTensor(inputs[0].dims.size(),
+                                       inputs[0].type,
+                                       inputs[0].dims,
+                                       true,
+                                       inputs[0].name));
+    attn_inputs.push_back(key_states);
+    attn_inputs.push_back(value_states);
+    // params.is_causal = true; ==> input[3] is not used
+    // input[3] is in use ==> params.is_causal = false;
+    std::vector<synTensor> attn_outputs;
+    auto attn = createTensor(
+        inputs[0].dims.size(), inputs[0].type, inputs[0].dims, false, "attn");
+    attn_outputs.push_back(attn);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_inputs.data(),
+                           attn_outputs.data(),
+                           attn_inputs.size(),
+                           attn_outputs.size(),
+                           &params,
+                           sizeof(params),
+                           guid_sdpa.c_str(),
+                           name_sdpa.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (sdpa) failed = ",
+             status);
+
+    std::vector<int64_t> q_dims = std::vector<int64_t>(inputs[0].dims);
+    std::vector<int64_t> qt_dims(q_dims.cbegin(), q_dims.cend());
+    int rank = q_dims.size();
+    qt_dims[rank - 3] = q_dims[rank - 2];
+    qt_dims[rank - 2] = q_dims[rank - 3];
+
+    std::vector<int> axis = {0, 2, 1, 3};
+    synTransposeParams trans_params;
+    for (size_t i = 0; i < axis.size(); i++) {
+      trans_params.permutation[i] =
+          static_cast<TransposePermutationDim>(axis[i]);
+    }
+    trans_params.tensorDim = rank;
+
+    std::vector<synTensor> attn_out_transpose;
+    auto attn_t =
+        createTensor(qt_dims.size(), inputs[0].type, qt_dims, false, "attn_t");
+    attn_out_transpose.push_back(attn_t);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_outputs.data(),
+                           attn_out_transpose.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedSdpaProjKernel synNodeCreate (transpose) failed = ",
+        status);
+
+    std::vector<int64_t> attn_reshape;
+    attn_reshape.push_back(qt_dims[0]);
+    attn_reshape.push_back(qt_dims[1]);
+    attn_reshape.push_back(qt_dims[2] * qt_dims[3]);
+
+    std::vector<synTensor> attn_out_reshape;
+    auto attn_r = createTensor(
+        attn_reshape.size(), inputs[0].type, attn_reshape, false, "attn_r");
+    attn_out_reshape.push_back(attn_r);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_out_transpose.data(),
+                           attn_out_reshape.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (reshape) failed = ",
+             status);
+
+    std::vector<synTensor> mul_inputs;
+    mul_inputs.push_back(attn_r);
+    mul_inputs.push_back(createTensor(inputs[2].dims.size(),
+                                      inputs[2].type,
+                                      inputs[2].dims,
+                                      true,
+                                      inputs[2].name));
     std::vector<synTensor> mul_outputs;
     mul_outputs.push_back(createTensor(outputs[0].dims.size(),
                                        outputs[0].type,
@@ -294,18 +562,69 @@ class FusedSdpaProjV2 : public HpuOperator {
 };
 
 template <typename T, typename Context>
-void FusedSdpaProjKernelV2(const Context& dev_ctx,
-                           const phi::DenseTensor& query_states,
-                           const phi::DenseTensor& key_value_states,
-                           const phi::DenseTensor& attn_mask,
-                           const phi::DenseTensor& linear_weights,
-                           phi::DenseTensor* out_linear,
-                           const phi::Scalar& scaling_factor) {
+void FusedSdpaProjKernelMask(
+    const Context& dev_ctx,
+    const phi::DenseTensor& query_states,
+    const phi::DenseTensor& key_value_states,
+    const paddle::optional<phi::DenseTensor>& attn_mask,
+    const phi::DenseTensor& linear_weights,
+    phi::DenseTensor* out_linear,
+    const phi::Scalar& scaling_factor,
+    const phi::Scalar& causal) {
   ConvertTensors ct;
   ct.Add(query_states);
   ct.Add(key_value_states);
   std::vector<DIMS> in_out_dims = ct.GetDims();
-  ct.Add(attn_mask);
+
+  ct.Add(linear_weights);
+  if (attn_mask.get_ptr()) {
+    ct.Add(attn_mask.get_ptr());
+  }
+  ct.Add(out_linear, false);
+  std::vector<DIMS> out_dims = ct.GetDims(false);
+  in_out_dims.insert(in_out_dims.end(), out_dims.begin(), out_dims.end());
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_sdpa_proj_mask_fwd_", in_out_dims, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    ns_Sdpa::ParamsV2 params;
+    memset(reinterpret_cast<void*>(&params), 0x00, sizeof(ns_Sdpa::ParamsV2));
+    params.scale = scaling_factor.to<float>();
+    params.is_causal = causal.to<bool>();
+    params.dropout.ratio = 0.0;
+    params.dropout.disableMaskOut = false;
+    params.is_inference = true;
+    params.softmax_mode = SDPA_DEFAULT_SOFTMAX;
+
+    FusedSdpaProjMask op(op_info.datatype_);
+    op.AddNode(ct, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+template <typename T, typename Context>
+void FusedSdpaProjKernelCausal(const Context& dev_ctx,
+                               const phi::DenseTensor& query_states,
+                               const phi::DenseTensor& key_value_states,
+                               const phi::DenseTensor& linear_weights,
+                               phi::DenseTensor* out_linear,
+                               const phi::Scalar& scaling_factor,
+                               const phi::Scalar& causal) {
+  ConvertTensors ct;
+  ct.Add(query_states);
+  ct.Add(key_value_states);
+  std::vector<DIMS> in_out_dims = ct.GetDims();
+
   ct.Add(linear_weights);
   ct.Add(out_linear, false);
   std::vector<DIMS> out_dims = ct.GetDims(false);
@@ -313,20 +632,20 @@ void FusedSdpaProjKernelV2(const Context& dev_ctx,
 
   OpCacheOperator op_info;
   op_info.prepareOpInfo<T, nullptr_t>(
-      "fused_sdpa_proj_v2_fwd_", in_out_dims, nullptr);
+      "fused_sdpa_proj_causal_fwd_", in_out_dims, nullptr);
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
     ns_Sdpa::ParamsV2 params;
     memset(reinterpret_cast<void*>(&params), 0x00, sizeof(ns_Sdpa::ParamsV2));
     params.scale = scaling_factor.to<float>();
-    params.is_causal = false;  // true;
+    params.is_causal = causal.to<bool>();
     params.dropout.ratio = 0.0;
     params.dropout.disableMaskOut = false;
     params.is_inference = true;
     params.softmax_mode = SDPA_DEFAULT_SOFTMAX;
 
-    FusedSdpaProjV2 op(op_info.datatype_);
+    FusedSdpaProjCausal op(op_info.datatype_);
     op.AddNode(ct, params);
     op.Compile();
     op_info.setOp(op);
@@ -342,29 +661,66 @@ void FusedSdpaProjKernelV2(const Context& dev_ctx,
 }  // namespace custom_kernel
 
 template <typename Context>
-void CallFusedSdpaProjKernelV2(const Context& dev_ctx,
-                               const phi::DenseTensor& query_states,
-                               const phi::DenseTensor& key_value_states,
-                               const phi::DenseTensor& attn_mask,
-                               const phi::DenseTensor& linear_weights,
-                               phi::DenseTensor* out_linear,
-                               const phi::Scalar& scaling_factor) {
+void CallFusedSdpaProjKernelMask(
+    const Context& dev_ctx,
+    const phi::DenseTensor& query_states,
+    const phi::DenseTensor& key_value_states,
+    const paddle::optional<phi::DenseTensor>& attn_mask,
+    const phi::DenseTensor& linear_weights,
+    phi::DenseTensor* out_linear,
+    const phi::Scalar& scaling_factor,
+    const phi::Scalar& causal) {
   if (query_states.dtype() == phi::DataType::FLOAT16) {
-    custom_kernel::FusedSdpaProjKernelV2<phi::dtype::float16>(dev_ctx,
-                                                              query_states,
-                                                              key_value_states,
-                                                              attn_mask,
-                                                              linear_weights,
-                                                              out_linear,
-                                                              scaling_factor);
+    custom_kernel::FusedSdpaProjKernelMask<phi::dtype::float16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        attn_mask,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
   } else if (query_states.dtype() == phi::DataType::BFLOAT16) {
-    custom_kernel::FusedSdpaProjKernelV2<phi::dtype::bfloat16>(dev_ctx,
-                                                               query_states,
-                                                               key_value_states,
-                                                               attn_mask,
-                                                               linear_weights,
-                                                               out_linear,
-                                                               scaling_factor);
+    custom_kernel::FusedSdpaProjKernelMask<phi::dtype::bfloat16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        attn_mask,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedSdpaProjKernel");
+  }
+}
+
+template <typename Context>
+void CallFusedSdpaProjKernelCausal(const Context& dev_ctx,
+                                   const phi::DenseTensor& query_states,
+                                   const phi::DenseTensor& key_value_states,
+                                   const phi::DenseTensor& linear_weights,
+                                   phi::DenseTensor* out_linear,
+                                   const phi::Scalar& scaling_factor,
+                                   const phi::Scalar& causal) {
+  if (query_states.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedSdpaProjKernelCausal<phi::dtype::float16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
+  } else if (query_states.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedSdpaProjKernelCausal<phi::dtype::bfloat16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
   } else {
     throw std::runtime_error("Unsupported data type for FusedSdpaProjKernel");
   }
@@ -373,9 +729,10 @@ void CallFusedSdpaProjKernelV2(const Context& dev_ctx,
 std::vector<paddle::Tensor> FusedSdpaProjV2(
     const paddle::Tensor& query_states,
     const paddle::Tensor& key_value_states,
-    const paddle::Tensor& attn_mask,
+    const paddle::optional<paddle::Tensor>& attn_mask,
     const paddle::Tensor& linear_weights,
-    float scaling_factor) {
+    float scaling_factor,
+    bool causal = false) {
   auto dev_ctx = static_cast<const phi::CustomContext*>(
       paddle::experimental::DeviceContextPool::Instance().Get(
           query_states.place()));
@@ -383,8 +740,15 @@ std::vector<paddle::Tensor> FusedSdpaProjV2(
       static_cast<const phi::DenseTensor*>(query_states.impl().get());
   auto key_value_states_tensor =
       static_cast<const phi::DenseTensor*>(key_value_states.impl().get());
-  auto attn_mask_tensor =
-      static_cast<const phi::DenseTensor*>(attn_mask.impl().get());
+
+  phi::DenseTensor* attn_mask_tensor = nullptr;
+  std::shared_ptr<phi::DenseTensor> attn_mask_tensor_null =
+      std::make_shared<phi::DenseTensor>();
+  if (attn_mask) {
+    auto attn_mask_ptr = *(attn_mask.get_ptr());
+    attn_mask_tensor =
+        static_cast<phi::DenseTensor*>(attn_mask_ptr.impl().get());
+  }
   auto linear_weights_tensor =
       static_cast<const phi::DenseTensor*>(linear_weights.impl().get());
 
@@ -398,20 +762,31 @@ std::vector<paddle::Tensor> FusedSdpaProjV2(
   out_linear->Resize(phi::make_ddim({bsz, seq_len, hidden_size}));
   dev_ctx->Alloc(out_linear.get(), query_states_tensor->dtype());
 
-  CallFusedSdpaProjKernelV2(*dev_ctx,
-                            *query_states_tensor,
-                            *key_value_states_tensor,
-                            *attn_mask_tensor,
-                            *linear_weights_tensor,
-                            out_linear.get(),
-                            phi::Scalar(scaling_factor));
+  if (attn_mask) {
+    CallFusedSdpaProjKernelMask(*dev_ctx,
+                                *query_states_tensor,
+                                *key_value_states_tensor,
+                                *attn_mask_tensor,
+                                *linear_weights_tensor,
+                                out_linear.get(),
+                                phi::Scalar(scaling_factor),
+                                phi::Scalar(causal));
+  } else {
+    CallFusedSdpaProjKernelCausal(*dev_ctx,
+                                  *query_states_tensor,
+                                  *key_value_states_tensor,
+                                  *linear_weights_tensor,
+                                  out_linear.get(),
+                                  phi::Scalar(scaling_factor),
+                                  phi::Scalar(causal));
+  }
   return {paddle::Tensor(out_linear)};
 }
 
 std::vector<std::vector<int64_t>> FusedSdpaProjV2Shape(
     const std::vector<int64_t>& query_states_shape,
     const std::vector<int64_t>& key_value_states_shape,
-    const std::vector<int64_t>& attn_mask_shape,
+    const paddle::optional<std::vector<int64_t>>& attn_mask_shape,
     const std::vector<int64_t>& linear_weights_shape) {
   int64_t bsz = query_states_shape[0];
   int64_t seq_len = query_states_shape[2];
@@ -422,15 +797,18 @@ std::vector<std::vector<int64_t>> FusedSdpaProjV2Shape(
 std::vector<paddle::DataType> FusedSdpaProjV2Dtype(
     const paddle::DataType& query_states_dtype,
     const paddle::DataType& key_value_states_dtype,
-    const paddle::DataType& attn_mask_dtype,
+    const paddle::optional<paddle::DataType>& attn_mask_dtype,
     const paddle::DataType& linear_weights_dtype) {
   return {query_states_dtype};
 }
 
 PD_BUILD_OP(fused_sdpa_proj_v2)
-    .Inputs({"query_states", "key_value_states", "attn_mask", "linear_weights"})
+    .Inputs({"query_states",
+             "key_value_states",
+             paddle::Optional("attn_mask"),
+             "linear_weights"})
     .Outputs({"out_linear"})
-    .Attrs({"scaling_factor: float"})
+    .Attrs({"scaling_factor: float", "causal:bool"})
     .SetKernelFn(PD_KERNEL(FusedSdpaProjV2))
     .SetInferShapeFn(PD_INFER_SHAPE(FusedSdpaProjV2Shape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedSdpaProjV2Dtype));

--- a/backends/intel_hpu/custom_ops/python/paddlenlp_ops/__init__.py
+++ b/backends/intel_hpu/custom_ops/python/paddlenlp_ops/__init__.py
@@ -14,3 +14,4 @@
 
 from paddle_custom_device.intel_hpu.ops import *  # noqa
 from .layers import *  # noqa
+from .llama_block_atten import *  # noqa

--- a/backends/intel_hpu/custom_ops/python/paddlenlp_ops/llama_block_atten.py
+++ b/backends/intel_hpu/custom_ops/python/paddlenlp_ops/llama_block_atten.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddlenlp_ops
+
+
+def get_padding_offset_v2(
+    input_ids, cum_offset, token_num, seq_lens, draft_tokens=None, seq_lens_encoder=None
+):
+    bsz, max_seq_len = input_ids.shape
+    cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens)
+    cum_offsets = paddle.zeros(shape=(bsz + 1), dtype="int32")
+    cum_offsets[1:] = cum_offsets_now
+    token_num = paddle.sum(seq_lens)
+    x_remove_padding = paddle.zeros(shape=(token_num), dtype=input_ids.dtype)
+    padding_offsets = paddle.zeros(shape=(token_num), dtype="int32")
+    cu_seqlens_q = paddle.zeros(shape=(bsz + 1), dtype="int32")
+    cu_seqlens_k = paddle.zeros(shape=(bsz + 1), dtype="int32")
+    current_index = 0
+    for i in range(bsz):
+        seq_len_now = seq_lens[i].item()
+        cum_offset = cum_offsets[i].item()
+        # x_remove_padding = paddle.concat((x_remove_padding, input_ids[i, :seq_len_now]))
+        x_remove_padding[current_index : current_index + seq_len_now] = input_ids[
+            i, :seq_len_now
+        ]
+        current_index += seq_len_now
+        for j in range(seq_len_now):
+            padding_offsets[i * max_seq_len - cum_offset + j] = cum_offset
+        cum_seq_len = (i + 1) * max_seq_len - cum_offsets[i + 1].item()
+        cu_seqlens_q[i + 1] = cum_seq_len
+        cu_seqlens_k[i + 1] = cum_seq_len
+    return (
+        x_remove_padding,
+        cum_offsets[:-1],
+        padding_offsets,
+        cu_seqlens_q,
+        cu_seqlens_k,
+    )
+
+
+def rebuild_padding_v2(
+    tmp_out,
+    cum_offsets,
+    seq_lens_decoder,
+    seq_len_encoder,
+    output_padding_offset=None,
+    max_len=-1,
+):
+    # tmp_out, // [token_num, dim_embed]
+    # cum_offsets, // [bsz, 1]
+    bs = seq_len_encoder.shape[0]
+    dim_emb = tmp_out.shape[1]
+    output_data = paddle.zeros((bs, dim_emb)).flatten()
+    seq_len = max_len
+    tmp_out = tmp_out.flatten()
+    for i in range(bs * dim_emb):
+        bi = i // dim_emb
+        bias_idx = i % dim_emb
+        seq_id = 0
+        # just encoder or stop, get last token; just decoder, get first token.
+        if seq_lens_decoder[bi] == 0:
+            if seq_len_encoder[bi] != 0:
+                seq_id = seq_len_encoder[bi] - 1
+            else:
+                continue
+        ori_token_idx = bi * seq_len - cum_offsets[bi] + seq_id
+        src_offset = ori_token_idx * dim_emb + bias_idx
+        output_data[i] = tmp_out[src_offset]
+    return output_data.reshape([bs, dim_emb])
+
+
+def fused_flatpa_proj_ref(
+    query,
+    key_cache,
+    value_cache,
+    block_groups,
+    block_list,
+    block_mapping,
+    block_bias,
+    linear_weights,
+    scaling_factor,
+):
+    batch_size = query.shape[0]
+    q_heads = query.shape[1]
+    head_size = query.shape[3]
+    kv_heads = key_cache.shape[1]
+    hidden_size = q_heads * head_size
+
+    shape = tuple(query.shape)
+    query = paddle.matmul(
+        block_mapping, (scaling_factor * query).view([shape[0], -1])
+    ).view([-1, *shape[1:]])
+
+    key = key_cache.index_select(block_list)
+    value = value_cache.index_select(block_list)
+    block_bias = block_bias.unsqueeze(1).unsqueeze(1)
+    if kv_heads != q_heads:
+        block_bias = block_bias.unsqueeze(1)
+        query = query.unflatten(1, (kv_heads, -1))
+        key = key.unflatten(1, (kv_heads, 1))
+        value = value.unflatten(1, (kv_heads, 1))
+        key = key.transpose([0, 1, 2, 4, 3])
+    else:
+        key = key.transpose([0, 1, 3, 2])
+
+    attn = paddle.matmul(query, key)
+    # if 'fp32_softmax' in enabled_flags():
+    #     attn = attn.float()
+    attn = attn + block_bias
+
+    block_max = attn.max(axis=-1, keepdim=True)
+    adjustment_target_shape = block_max.shape
+    attn = attn.subtract(block_max)
+    attn = attn.exp()
+    # attn = attn.to(value.dtype)
+    block_sums = attn.sum(axis=-1, keepdim=True)
+    attn = paddle.matmul(attn, value)
+    block_max = block_max.squeeze()
+    block_sums = block_sums.squeeze()
+
+    # Calculate maximum of blocks that belong to the same sequences
+    # and cast adjustments to native dtype
+    orig_dtype = block_max.dtype
+    if orig_dtype == paddle.float16:
+        # fp16 index_reduce is not supported ATM
+        block_max = block_max.to(paddle.float32)
+    group_max = paddle.full(
+        [batch_size + 1, *block_max.shape[1:]], float("-inf"), dtype=block_max.dtype
+    )
+
+    paddlenlp_ops.index_reduce_(group_max, block_groups, block_max, 0, "amax", True)
+    group_max = group_max.index_select(block_groups, 0)
+
+    block_adjustment = (block_max - group_max).exp()
+    # block_adjustment = block_adjustment.to(value.dtype)
+    sum_adjusted = block_sums.multiply(block_adjustment)
+
+    # Sum block's sums that belongs to the same sequences
+    shape = tuple(sum_adjusted.shape)
+    group_sum_adjusted = paddle.matmul(
+        block_mapping, sum_adjusted.view([shape[0], -1]), transpose_x=True
+    ).view([-1, *shape[1:]])
+    shape = tuple(group_sum_adjusted.shape)
+    group_sum_adjusted = paddle.matmul(
+        block_mapping, group_sum_adjusted.view([shape[0], -1])
+    ).view([-1, *shape[1:]])
+
+    sum_adjusted = sum_adjusted.view([*adjustment_target_shape])
+    group_sum_adjusted = group_sum_adjusted.view([*adjustment_target_shape])
+    block_adjustment = block_adjustment.view([*adjustment_target_shape])
+
+    # For stability in case some of the sums have been zeroed out during block aggretation
+    group_sum_adjusted = paddle.maximum(group_sum_adjusted, sum_adjusted)
+
+    # Post processing for the attention scores
+    rescale = block_adjustment.divide(group_sum_adjusted)
+    attn = attn.multiply(rescale)
+
+    shape = tuple(attn.shape)
+    attn = paddle.matmul(
+        block_mapping, attn.view([shape[0], -1]), transpose_x=True
+    ).view([-1, *shape[1:]])
+
+    attn = attn.squeeze(-2)
+    if kv_heads != q_heads:
+        attn = attn.flatten(1, 2)
+
+    return paddle.matmul(attn.view([batch_size, 1, hidden_size]), linear_weights)

--- a/backends/intel_hpu/custom_ops/tests/test_flatPA_proj.py
+++ b/backends/intel_hpu/custom_ops/tests/test_flatPA_proj.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddlenlp_ops
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+paddle.device.set_device(f"intel_hpu:{intel_hpus_module_id}")
+
+paddle.seed(102)
+
+batch_size = 8
+q_head = 32
+head_dim = 128
+hidden_size = q_head * head_dim
+total_block_num = 40
+block_size = 64
+num_of_block = 12
+scaling_factor = head_dim**-0.5
+
+query = paddle.rand([batch_size, q_head, 1, head_dim], dtype=paddle.bfloat16)
+block_list = paddle.rand([num_of_block], dtype=paddle.int32)
+block_groups = paddle.rand([num_of_block], dtype=paddle.int32)
+block_mapping = paddle.rand([num_of_block, batch_size], dtype=paddle.bfloat16)
+attn_bias = paddle.rand([num_of_block, block_size], dtype=paddle.bfloat16)
+linear_weights = paddle.rand([hidden_size, hidden_size], dtype=paddle.bfloat16)
+
+
+def test_fused_flatpa_proj(kv_head, testcase):
+    key_cache = paddle.rand(
+        [total_block_num, kv_head, block_size, head_dim], dtype=paddle.bfloat16
+    )
+    value_cache = paddle.rand(
+        [total_block_num, kv_head, block_size, head_dim], dtype=paddle.bfloat16
+    )
+
+    out_linear_ref = paddlenlp_ops.fused_flatpa_proj_ref(
+        query,
+        key_cache,
+        value_cache,
+        block_groups,
+        block_list,
+        block_mapping,
+        attn_bias,
+        linear_weights,
+        scaling_factor=scaling_factor,
+    )
+
+    out_linear_out = paddlenlp_ops.fused_flatpa_proj(
+        query,
+        key_cache,
+        value_cache,
+        block_groups,
+        block_list,
+        block_mapping,
+        attn_bias,
+        linear_weights,
+        scaling_factor=scaling_factor,
+    )
+
+    assert (
+        (out_linear_out == out_linear_ref).all().item()
+    ), f"Test failed for kv_head={kv_head}"
+    print(f"Test Pass for {testcase} testcase")
+
+
+test_fused_flatpa_proj(kv_head=32, testcase="MHA")
+test_fused_flatpa_proj(kv_head=8, testcase="GQA")

--- a/backends/intel_hpu/custom_ops/tests/test_sdpa_proj_v2.py
+++ b/backends/intel_hpu/custom_ops/tests/test_sdpa_proj_v2.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddlenlp_ops
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+paddle.device.set_device(f"intel_hpu:{intel_hpus_module_id}")
+
+paddle.seed(105)
+
+
+def ref_result(
+    query_states,
+    key_states,
+    value_states,
+    attention_mask,
+    linear_weights,
+    scaling_factor,
+):
+    bsz, q_len, num_heads, head_dim = query_states.shape
+    attn_output = paddle.incubate.nn.functional.fused_dot_product_attention(
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        0.0,
+        attention_mask is None,
+        scaling_factor,
+        False,
+    )
+    attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
+
+    out_linear_out = paddle.matmul(attn_output, linear_weights)
+
+    return out_linear_out
+
+
+head_dim = 128
+num_head = 32
+kv_num_heads = num_head
+hidden_size = num_head * head_dim
+
+batch_size = 4
+# seq_len = 1
+seq_len = 25
+kv_seq_len = 25
+max_seq_length = 2048
+
+query_states = paddle.rand(
+    [batch_size, num_head, seq_len, head_dim], dtype=paddle.float32
+).to(paddle.bfloat16)
+key_states = paddle.rand(
+    [batch_size, kv_num_heads, kv_seq_len, head_dim], dtype=paddle.float32
+).to(paddle.bfloat16)
+value_states = paddle.rand(
+    [batch_size, kv_num_heads, kv_seq_len, head_dim], dtype=paddle.float32
+).to(paddle.bfloat16)
+
+attn_mask = paddle.ones([1, 1, max_seq_length, max_seq_length], dtype=paddle.bfloat16)
+attn_mask = paddle.tril(attn_mask)
+attn_mask = (1.0 - attn_mask) * -10000.0
+
+linear_weights = paddle.rand([hidden_size, hidden_size], dtype=paddle.float32).to(
+    paddle.bfloat16
+)
+
+
+def main():
+    attention_mask = attn_mask[..., :seq_len, :kv_seq_len]
+    attention_mask = attention_mask.astype(query_states.dtype)
+
+    out_linear_out_op = paddlenlp_ops.fused_sdpa_proj(
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        linear_weights,
+        scaling_factor=head_dim**-0.5,
+    )
+
+    out_linear_out_ref = ref_result(
+        query_states.transpose([0, 2, 1, 3]),
+        key_states.transpose([0, 2, 1, 3]),
+        value_states.transpose([0, 2, 1, 3]),
+        attention_mask,
+        linear_weights,
+        scaling_factor=head_dim**-0.5,
+    )
+
+    key_value_states = paddle.stack([key_states, value_states], axis=0)
+
+    # Test is causal && mask=None
+    # seq_len = kv_seq_len
+    attention_mask = None
+    out_linear_out_op_v2 = paddlenlp_ops.fused_sdpa_proj_v2(
+        query_states,
+        key_value_states,
+        attention_mask,
+        linear_weights,
+        scaling_factor=head_dim**-0.5,
+        causal=attention_mask is None,
+    )
+
+    print((out_linear_out_ref == out_linear_out_op).all())
+    print(
+        paddle.allclose(
+            out_linear_out_ref.to("cpu").to("float32"),
+            out_linear_out_op_v2.to("cpu").to("float32"),
+            rtol=1e-2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backends/intel_hpu/kernels/hpu_funcs.h
+++ b/backends/intel_hpu/kernels/hpu_funcs.h
@@ -57,7 +57,7 @@ class HpuFusedOperator : public HpuOperator {
                                       bool is_input = true,
                                       synSectionHandle section = nullptr) {
     PD_CHECK(ct != nullptr, "[RUNTIME] input ct is a nullptr");
-    auto tensors = ct.GetTensors(is_input);
+    auto tensors = ct->GetTensors(is_input);
     synTensor t = createTensor(tensors[idx].dims.size(),
                                tensors[idx].type,
                                tensors[idx].dims,

--- a/backends/intel_hpu/kernels/hpu_funcs.h
+++ b/backends/intel_hpu/kernels/hpu_funcs.h
@@ -1,0 +1,264 @@
+// Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_operator.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+class HpuFusedOperator : public HpuOperator {
+ public:
+  explicit HpuFusedOperator(const std::string& guid, bool is_eager = true)
+      : HpuOperator(guid, is_eager) {}
+
+  template <typename T>
+  std::string guid_dtype() {
+    if (std::is_same<T, phi::dtype::float16>::value) {
+      return "f16";
+    } else if (std::is_same<T, phi::dtype::bfloat16>::value) {
+      return "bf16";
+    } else if (std::is_same<T, float>::value) {
+      return "f32";
+    } else if (std::is_same<T, phi::dtype::float8_e4m3fn>::value) {
+      return "hf8";
+    } else if (std::is_same<T, int16_t>::value) {
+      return "i16";
+    } else if (std::is_same<T, int32_t>::value) {
+      return "i32";
+    } else if (std::is_same<T, bool>::value) {
+      return "i8";
+    } else if (std::is_same<T, int8_t>::value) {
+      return "i8";
+    } else if (std::is_same<T, int64_t>::value) {
+      return "i64";
+    } else {
+      PD_CHECK(
+          false, "[RUNTIME] synDataType not supported = %s", typeid(T).name());
+    }
+  }
+
+  inline synTensor createTensorFromCT(ConvertTensors* ct,
+                                      int idx,
+                                      bool is_input = true,
+                                      synSectionHandle section = nullptr) {
+    PD_CHECK(ct != nullptr, "[RUNTIME] input ct is a nullptr");
+    auto tensors = ct.GetTensors(is_input);
+    synTensor t = createTensor(tensors[idx].dims.size(),
+                               tensors[idx].type,
+                               tensors[idx].dims,
+                               true,
+                               tensors[idx].name,
+                               section);
+    return t;
+  }
+
+  inline synTensor createTensorNoPresist(std::string name,
+                                         synDataType dtype,
+                                         std::vector<int64_t> dims,
+                                         synSectionHandle section = nullptr) {
+    synTensor t =
+        createTensor(dims.size(), dtype, dims, false, name.c_str(), section);
+    return t;
+  }
+
+  template <typename T>
+  inline void AddNode_OP(std::vector<synTensor> outputs,
+                         T params,
+                         std::string guid,
+                         std::string node_name) {
+    synStatus status = synNodeCreate(graphHandle_,
+                                     nullptr,
+                                     outputs.data(),
+                                     0,
+                                     outputs.size(),
+                                     &params,
+                                     sizeof(params),
+                                     guid.c_str(),
+                                     node_name.c_str(),
+                                     nullptr,
+                                     nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (",
+             node_name,
+             ") failed = ",
+             status);
+  }
+
+  inline void AddNode_IO(std::vector<synTensor> inputs,
+                         std::vector<synTensor> outputs,
+                         std::string guid,
+                         std::string node_name) {
+    synStatus status = synNodeCreate(graphHandle_,
+                                     inputs.data(),
+                                     outputs.data(),
+                                     inputs.size(),
+                                     outputs.size(),
+                                     nullptr,
+                                     0,
+                                     guid.c_str(),
+                                     node_name.c_str(),
+                                     nullptr,
+                                     nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (",
+             node_name,
+             ") failed = ",
+             status);
+  }
+
+  template <typename T>
+  inline void AddNode_IOP(std::vector<synTensor> inputs,
+                          std::vector<synTensor> outputs,
+                          T params,
+                          std::string guid,
+                          std::string node_name) {
+    synStatus status = synNodeCreate(graphHandle_,
+                                     inputs.data(),
+                                     outputs.data(),
+                                     inputs.size(),
+                                     outputs.size(),
+                                     &params,
+                                     sizeof(params),
+                                     guid.c_str(),
+                                     node_name.c_str(),
+                                     nullptr,
+                                     nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] synNodeCreate (",
+             node_name,
+             ") failed = ",
+             status);
+  }
+
+  template <typename T>
+  inline void AddNodeFull(std::vector<synTensor> outputs,
+                          ns_ConstantKernel::Params params,
+                          std::string node_name) {
+    std::string guid = "constant_" + guid_dtype<T>();
+    AddNode_OP<ns_ConstantKernel::Params>(outputs, params, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeAdd(std::vector<synTensor> inputs,
+                         std::vector<synTensor> outputs,
+                         std::string node_name) {
+    std::string guid = "add_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeSub(std::vector<synTensor> inputs,
+                         std::vector<synTensor> outputs,
+                         std::string node_name) {
+    std::string guid = "sub_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeMultiply(std::vector<synTensor> inputs,
+                              std::vector<synTensor> outputs,
+                              std::string node_name) {
+    std::string guid = "mult_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeDivide(std::vector<synTensor> inputs,
+                            std::vector<synTensor> outputs,
+                            std::string node_name) {
+    std::string guid = "div_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeMaximum(std::vector<synTensor> inputs,
+                             std::vector<synTensor> outputs,
+                             std::string node_name) {
+    std::string guid = "max_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeExp(std::vector<synTensor> inputs,
+                         std::vector<synTensor> outputs,
+                         std::string node_name) {
+    std::string guid = "exp_fwd_" + guid_dtype<T>();
+    AddNode_IO(inputs, outputs, guid, node_name);
+  }
+
+  inline void AddNodeReshape(std::vector<synTensor> inputs,
+                             std::vector<synTensor> outputs,
+                             std::string node_name) {
+    AddNode_IO(inputs, outputs, "reshape", node_name);
+  }
+
+  inline void AddNodeBatchGemm(std::vector<synTensor> inputs,
+                               std::vector<synTensor> outputs,
+                               synGEMMParams params,
+                               std::string node_name) {
+    AddNode_IOP<synGEMMParams>(
+        inputs, outputs, params, "batch_gemm", node_name);
+  }
+
+  inline void AddNodeGemm(std::vector<synTensor> inputs,
+                          std::vector<synTensor> outputs,
+                          synGEMMParams params,
+                          std::string node_name) {
+    AddNode_IOP<synGEMMParams>(inputs, outputs, params, "gemm", node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeIndexSelect(std::vector<synTensor> inputs,
+                                 std::vector<synTensor> outputs,
+                                 ns_GatherKernel::Params params,
+                                 std::string node_name) {
+    std::string guid = "gather_fwd_" + guid_dtype<T>();
+    AddNode_IOP<ns_GatherKernel::Params>(
+        inputs, outputs, params, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeIndexReduce(std::vector<synTensor> inputs,
+                                 std::vector<synTensor> outputs,
+                                 ns_IndexReduce::Params params,
+                                 std::string node_name) {
+    std::string guid = "index_reduce_fwd_" + guid_dtype<T>();
+    AddNode_IOP<ns_IndexReduce::Params>(
+        inputs, outputs, params, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeReduceSum(std::vector<synTensor> inputs,
+                               std::vector<synTensor> outputs,
+                               ns_Reduction::Params params,
+                               std::string node_name) {
+    std::string guid = "reduce_sum_fwd_" + guid_dtype<T>();
+    AddNode_IOP<ns_Reduction::Params>(inputs, outputs, params, guid, node_name);
+  }
+
+  template <typename T>
+  inline void AddNodeReduceMax(std::vector<synTensor> inputs,
+                               std::vector<synTensor> outputs,
+                               ns_Reduction::Params params,
+                               std::string node_name) {
+    std::string guid = "reduce_max_fwd_" + guid_dtype<T>();
+    AddNode_IOP<ns_Reduction::Params>(inputs, outputs, params, guid, node_name);
+  }
+};
+
+}  // namespace custom_kernel


### PR DESCRIPTION
Add Block Attention related OPs and Tests:
1. Enhance fused_sdpa_proj_v2 to support  attention_mask=None and is_causal=True scenario.
2. Add fused_flatpa_proj to do block attention
3. Add block attention reference python code
4. Add Unit test for fused_sdpa_proj_v2  and fused_flatpa_proj 
5. Add hpu_funcs.h to simplify op development process
