### PR TITLE
[NPU] Fix unittests in PIR mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ version.info
 
 # ignore Paddle change
 Paddle/
+
+# ignore clangd cache
+.cache/

--- a/backends/npu/tests/unittests/test_activation_op.py
+++ b/backends/npu/tests/unittests/test_activation_op.py
@@ -499,7 +499,6 @@ class TestLog2(TestActivation):
 
                 out1 = paddle.log2(data_x)
                 exe = paddle.static.Executor(place=self.place)
-                exe.run(paddle.static.default_startup_program())
                 (res1,) = exe.run(
                     paddle.static.default_main_program(),
                     feed={"data_x": input_x},

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -103,7 +103,6 @@ def create_test_class(op_type, typename, callback):
                         op(x=inputs[case["x"]], y=inputs[case["y"]], **case["args"])
                         exe = paddle.static.Executor(self.place)
 
-                        exe.run(paddle.static.default_startup_program())
                         exe.run(paddle.static.default_main_program())
 
                 for case in cases:

--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -61,7 +61,6 @@ def create_test_class(op_type, typename, callback):
             paddle.set_device(self.device)
             paddle.enable_static()
             exe = paddle.static.Executor(self.place)
-            exe.run(paddle.static.default_startup_program())
             paddle.disable_static()
 
         def test_output(self):

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -65,6 +65,9 @@ class TestDropoutOp(OpTest):
         self.__class__.use_custom_device = True
         self.place = paddle.CustomPlace("npu", 0)
 
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
@@ -231,6 +234,9 @@ class TestDropoutOpInference(OpTest):
         self.__class__.use_custom_device = True
         self.place = paddle.CustomPlace("npu", 0)
 
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
@@ -317,6 +323,9 @@ class TestDropoutOpFp16(TestDropoutOp):
         self.__class__.no_need_check_grad = True
         self.place = paddle.CustomPlace("npu", 0)
 
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+
 
 class TestDropoutOpFp64(TestDropoutOp):
     # float64
@@ -327,6 +336,9 @@ class TestDropoutOpFp64(TestDropoutOp):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
         self.place = paddle.CustomPlace("npu", 0)
+
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
 
 
 _list = [
@@ -340,6 +352,9 @@ class TestDropoutAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         self.places = [base.CPUPlace(), paddle.CustomPlace("npu", 0)]
+
+        exe = paddle.static.Executor(self.places[-1])
+        exe.run(paddle.static.default_startup_program())
 
     def check_static_result(self, place):
         with base.program_guard(base.Program(), base.Program()):

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -412,6 +412,7 @@ class TestDropoutAPI(unittest.TestCase):
             res_np2 = np.zeros_like(in_np)
 
             exe = base.Executor(place)
+            exe.run(base.default_startup_program())
             res_list = [
                 res1,
                 res2,

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -397,7 +397,6 @@ class TestDropoutAPI(unittest.TestCase):
             res_np2 = np.zeros_like(in_np)
 
             exe = base.Executor(place)
-            exe.run(base.default_startup_program())
             res_list = [
                 res1,
                 res2,

--- a/backends/npu/tests/unittests/test_dropout_op_npu.py
+++ b/backends/npu/tests/unittests/test_dropout_op_npu.py
@@ -65,9 +65,6 @@ class TestDropoutOp(OpTest):
         self.__class__.use_custom_device = True
         self.place = paddle.CustomPlace("npu", 0)
 
-        exe = paddle.static.Executor(self.place)
-        exe.run(paddle.static.default_startup_program())
-
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
@@ -234,9 +231,6 @@ class TestDropoutOpInference(OpTest):
         self.__class__.use_custom_device = True
         self.place = paddle.CustomPlace("npu", 0)
 
-        exe = paddle.static.Executor(self.place)
-        exe.run(paddle.static.default_startup_program())
-
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
@@ -323,9 +317,6 @@ class TestDropoutOpFp16(TestDropoutOp):
         self.__class__.no_need_check_grad = True
         self.place = paddle.CustomPlace("npu", 0)
 
-        exe = paddle.static.Executor(self.place)
-        exe.run(paddle.static.default_startup_program())
-
 
 class TestDropoutOpFp64(TestDropoutOp):
     # float64
@@ -336,9 +327,6 @@ class TestDropoutOpFp64(TestDropoutOp):
         self.__class__.use_custom_device = True
         self.__class__.no_need_check_grad = True
         self.place = paddle.CustomPlace("npu", 0)
-
-        exe = paddle.static.Executor(self.place)
-        exe.run(paddle.static.default_startup_program())
 
 
 _list = [
@@ -352,9 +340,6 @@ class TestDropoutAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         self.places = [base.CPUPlace(), paddle.CustomPlace("npu", 0)]
-
-        exe = paddle.static.Executor(self.places[-1])
-        exe.run(paddle.static.default_startup_program())
 
     def check_static_result(self, place):
         with base.program_guard(base.Program(), base.Program()):

--- a/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_add_op_npu.py
@@ -23,10 +23,6 @@ from tests.op_test import OpTest, skip_check_grad_ci
 
 paddle.enable_static()
 
-# Initialize NPU device
-exe = paddle.static.Executor(paddle.CustomPlace("npu", 0))
-exe.run(paddle.static.default_startup_program())
-
 
 class TestElementwiseAddOp(OpTest):
     def setUp(self):

--- a/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
+++ b/backends/npu/tests/unittests/test_elementwise_sub_op_npu.py
@@ -192,10 +192,13 @@ class TestSubtractError(unittest.TestCase):
             )
             self.assertRaises(TypeError, paddle.subtract, x1, y1)
 
+            # TypeError won't be raised on X86_64 when uint8-supported onednn kernel
+            # is available, but will be raised on ARM due to lack of uint8 kernel support.
+
             # the input dtype must be float16 or float32 or float64 or int32 or int64
-            x2 = paddle.static.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
-            y2 = paddle.static.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
-            self.assertRaises(TypeError, paddle.subtract, x2, y2)
+            # x2 = paddle.static.data(name="x2", shape=[3, 4, 5, 6], dtype="uint8")
+            # y2 = paddle.static.data(name="y2", shape=[3, 4, 5, 6], dtype="uint8")
+            # self.assertRaises(TypeError, paddle.subtract, x2, y2)
 
 
 class TestSubtractNet(unittest.TestCase):

--- a/backends/npu/tests/unittests/test_randperm_op_npu.py
+++ b/backends/npu/tests/unittests/test_randperm_op_npu.py
@@ -115,7 +115,6 @@ class TestRandpermOpError(unittest.TestCase):
                 with program_guard(Program(), Program()):
                     paddle.randperm(-3)
                     exe = paddle.static.Executor()
-                    exe.run(paddle.static.default_startup_program())
                     exe.run(paddle.static.default_main_program())
 
             self.assertRaises(RuntimeError, test_invalid_n)
@@ -124,7 +123,6 @@ class TestRandpermOpError(unittest.TestCase):
                 with program_guard(Program(), Program()):
                     paddle.randperm(10, "int8")
                     exe = paddle.static.Executor()
-                    exe.run(paddle.static.default_startup_program())
                     exe.run(paddle.static.default_main_program())
 
             self.assertRaises(TypeError, test_invalid_dtype)

--- a/backends/npu/tests/unittests/test_unbind_op_npu.py
+++ b/backends/npu/tests/unittests/test_unbind_op_npu.py
@@ -30,6 +30,7 @@ class TestUnbind(unittest.TestCase):
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
         exe = base.Executor(place=paddle.CustomPlace("npu", 0))
+        exe.run(base.default_startup_program())
 
         [res_1, res_2] = exe.run(
             base.default_main_program(),
@@ -51,6 +52,8 @@ class TestUnbind(unittest.TestCase):
             y = paddle.unbind(x)
 
             exe = paddle.static.Executor(place)
+            exe.run(base.default_startup_program())
+
             res = exe.run(
                 paddle.static.default_main_program(),
                 feed={
@@ -87,6 +90,7 @@ class TestLayersUnbind(unittest.TestCase):
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
         exe = base.Executor(place=paddle.CustomPlace("npu", 0))
+        exe.run(base.default_startup_program())
 
         [res_1, res_2] = exe.run(
             base.default_main_program(),

--- a/backends/npu/tests/unittests/test_unbind_op_npu.py
+++ b/backends/npu/tests/unittests/test_unbind_op_npu.py
@@ -30,7 +30,6 @@ class TestUnbind(unittest.TestCase):
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
         exe = base.Executor(place=paddle.CustomPlace("npu", 0))
-        exe.run(base.default_startup_program())
 
         [res_1, res_2] = exe.run(
             base.default_main_program(),
@@ -52,7 +51,6 @@ class TestUnbind(unittest.TestCase):
             y = paddle.unbind(x)
 
             exe = paddle.static.Executor(place)
-            exe.run(base.default_startup_program())
 
             res = exe.run(
                 paddle.static.default_main_program(),
@@ -90,7 +88,6 @@ class TestLayersUnbind(unittest.TestCase):
         input_1 = np.random.random([2, 3]).astype("float32")
         axis = paddle.static.data(shape=[], dtype="int32", name="axis")
         exe = base.Executor(place=paddle.CustomPlace("npu", 0))
-        exe.run(base.default_startup_program())
 
         [res_1, res_2] = exe.run(
             base.default_main_program(),


### PR DESCRIPTION
- 移除不必要的 run startup_program

### test_drop_out_op
没初始化 NPU
![image](https://github.com/user-attachments/assets/8f6ca23e-29b2-4efb-bbaf-8a9d714f5166)

### test_elementwise_sub_op
x86 平台由于 onednn 存在支持 uint8 的kernel，不会引发 error，但在 arm 平台会抛出异常。
![image](https://github.com/user-attachments/assets/30952b70-213f-40e2-9249-353791201057)

### test_unbind_op
没初始化 NPU
![image](https://github.com/user-attachments/assets/f7d62346-fb9c-4a07-a7fe-7fac9772a928)

### 其它
还将 paddle submodule 的 commit 更新到了 1befb859f8fa317af8eb45f8fdaa27ad5a42ad2b
