### PR TITLE
[INTEL_HPU] Add FSDPA with QKV BTMH shape

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_flatpa_proj.cc
@@ -43,9 +43,10 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
     std::vector<int64_t> linear_weights_dims =
         std::vector<int64_t>(inputs[7].dims);
     int64_t batch_size = q_dims[0];
-    int64_t num_head = q_dims[1];
+    int64_t num_head = q_dims[2];
     int64_t head_dim = q_dims[3];
-    int64_t block_size = kv_dims[2];
+    int64_t block_size = kv_dims[1];
+    int64_t num_kv_head = kv_dims[2];
     int64_t num_of_block = block_list_dims[0];
     int64_t hidden_size = linear_weights_dims[0];
 
@@ -135,33 +136,65 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
 
     std::vector<int64_t> index_selected_dims;
     index_selected_dims.push_back(num_of_block);
-    index_selected_dims.push_back(num_head);
     index_selected_dims.push_back(block_size);
+    index_selected_dims.push_back(num_kv_head);
     index_selected_dims.push_back(head_dim);
 
-    auto index_select_k =
-        createTensorNoPresist("index_select_k", dtype_, index_selected_dims);
-    auto index_select_v =
-        createTensorNoPresist("index_select_v", dtype_, index_selected_dims);
+    auto index_select_k_i =
+        createTensorNoPresist("index_select_k_i", dtype_, index_selected_dims);
+    auto index_select_v_i =
+        createTensorNoPresist("index_select_v_i", dtype_, index_selected_dims);
     std::vector<synTensor> index_select_k_out;
-    index_select_k_out.push_back(index_select_k);
+    index_select_k_out.push_back(index_select_k_i);
     std::vector<synTensor> index_select_v_out;
-    index_select_v_out.push_back(index_select_v);
+    index_select_v_out.push_back(index_select_v_i);
 
     AddNodeIndexSelect<T>(index_select_k_in,
                           index_select_k_out,
                           params.index_select_params,
-
-                          guid_ + "index_select_k");
+                          guid_ + "index_select_k_i");
     AddNodeIndexSelect<T>(index_select_v_in,
                           index_select_v_out,
                           params.index_select_params,
+                          guid_ + "index_select_v_i");
 
-                          guid_ + "index_select_v");
+    std::vector<int> axis = {0, 2, 1, 3};
+    synTransposeParams trans_params;
+    for (size_t i = 0; i < axis.size(); i++) {
+      trans_params.permutation[i] =
+          static_cast<TransposePermutationDim>(axis[i]);
+    }
+    trans_params.tensorDim = 4;
+
+    std::vector<int64_t> transpose_dims;
+    transpose_dims.push_back(num_of_block);
+    transpose_dims.push_back(num_kv_head);
+    transpose_dims.push_back(block_size);
+    transpose_dims.push_back(head_dim);
+
+    auto transpose_k =
+        createTensorNoPresist("transpose_k", dtype_, transpose_dims);
+    std::vector<synTensor> trans_index_select_k;
+    trans_index_select_k.push_back(transpose_k);
+
+    AddNodeTranspose(index_select_k_out,
+                     trans_index_select_k,
+                     trans_params,
+                     guid_ + "transpose_k");
+
+    auto transpose_v =
+        createTensorNoPresist("transpose_v", dtype_, transpose_dims);
+    std::vector<synTensor> trans_index_select_v;
+    trans_index_select_v.push_back(transpose_v);
+
+    AddNodeTranspose(index_select_v_out,
+                     trans_index_select_v,
+                     trans_params,
+                     guid_ + "transpose_v");
 
     std::vector<synTensor> q_k_in;
     q_k_in.push_back(reshaped_map_q);
-    q_k_in.push_back(index_select_k);
+    q_k_in.push_back(transpose_k);
 
     std::vector<int64_t> q_k_dims;
     q_k_dims.push_back(num_of_block);
@@ -313,7 +346,7 @@ class FusedFlatPaMHAProj : public HpuFusedOperator {
 
     std::vector<synTensor> score_v_in;
     score_v_in.push_back(score);
-    score_v_in.push_back(index_select_v);
+    score_v_in.push_back(transpose_v);
 
     auto score_v = createTensorNoPresist("score_v", dtype_, reshape_map_q_dims);
     std::vector<synTensor> score_v_out;
@@ -496,10 +529,10 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     std::vector<int64_t> linear_weights_dims =
         std::vector<int64_t>(inputs[7].dims);
     int64_t batch_size = q_dims[0];
-    int64_t num_head = q_dims[1];
+    int64_t num_head = q_dims[2];
     int64_t head_dim = q_dims[3];
-    int64_t num_kv_head = kv_dims[1];
-    int64_t block_size = kv_dims[2];
+    int64_t block_size = kv_dims[1];
+    int64_t num_kv_head = kv_dims[2];
     int64_t num_of_block = block_list_dims[0];
     int64_t hidden_size = linear_weights_dims[0];
     int64_t ngroups = num_head / num_kv_head;
@@ -591,8 +624,8 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
 
     std::vector<int64_t> index_selected_dims;
     index_selected_dims.push_back(num_of_block);
-    index_selected_dims.push_back(num_kv_head);
     index_selected_dims.push_back(block_size);
+    index_selected_dims.push_back(num_kv_head);
     index_selected_dims.push_back(head_dim);
 
     auto index_select_k_i =
@@ -613,6 +646,40 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
                           params.index_select_params,
                           guid_ + "index_select_v_i");
 
+    std::vector<int> axis = {0, 2, 1, 3};
+    synTransposeParams trans_params;
+    for (size_t i = 0; i < axis.size(); i++) {
+      trans_params.permutation[i] =
+          static_cast<TransposePermutationDim>(axis[i]);
+    }
+    trans_params.tensorDim = 4;
+
+    std::vector<int64_t> transpose_dims;
+    transpose_dims.push_back(num_of_block);
+    transpose_dims.push_back(num_kv_head);
+    transpose_dims.push_back(block_size);
+    transpose_dims.push_back(head_dim);
+
+    auto transpose_k =
+        createTensorNoPresist("transpose_k", dtype_, transpose_dims);
+    std::vector<synTensor> trans_index_select_k;
+    trans_index_select_k.push_back(transpose_k);
+
+    AddNodeTranspose(index_select_k_out,
+                     trans_index_select_k,
+                     trans_params,
+                     guid_ + "transpose_k");
+
+    auto transpose_v =
+        createTensorNoPresist("transpose_v", dtype_, transpose_dims);
+    std::vector<synTensor> trans_index_select_v;
+    trans_index_select_v.push_back(transpose_v);
+
+    AddNodeTranspose(index_select_v_out,
+                     trans_index_select_v,
+                     trans_params,
+                     guid_ + "transpose_v");
+
     std::vector<int64_t> reshape_kv_dims;
     reshape_kv_dims.push_back(num_of_block);
     reshape_kv_dims.push_back(num_kv_head);
@@ -626,7 +693,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     reshape_index_select_k.push_back(index_select_k);
 
     AddNodeReshape(
-        index_select_k_out, reshape_index_select_k, guid_ + "reshape_k");
+        trans_index_select_k, reshape_index_select_k, guid_ + "reshape_k");
 
     auto index_select_v =
         createTensorNoPresist("index_select_v", dtype_, reshape_kv_dims);
@@ -634,7 +701,7 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     reshape_index_select_v.push_back(index_select_v);
 
     AddNodeReshape(
-        index_select_v_out, reshape_index_select_v, guid_ + "reshape_v");
+        trans_index_select_v, reshape_index_select_v, guid_ + "reshape_v");
 
     std::vector<synTensor> q_k_in;
     q_k_in.push_back(reshaped_map_q);
@@ -753,7 +820,6 @@ class FusedFlatPaGQAProj : public HpuFusedOperator {
     AddNodeIndexSelect<T>(index_select_groupmax_in,
                           index_select_groupmax_out,
                           params.index_select_params,
-
                           guid_ + "index_select_groupmax");
 
     std::vector<synTensor> sub_group_max_in;

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_rms_qkv_rope_t.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_rms_qkv_rope_t.cc
@@ -1,0 +1,595 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+struct FusedRmsQkvRopeParams {
+  ns_LayerNormKernel::Params rmsnorm_params;
+
+  int head_dim;
+  int num_head;
+  int kv_num_head;
+};
+
+class FusedRmsQkvRopeT : public HpuOperator {
+ public:
+  explicit FusedRmsQkvRopeT(synDataType dtype)
+      : HpuOperator("fused_rms_qkv_rope_t_fwd_"), dtype_(dtype) {}
+
+  void AddNode(const std::vector<DIMS>& ins,
+               const std::vector<DIMS>& outs,
+               FusedRmsQkvRopeParams& params) {
+    synStatus status = synFail;
+
+    std::string name_reshape = guid_ + "reshape";
+    std::string name_concat = guid_ + "concat";
+    std::string name_rmsnorm = guid_ + "rmsnorm";
+    std::string name_rope = guid_ + "rope";
+
+    std::string guid_reshape = "reshape";
+    std::string guid_concat = "concat";
+    std::string guid_rmsnorm = "rms_norm_ex_fwd_";
+    std::string guid_rope = "rotary_pos_embedding_fwd_";
+
+    // std::string guid_rope = "rope_st2_fwd_";
+
+    if (dtype_ == syn_type_fp16) {
+      guid_rmsnorm = guid_rmsnorm + "f16";
+      guid_rope = guid_rope + "f16";
+    } else if (dtype_ == syn_type_bf16) {
+      guid_rmsnorm = guid_rmsnorm + "bf16";
+      guid_rope = guid_rope + "bf16";
+    }
+
+    auto src = createTensor(ins[0].size(), dtype_, ins[0], true, "src");
+    auto ln_scales =
+        createTensor(ins[1].size(), dtype_, ins[1], true, "ln_scales");
+
+    std::vector<synTensor> rmsnorm_inputs;
+    rmsnorm_inputs.push_back(src);
+    rmsnorm_inputs.push_back(ln_scales);
+
+    auto tmp_dims = ins[0];
+    tmp_dims[2] = 1;
+    auto norm_out =
+        createTensor(ins[0].size(), dtype_, ins[0], false, "norm_out");
+    auto norm_var =
+        createTensor(tmp_dims.size(), dtype_, tmp_dims, false, "norm_var");
+
+    std::vector<synTensor> rmsnorm_outputs;
+    rmsnorm_outputs.push_back(norm_out);
+    rmsnorm_outputs.push_back(norm_var);
+
+    status = synNodeCreate(graphHandle_,
+                           rmsnorm_inputs.data(),
+                           rmsnorm_outputs.data(),
+                           2,
+                           2,
+                           &params.rmsnorm_params,
+                           sizeof(params.rmsnorm_params),
+                           guid_rmsnorm.c_str(),
+                           name_rmsnorm.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (norm) failed = ",
+             status);
+
+    auto qkv_weights =
+        createTensor(ins[2].size(), dtype_, ins[2], true, "qkv_weights");
+    std::vector<synTensor> mul_inputs;
+    mul_inputs.push_back(norm_out);
+    mul_inputs.push_back(qkv_weights);
+
+    auto wt_dims = ins[2];
+    tmp_dims[2] = wt_dims[0];
+
+    auto qkv_out =
+        createTensor(tmp_dims.size(), dtype_, tmp_dims, false, "qkv_out");
+    std::vector<synTensor> mul_outputs;
+    mul_outputs.push_back(qkv_out);
+
+    synGEMMParams gemm_params;
+    gemm_params.transpose_a = false;
+    gemm_params.transpose_b = true;
+    std::string guid_gemm = "gemm";
+    std::string gemm_name = guid_ + "gemm";
+    status = synNodeCreate(graphHandle_,
+                           mul_inputs.data(),
+                           mul_outputs.data(),
+                           2,
+                           1,
+                           &gemm_params,
+                           sizeof(gemm_params),
+                           guid_gemm.c_str(),
+                           gemm_name.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (matmul) failed = ",
+             status);
+
+    auto reshape_dims = ins[0];
+    reshape_dims[2] = params.num_head + 2 * params.kv_num_head;
+    reshape_dims.push_back(params.head_dim);
+
+    std::vector<synTensor> reshape_outputs;
+    auto reshape_out = createTensor(
+        reshape_dims.size(), dtype_, reshape_dims, false, "reshape_out");
+    reshape_outputs.push_back(reshape_out);
+
+    status = synNodeCreate(graphHandle_,
+                           mul_outputs.data(),
+                           reshape_outputs.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (reshape) failed = ",
+        status);
+
+    auto kv_dims = outs[1];
+    kv_dims.erase(kv_dims.begin());
+
+    synSplitParams splitParams;
+    splitParams.axis = 1;
+
+    std::vector<synTensor> split_outpus;
+    auto q_split =
+        createTensor(outs[0].size(), dtype_, outs[0], false, "q_split");
+    split_outpus.push_back(q_split);
+
+    auto k_split =
+        createTensor(kv_dims.size(), dtype_, kv_dims, false, "k_split");
+    split_outpus.push_back(k_split);
+
+    auto v_split =
+        createTensor(kv_dims.size(), dtype_, kv_dims, false, "v_split");
+    split_outpus.push_back(v_split);
+
+    std::string split_guid = "split";
+    std::string split_name = guid_ + "split";
+    status = synNodeCreate(graphHandle_,
+                           reshape_outputs.data(),
+                           split_outpus.data(),
+                           1,
+                           split_outpus.size(),
+                           &splitParams,
+                           sizeof(splitParams),
+                           split_guid.c_str(),
+                           split_name.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (split) failed = ",
+             status);
+
+    std::vector<synTensor> rotary_embs_inputs;
+    auto rotary_embs_c =
+        createTensor(ins[3].size(), dtype_, ins[3], true, "rotary_embs");
+    rotary_embs_inputs.push_back(rotary_embs_c);
+
+    auto rotary_embs_dims = ins[3];
+    rotary_embs_dims[0] = 1;
+
+    std::vector<synTensor> cos_inputs;
+    auto cos_in = createTensor(
+        rotary_embs_dims.size(), dtype_, rotary_embs_dims, false, "cos_in");
+    cos_inputs.push_back(cos_in);
+
+    synSliceParamsV2 sliceParams;
+    for (uint64_t i = 0; i < rotary_embs_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = rotary_embs_dims[rotary_embs_dims.size() - 1 - i];
+    }
+
+    std::string slice_guid = "slice";
+    std::string slice_name = guid_ + "slice";
+    std::string slice_name_cos = slice_name + "_cos";
+    status = synNodeCreate(graphHandle_,
+                           rotary_embs_inputs.data(),
+                           cos_inputs.data(),
+                           rotary_embs_inputs.size(),
+                           cos_inputs.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_cos.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/cos) failed = ",
+        status);
+
+    std::vector<synTensor> sin_inputs;
+    auto sin_in = createTensor(
+        rotary_embs_dims.size(), dtype_, rotary_embs_dims, false, "sin_in");
+    sin_inputs.push_back(sin_in);
+    sliceParams.starts[rotary_embs_dims.size() - 1] = 1;
+    sliceParams.ends[rotary_embs_dims.size() - 1] = 2;
+    std::string slice_name_sin = slice_name + "_sin";
+    status = synNodeCreate(graphHandle_,
+                           rotary_embs_inputs.data(),
+                           sin_inputs.data(),
+                           rotary_embs_inputs.size(),
+                           sin_inputs.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_sin.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/sin) failed = ",
+        status);
+
+    reshape_dims[2] = 1;
+    std::vector<synTensor> sin_squeezed;
+    auto sin_sq = createTensor(
+        reshape_dims.size(), dtype_, reshape_dims, false, "sin_squeezed");
+    sin_squeezed.push_back(sin_sq);
+    status = synNodeCreate(graphHandle_,
+                           sin_inputs.data(),
+                           sin_squeezed.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (reshape/sin) failed = ",
+        status);
+
+    std::vector<synTensor> cos_squeezed;
+    auto cos_sq = createTensor(
+        reshape_dims.size(), dtype_, reshape_dims, false, "cos_squeezed");
+    cos_squeezed.push_back(cos_sq);
+    status = synNodeCreate(graphHandle_,
+                           cos_inputs.data(),
+                           cos_squeezed.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (reshape/cos) failed = ",
+        status);
+
+    std::vector<synTensor> inputs_q;
+    std::vector<synTensor> outputs_q;
+    inputs_q.push_back(q_split);
+    inputs_q.push_back(sin_sq);
+    inputs_q.push_back(cos_sq);
+
+    auto q_states =
+        createTensor(outs[0].size(), dtype_, outs[0], true, "query_states");
+    outputs_q.push_back(q_states);
+
+    ns_RoPESt2::ParamsV2 ropeParams;
+    ropeParams.offset = 0;
+    ropeParams.mode = ROTARY_POS_EMBEDDING_MODE_BLOCKWISE;
+
+    status = synNodeCreate(graphHandle_,
+                           inputs_q.data(),
+                           outputs_q.data(),
+                           inputs_q.size(),
+                           outputs_q.size(),
+                           &ropeParams,
+                           sizeof(ropeParams),
+                           guid_rope.c_str(),
+                           name_rope.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (rope/q) failed = ",
+             status);
+
+    std::vector<synTensor> inputs_k;
+    std::vector<synTensor> outputs_k;
+    inputs_k.push_back(k_split);
+    inputs_k.push_back(sin_sq);
+    inputs_k.push_back(cos_sq);
+
+    auto k_rope =
+        createTensor(kv_dims.size(), dtype_, kv_dims, false, "k_rope");
+    outputs_k.push_back(k_rope);
+
+    status = synNodeCreate(graphHandle_,
+                           inputs_k.data(),
+                           outputs_k.data(),
+                           inputs_k.size(),
+                           outputs_k.size(),
+                           &ropeParams,
+                           sizeof(ropeParams),
+                           guid_rope.c_str(),
+                           name_rope.c_str(),
+                           nullptr,
+                           nullptr);
+
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (rope/k) failed = ",
+             status);
+
+    std::vector<synTensor> inputs_concat;
+    std::vector<synTensor> outputs_concat;
+    inputs_concat.push_back(k_rope);
+    inputs_concat.push_back(v_split);
+
+    kv_dims[0] *= 2;
+    auto kv_concat =
+        createTensor(kv_dims.size(), dtype_, kv_dims, false, "kv_concat");
+    outputs_concat.push_back(kv_concat);
+
+    unsigned concatParams = 3;
+    status = synNodeCreate(graphHandle_,
+                           inputs_concat.data(),
+                           outputs_concat.data(),
+                           inputs_concat.size(),
+                           outputs_concat.size(),
+                           &concatParams,
+                           sizeof(concatParams),
+                           guid_concat.c_str(),
+                           name_concat.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (stack/concat) "
+             "failed = ",
+             status);
+
+    std::vector<synTensor> outputs_stack;
+
+    auto kv_state =
+        createTensor(outs[1].size(), dtype_, outs[1], true, "key_value_states");
+    outputs_stack.push_back(kv_state);
+
+    status = synNodeCreate(graphHandle_,
+                           outputs_concat.data(),
+                           outputs_stack.data(),
+                           outputs_concat.size(),
+                           outputs_stack.size(),
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (stack/reshape) "
+             "failed = ",
+             status);
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedRmsQkvRopeKernelT(const Context& dev_ctx,
+                            const phi::DenseTensor& src,
+                            const phi::DenseTensor& ln_scales,
+                            const phi::DenseTensor& qkv_weights,
+                            const phi::DenseTensor& rotary_embs,
+                            phi::DenseTensor* query_states,
+                            phi::DenseTensor* key_value_states,
+                            const phi::Scalar& epsilon,
+                            const phi::Scalar& head_dim,
+                            const phi::Scalar& num_head) {
+  std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
+  std::vector<int64_t> ln_scales_dims =
+      phi::vectorize<int64_t>(ln_scales.dims());
+  std::vector<int64_t> qkv_weights_dims =
+      phi::vectorize<int64_t>(qkv_weights.dims());
+  std::vector<int64_t> rotary_embs_dims =
+      phi::vectorize<int64_t>(rotary_embs.dims());
+
+  std::vector<int64_t> out_q_dim =
+      phi::vectorize<int64_t>(query_states->dims());
+  std::vector<int64_t> out_kv_dim =
+      phi::vectorize<int64_t>(key_value_states->dims());
+
+  std::vector<DIMS> inputs = {
+      src_dims, ln_scales_dims, qkv_weights_dims, rotary_embs_dims};
+  std::vector<DIMS> outputs = {out_q_dim, out_kv_dim};
+
+  int head_dim_ = head_dim.to<int>();
+  int num_head_ = num_head.to<int>();
+  // const int64_t bsz = src_dims[0];
+  // const int64_t seq_len = src_dims[1];
+  const int64_t fused_hidden_size = qkv_weights_dims[0];
+  // const int64_t hidden_size = qkv_weights_dims[1];
+  const int kv_num_head =
+      (fused_hidden_size - num_head_ * head_dim_) / head_dim_ / 2;
+  // const int num_groups = num_head_ / kv_num_head;
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_rms_qkv_rope_t_fwd_", {src_dims}, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedRmsQkvRopeParams params;
+    memset(
+        reinterpret_cast<void*>(&params), 0x00, sizeof(FusedRmsQkvRopeParams));
+    params.rmsnorm_params.epsValid = true;
+    params.rmsnorm_params.eps = epsilon.to<float>();
+    params.head_dim = head_dim_;
+    params.num_head = num_head_;
+    params.kv_num_head = kv_num_head;
+
+    FusedRmsQkvRopeT op(op_info.datatype_);
+    op.AddNode(inputs, outputs, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors;
+  tensors["src"] = reinterpret_cast<uint64_t>(src.data<T>());
+  tensors["ln_scales"] = reinterpret_cast<uint64_t>(ln_scales.data<T>());
+  tensors["qkv_weights"] = reinterpret_cast<uint64_t>(qkv_weights.data<T>());
+  tensors["rotary_embs"] = reinterpret_cast<uint64_t>(rotary_embs.data<T>());
+
+  tensors["query_states"] = reinterpret_cast<uint64_t>(query_states->data<T>());
+  tensors["key_value_states"] =
+      reinterpret_cast<uint64_t>(key_value_states->data<T>());
+
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedRmsQkvRopeKernelT(const Context& dev_ctx,
+                                const phi::DenseTensor& src,
+                                const phi::DenseTensor& ln_scales,
+                                const phi::DenseTensor& qkv_weights,
+                                const phi::DenseTensor& rotary_embs,
+                                phi::DenseTensor* query_states,
+                                phi::DenseTensor* key_value_states,
+                                const phi::Scalar& epsilon,
+                                const phi::Scalar& head_dim,
+                                const phi::Scalar& num_head) {
+  if (src.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedRmsQkvRopeKernelT<phi::dtype::float16>(dev_ctx,
+                                                               src,
+                                                               ln_scales,
+                                                               qkv_weights,
+                                                               rotary_embs,
+                                                               query_states,
+                                                               key_value_states,
+                                                               epsilon,
+                                                               head_dim,
+                                                               num_head);
+  } else if (src.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedRmsQkvRopeKernelT<phi::dtype::bfloat16>(
+        dev_ctx,
+        src,
+        ln_scales,
+        qkv_weights,
+        rotary_embs,
+        query_states,
+        key_value_states,
+        epsilon,
+        head_dim,
+        num_head);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedRmsQkvRopeKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedRmsQkvRopeT(const paddle::Tensor& src,
+                                             const paddle::Tensor& ln_scales,
+                                             const paddle::Tensor& qkv_weights,
+                                             const paddle::Tensor& rotary_embs,
+                                             float epsilon,
+                                             int head_dim,
+                                             int num_head) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
+  auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto ln_scales_tensor =
+      static_cast<const phi::DenseTensor*>(ln_scales.impl().get());
+  auto qkv_weights_tensor =
+      static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
+  auto rotary_embs_tensor =
+      static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
+
+  // allocate memory on device.
+  int64_t bsz = src.dims()[0];
+  int64_t seq_len = src.dims()[1];
+  int64_t fused_hidden_size = qkv_weights.dims()[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+
+  std::shared_ptr<phi::DenseTensor> query_states =
+      std::make_shared<phi::DenseTensor>();
+  query_states->Resize(phi::make_ddim({bsz, seq_len, num_head, head_dim}));
+  dev_ctx->Alloc(query_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> key_value_states =
+      std::make_shared<phi::DenseTensor>();
+  key_value_states->Resize(
+      phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
+  dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
+
+  CallFusedRmsQkvRopeKernelT(*dev_ctx,
+                             *src_tensor,
+                             *ln_scales_tensor,
+                             *qkv_weights_tensor,
+                             *rotary_embs_tensor,
+                             query_states.get(),
+                             key_value_states.get(),
+                             phi::Scalar(epsilon),
+                             phi::Scalar(head_dim),
+                             phi::Scalar(num_head));
+  return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
+}
+
+std::vector<std::vector<int64_t>> FusedRmsQkvRopeTShape(
+    const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& ln_scales_shape,
+    const std::vector<int64_t>& qkv_weights_shape,
+    const std::vector<int64_t>& rotary_embs_shape,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  int64_t bsz = src_shape[0];
+  int64_t seq_len = src_shape[1];
+  int64_t fused_hidden_size = qkv_weights_shape[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+  return {{bsz, seq_len, num_head, head_dim},
+          {2, bsz, seq_len, kv_num_head, head_dim}};
+}
+
+std::vector<paddle::DataType> FusedRmsQkvRopeTDtype(
+    const paddle::DataType& src_dtype,
+    const paddle::DataType& ln_scales_dtype,
+    const paddle::DataType& qkv_weights_dtype,
+    const paddle::DataType& rotary_embs_dtype) {
+  return {src_dtype, src_dtype};
+}
+
+PD_BUILD_OP(fused_rms_qkv_rope_t)
+    .Inputs({"src", "ln_scales", "qkv_weights", "rotary_embs"})
+    .Outputs({"query_states", "key_value_states"})
+    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .SetKernelFn(PD_KERNEL(FusedRmsQkvRopeT))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedRmsQkvRopeTShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedRmsQkvRopeTDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_sdpa_proj_t.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_sdpa_proj_t.cc
@@ -1,0 +1,511 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+class FusedSdpaProjBTMH : public HpuOperator {
+ public:
+  explicit FusedSdpaProjBTMH(synDataType dtype)
+      : HpuOperator("fused_sdpa_proj_", false), dtype_(dtype) {}
+
+  void AddNode(ConvertTensors& ct, ns_Sdpa::ParamsV2 params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    synStatus status = synFail;
+
+    std::string name_sdpa = guid_ + "sdpa";
+    std::string name_trans = guid_ + "transpose";
+    std::string name_reshape = guid_ + "reshape";
+    std::string name_gemm = guid_ + "gemm";
+
+    std::string guid_sdpa = "sdpa_recomp_fwd_";
+    std::string guid_reshape = "reshape";
+    std::string guid_trans = "transpose";
+    std::string guid_gemm = "gemm";
+
+    if (dtype_ == syn_type_fp16) {
+      guid_sdpa = guid_sdpa + "f16";
+    } else if (dtype_ == syn_type_bf16) {
+      guid_sdpa = guid_sdpa + "bf16";
+    }
+
+    std::vector<synTensor> kv_inputs;
+    kv_inputs.push_back(createTensor(inputs[1].dims.size(),
+                                     inputs[1].type,
+                                     inputs[1].dims,
+                                     true,
+                                     inputs[1].name));
+    auto k_v_dims = inputs[1].dims;
+    k_v_dims[0] = 1;
+
+    synSliceParamsV2 sliceParams;
+    for (uint64_t i = 0; i < k_v_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = k_v_dims[k_v_dims.size() - 1 - i];
+    }
+
+    std::string slice_guid = "slice";
+    std::string slice_name = guid_ + "slice";
+    std::string slice_name_k = slice_name + "_key";
+
+    std::vector<synTensor> k_slice;
+    auto k_split =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "k_split");
+    k_slice.push_back(k_split);
+
+    status = synNodeCreate(graphHandle_,
+                           kv_inputs.data(),
+                           k_slice.data(),
+                           kv_inputs.size(),
+                           k_slice.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_k.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/k) failed = ",
+        status);
+
+    std::vector<synTensor> v_slice;
+    auto v_split =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "v_split");
+    v_slice.push_back(v_split);
+    sliceParams.starts[k_v_dims.size() - 1] = 1;
+    sliceParams.ends[k_v_dims.size() - 1] = 2;
+    std::string slice_name_v = slice_name + "_value";
+    status = synNodeCreate(graphHandle_,
+                           kv_inputs.data(),
+                           v_slice.data(),
+                           kv_inputs.size(),
+                           v_slice.size(),
+                           &sliceParams,
+                           sizeof(sliceParams),
+                           slice_guid.c_str(),
+                           slice_name_v.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (slice/v) failed = ",
+        status);
+
+    synSqueezeParams squeezeParams;
+    squeezeParams.axis = 4;
+    std::string squeeze_guid = "squeeze";
+    std::string squeeze_name = guid_ + "squeeze";
+
+    k_v_dims.erase(k_v_dims.begin());
+
+    std::vector<synTensor> key_squeezed;
+    auto key_states =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "key_states");
+
+    key_squeezed.push_back(key_states);
+    std::string squeeze_name_key = squeeze_name + "_key";
+    status = synNodeCreate(graphHandle_,
+                           k_slice.data(),
+                           key_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_key.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (squeeze/key) failed = ",
+        status);
+
+    std::vector<synTensor> value_squeezed;
+    auto value_states =
+        createTensor(k_v_dims.size(), dtype_, k_v_dims, false, "value_states");
+    value_squeezed.push_back(value_states);
+    std::string squeeze_name_value = squeeze_name + "_value";
+    status = synNodeCreate(graphHandle_,
+                           v_slice.data(),
+                           value_squeezed.data(),
+                           1,
+                           1,
+                           &squeezeParams,
+                           sizeof(squeezeParams),
+                           squeeze_guid.c_str(),
+                           squeeze_name_value.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedRmsQkvRopeKernel synNodeCreate (squeeze/value) "
+             "failed = ",
+             status);
+
+    std::vector<int64_t> q_dims = std::vector<int64_t>(inputs[0].dims);
+    std::vector<int64_t> qt_dims(q_dims.cbegin(), q_dims.cend());
+    int rank = q_dims.size();
+    qt_dims[rank - 3] = q_dims[rank - 2];
+    qt_dims[rank - 2] = q_dims[rank - 3];
+
+    std::vector<int> axis = {0, 2, 1, 3};
+    synTransposeParams trans_params;
+    for (size_t i = 0; i < axis.size(); i++) {
+      trans_params.permutation[i] =
+          static_cast<TransposePermutationDim>(axis[i]);
+    }
+    trans_params.tensorDim = rank;
+
+    std::vector<synTensor> q_inputs;
+    q_inputs.push_back(createTensor(inputs[0].dims.size(),
+                                    inputs[0].type,
+                                    inputs[0].dims,
+                                    true,
+                                    inputs[0].name));
+
+    std::vector<synTensor> q_transpose;
+    auto q_t =
+        createTensor(qt_dims.size(), inputs[0].type, qt_dims, false, "q_t");
+    q_transpose.push_back(q_t);
+
+    status = synNodeCreate(graphHandle_,
+                           q_inputs.data(),
+                           q_transpose.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedSdpaProjKernel synNodeCreate (q_transpose) failed = ",
+        status);
+
+    std::vector<int64_t> kvt_dims(q_dims.cbegin(), q_dims.cend());
+    kvt_dims[rank - 3] = k_v_dims[rank - 2];
+    kvt_dims[rank - 2] = k_v_dims[rank - 3];
+
+    std::vector<synTensor> k_transpose;
+    auto k_t =
+        createTensor(kvt_dims.size(), inputs[0].type, kvt_dims, false, "k_t");
+    k_transpose.push_back(k_t);
+
+    status = synNodeCreate(graphHandle_,
+                           key_squeezed.data(),
+                           k_transpose.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedSdpaProjKernel synNodeCreate (k_transpose) failed = ",
+        status);
+
+    std::vector<synTensor> v_transpose;
+    auto v_t =
+        createTensor(kvt_dims.size(), inputs[0].type, kvt_dims, false, "v_t");
+    v_transpose.push_back(v_t);
+
+    status = synNodeCreate(graphHandle_,
+                           value_squeezed.data(),
+                           v_transpose.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedSdpaProjKernel synNodeCreate (v_transpose) failed = ",
+        status);
+
+    std::vector<synTensor> attn_inputs;
+    attn_inputs.push_back(q_t);
+    attn_inputs.push_back(k_t);
+    attn_inputs.push_back(v_t);
+    // params.is_causal = true; ==> input[3] is not used
+    // input[3] is in use ==> params.is_causal = false;
+    std::vector<synTensor> attn_outputs;
+    auto attn =
+        createTensor(qt_dims.size(), inputs[0].type, qt_dims, false, "attn");
+    attn_outputs.push_back(attn);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_inputs.data(),
+                           attn_outputs.data(),
+                           attn_inputs.size(),
+                           attn_outputs.size(),
+                           &params,
+                           sizeof(params),
+                           guid_sdpa.c_str(),
+                           name_sdpa.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (sdpa) failed = ",
+             status);
+
+    std::vector<synTensor> attn_out_transpose;
+    auto attn_t =
+        createTensor(q_dims.size(), inputs[0].type, q_dims, false, "attn_t");
+    attn_out_transpose.push_back(attn_t);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_outputs.data(),
+                           attn_out_transpose.data(),
+                           1,
+                           1,
+                           &trans_params,
+                           sizeof(trans_params),
+                           guid_trans.c_str(),
+                           name_trans.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(
+        status == synSuccess,
+        "[RUNTIME] FusedSdpaProjKernel synNodeCreate (transpose) failed = ",
+        status);
+
+    std::vector<int64_t> attn_reshape;
+    attn_reshape.push_back(q_dims[0]);
+    attn_reshape.push_back(q_dims[1]);
+    attn_reshape.push_back(q_dims[2] * q_dims[3]);
+
+    std::vector<synTensor> attn_out_reshape;
+    auto attn_r = createTensor(
+        attn_reshape.size(), inputs[0].type, attn_reshape, false, "attn_r");
+    attn_out_reshape.push_back(attn_r);
+
+    status = synNodeCreate(graphHandle_,
+                           attn_out_transpose.data(),
+                           attn_out_reshape.data(),
+                           1,
+                           1,
+                           nullptr,
+                           0,
+                           guid_reshape.c_str(),
+                           name_reshape.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (reshape) failed = ",
+             status);
+
+    std::vector<synTensor> mul_inputs;
+    mul_inputs.push_back(attn_r);
+    mul_inputs.push_back(createTensor(inputs[2].dims.size(),
+                                      inputs[2].type,
+                                      inputs[2].dims,
+                                      true,
+                                      inputs[2].name));
+    std::vector<synTensor> mul_outputs;
+    mul_outputs.push_back(createTensor(outputs[0].dims.size(),
+                                       outputs[0].type,
+                                       outputs[0].dims,
+                                       true,
+                                       outputs[0].name));
+    synGEMMParams gemm_params;
+    gemm_params.transpose_a = false;
+    gemm_params.transpose_b = false;
+    status = synNodeCreate(graphHandle_,
+                           mul_inputs.data(),
+                           mul_outputs.data(),
+                           2,
+                           1,
+                           &gemm_params,
+                           sizeof(gemm_params),
+                           guid_gemm.c_str(),
+                           name_gemm.c_str(),
+                           nullptr,
+                           nullptr);
+    PD_CHECK(status == synSuccess,
+             "[RUNTIME] FusedSdpaProjKernel synNodeCreate (matmul) failed = ",
+             status);
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedSdpaProjBTMHKernel(const Context& dev_ctx,
+                             const phi::DenseTensor& query_states,
+                             const phi::DenseTensor& key_value_states,
+                             const phi::DenseTensor& linear_weights,
+                             phi::DenseTensor* out_linear,
+                             const phi::Scalar& scaling_factor,
+                             const phi::Scalar& causal) {
+  ConvertTensors ct;
+  ct.Add(query_states);
+  ct.Add(key_value_states);
+  std::vector<DIMS> in_out_dims = ct.GetDims();
+
+  ct.Add(linear_weights);
+  ct.Add(out_linear, false);
+  std::vector<DIMS> out_dims = ct.GetDims(false);
+  in_out_dims.insert(in_out_dims.end(), out_dims.begin(), out_dims.end());
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_sdpa_proj_causal_fwd_", in_out_dims, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    ns_Sdpa::ParamsV2 params;
+    memset(reinterpret_cast<void*>(&params), 0x00, sizeof(ns_Sdpa::ParamsV2));
+    params.scale = scaling_factor.to<float>();
+    params.is_causal = causal.to<bool>();
+    params.dropout.ratio = 0.0;
+    params.dropout.disableMaskOut = false;
+    params.is_inference = true;
+    params.softmax_mode = SDPA_DEFAULT_SOFTMAX;
+
+    FusedSdpaProjBTMH op(op_info.datatype_);
+    op.AddNode(ct, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedSdpaProjBTMHKernel(const Context& dev_ctx,
+                                 const phi::DenseTensor& query_states,
+                                 const phi::DenseTensor& key_value_states,
+                                 const phi::DenseTensor& linear_weights,
+                                 phi::DenseTensor* out_linear,
+                                 const phi::Scalar& scaling_factor,
+                                 const phi::Scalar& causal) {
+  if (query_states.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedSdpaProjBTMHKernel<phi::dtype::float16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
+  } else if (query_states.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedSdpaProjBTMHKernel<phi::dtype::bfloat16>(
+        dev_ctx,
+        query_states,
+        key_value_states,
+        linear_weights,
+        out_linear,
+        scaling_factor,
+        causal);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedSdpaProjKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedSdpaProjBTMH(
+    const paddle::Tensor& query_states,
+    const paddle::Tensor& key_value_states,
+    const paddle::optional<paddle::Tensor>& attn_mask,
+    const paddle::optional<paddle::Tensor>& valid_seq_len,
+    const paddle::Tensor& linear_weights,
+    float scaling_factor,
+    bool causal = false) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(
+          query_states.place()));
+  auto query_states_tensor =
+      static_cast<const phi::DenseTensor*>(query_states.impl().get());
+  auto key_value_states_tensor =
+      static_cast<const phi::DenseTensor*>(key_value_states.impl().get());
+  auto linear_weights_tensor =
+      static_cast<const phi::DenseTensor*>(linear_weights.impl().get());
+
+  // allocate memory on device.
+  int64_t bsz = query_states.dims()[0];
+  int64_t seq_len = query_states.dims()[1];
+  int hidden_size = linear_weights.dims()[1];
+
+  std::shared_ptr<phi::DenseTensor> out_linear =
+      std::make_shared<phi::DenseTensor>();
+  out_linear->Resize(phi::make_ddim({bsz, seq_len, hidden_size}));
+  dev_ctx->Alloc(out_linear.get(), query_states_tensor->dtype());
+
+  if (!attn_mask && !valid_seq_len) {
+    CallFusedSdpaProjBTMHKernel(*dev_ctx,
+                                *query_states_tensor,
+                                *key_value_states_tensor,
+                                *linear_weights_tensor,
+                                out_linear.get(),
+                                phi::Scalar(scaling_factor),
+                                phi::Scalar(causal));
+  }
+  return {paddle::Tensor(out_linear)};
+}
+
+std::vector<std::vector<int64_t>> FusedSdpaProjBTMHShape(
+    const std::vector<int64_t>& query_states_shape,
+    const std::vector<int64_t>& key_value_states_shape,
+    const paddle::optional<std::vector<int64_t>>& attn_mask_shape,
+    const paddle::optional<std::vector<int64_t>>& valid_seq_len_shape,
+    const std::vector<int64_t>& linear_weights_shape) {
+  int64_t bsz = query_states_shape[0];
+  int64_t seq_len = query_states_shape[1];
+  int hidden_size = linear_weights_shape[1];
+  return {{bsz, seq_len, hidden_size}};
+}
+
+std::vector<paddle::DataType> FusedSdpaProjBTMHDtype(
+    const paddle::DataType& query_states_dtype,
+    const paddle::DataType& key_value_states_dtype,
+    const paddle::optional<paddle::DataType>& attn_mask_dtype,
+    const paddle::optional<paddle::DataType>& valid_seq_len_dtype,
+    const paddle::DataType& linear_weights_dtype) {
+  return {query_states_dtype};
+}
+
+PD_BUILD_OP(fused_sdpa_proj_t)
+    .Inputs({"query_states",
+             "key_value_states",
+             paddle::Optional("attn_mask"),
+             paddle::Optional("valid_seq_len"),
+             "linear_weights"})
+    .Outputs({"out_linear"})
+    .Attrs({"scaling_factor: float", "causal:bool"})
+    .SetKernelFn(PD_KERNEL(FusedSdpaProjBTMH))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedSdpaProjBTMHShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedSdpaProjBTMHDtype));

--- a/backends/intel_hpu/custom_ops/python/paddlenlp_ops/llama_block_atten.py
+++ b/backends/intel_hpu/custom_ops/python/paddlenlp_ops/llama_block_atten.py
@@ -94,18 +94,20 @@ def fused_flatpa_proj_ref(
     scaling_factor,
 ):
     batch_size = query.shape[0]
-    q_heads = query.shape[1]
+    q_heads = query.shape[2]
     head_size = query.shape[3]
-    kv_heads = key_cache.shape[1]
+    kv_heads = key_cache.shape[2]
     hidden_size = q_heads * head_size
 
     shape = tuple(query.shape)
-    query = paddle.matmul(
-        block_mapping, (scaling_factor * query).view([shape[0], -1])
-    ).view([-1, *shape[1:]])
+    query = (
+        paddle.matmul(block_mapping, (scaling_factor * query).view([shape[0], -1]))
+        .view([-1, *shape[2:]])
+        .unsqueeze(-2)
+    )
 
-    key = key_cache.index_select(block_list)
-    value = value_cache.index_select(block_list)
+    key = key_cache.index_select(block_list).transpose([0, 2, 1, 3])
+    value = value_cache.index_select(block_list).transpose([0, 2, 1, 3])
     block_bias = block_bias.unsqueeze(1).unsqueeze(1)
     if kv_heads != q_heads:
         block_bias = block_bias.unsqueeze(1)

--- a/backends/intel_hpu/custom_ops/tests/test_flatPA_proj.py
+++ b/backends/intel_hpu/custom_ops/tests/test_flatPA_proj.py
@@ -30,7 +30,7 @@ block_size = 64
 num_of_block = 12
 scaling_factor = head_dim**-0.5
 
-query = paddle.rand([batch_size, q_head, 1, head_dim], dtype=paddle.bfloat16)
+query = paddle.rand([batch_size, 1, q_head, head_dim], dtype=paddle.bfloat16)
 block_list = paddle.rand([num_of_block], dtype=paddle.int32)
 block_groups = paddle.rand([num_of_block], dtype=paddle.int32)
 block_mapping = paddle.rand([num_of_block, batch_size], dtype=paddle.bfloat16)
@@ -40,10 +40,10 @@ linear_weights = paddle.rand([hidden_size, hidden_size], dtype=paddle.bfloat16)
 
 def test_fused_flatpa_proj(kv_head, testcase):
     key_cache = paddle.rand(
-        [total_block_num, kv_head, block_size, head_dim], dtype=paddle.bfloat16
+        [total_block_num, block_size, kv_head, head_dim], dtype=paddle.bfloat16
     )
     value_cache = paddle.rand(
-        [total_block_num, kv_head, block_size, head_dim], dtype=paddle.bfloat16
+        [total_block_num, block_size, kv_head, head_dim], dtype=paddle.bfloat16
     )
 
     out_linear_ref = paddlenlp_ops.fused_flatpa_proj_ref(

--- a/backends/intel_hpu/custom_ops/tests/test_sdpa_proj.py
+++ b/backends/intel_hpu/custom_ops/tests/test_sdpa_proj.py
@@ -15,7 +15,10 @@
 import paddle
 import paddlenlp_ops
 
-paddle.device.set_device("intel_hpu")
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 1)
+paddle.device.set_device(f"intel_hpu:{intel_hpus_module_id}")
 
 paddle.seed(105)
 
@@ -51,21 +54,23 @@ num_head = 32
 kv_num_heads = num_head
 hidden_size = num_head * head_dim
 
-batch_size = 5
-seq_len = 1
-# seq_len = 25
-kv_seq_len = 25
+batch_size = 4
+seq_len = 16
+kv_seq_len = 16
 max_seq_length = 2048
 
+scaling_factor = head_dim**-0.5
+
 query_states = paddle.rand(
-    [batch_size, num_head, seq_len, head_dim], dtype=paddle.float32
+    [batch_size, seq_len, num_head, head_dim], dtype=paddle.float32
 ).to(paddle.bfloat16)
 key_states = paddle.rand(
-    [batch_size, kv_num_heads, kv_seq_len, head_dim], dtype=paddle.float32
+    [batch_size, kv_seq_len, kv_num_heads, head_dim], dtype=paddle.float32
 ).to(paddle.bfloat16)
 value_states = paddle.rand(
-    [batch_size, kv_num_heads, kv_seq_len, head_dim], dtype=paddle.float32
+    [batch_size, kv_seq_len, kv_num_heads, head_dim], dtype=paddle.float32
 ).to(paddle.bfloat16)
+key_value_states = paddle.stack([key_states, value_states], axis=0)
 
 attn_mask = paddle.ones([1, 1, max_seq_length, max_seq_length], dtype=paddle.bfloat16)
 attn_mask = paddle.tril(attn_mask)
@@ -81,26 +86,61 @@ def main():
     attention_mask = attention_mask.astype(query_states.dtype)
 
     out_linear_out_op = paddlenlp_ops.fused_sdpa_proj(
-        query_states,
-        key_states,
-        value_states,
-        attention_mask,
-        linear_weights,
-        scaling_factor=head_dim**-0.5,
-    )
-
-    out_linear_out_ref = ref_result(
         query_states.transpose([0, 2, 1, 3]),
         key_states.transpose([0, 2, 1, 3]),
         value_states.transpose([0, 2, 1, 3]),
         attention_mask,
         linear_weights,
-        scaling_factor=head_dim**-0.5,
+        scaling_factor,
     )
 
-    print(out_linear_out_ref)
-    print(out_linear_out_op)
-    print((out_linear_out_op == out_linear_out_ref).all())
+    out_linear_v2_op_mask = paddlenlp_ops.fused_sdpa_proj_v2(
+        query_states.transpose([0, 2, 1, 3]),
+        key_value_states.transpose([0, 1, 3, 2, 4]),
+        attention_mask,
+        linear_weights,
+        scaling_factor,
+        causal=False,
+    )
+
+    out_linear_v2_op_causal = paddlenlp_ops.fused_sdpa_proj_v2(
+        query_states.transpose([0, 2, 1, 3]),
+        key_value_states.transpose([0, 1, 3, 2, 4]),
+        None,
+        linear_weights,
+        scaling_factor,
+        causal=True,
+    )
+
+    out_linear_t_op = paddlenlp_ops.fused_sdpa_proj_t(
+        query_states,
+        key_value_states,
+        None,
+        None,
+        linear_weights,
+        scaling_factor,
+        causal=True,
+    )
+
+    out_linear_out_ref = ref_result(
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        linear_weights,
+        scaling_factor,
+    )
+
+    print((out_linear_out_ref == out_linear_out_op).all())
+    print((out_linear_out_ref == out_linear_v2_op_mask).all())
+    print((out_linear_v2_op_causal == out_linear_t_op).all())
+    print(
+        paddle.allclose(
+            out_linear_out_ref.to("cpu").to("float32"),
+            out_linear_t_op.to("cpu").to("float32"),
+            rtol=1e-2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/backends/intel_hpu/kernels/hpu_funcs.h
+++ b/backends/intel_hpu/kernels/hpu_funcs.h
@@ -207,6 +207,14 @@ class HpuFusedOperator : public HpuOperator {
     AddNode_IO(inputs, outputs, "reshape", node_name);
   }
 
+  inline void AddNodeTranspose(std::vector<synTensor> inputs,
+                               std::vector<synTensor> outputs,
+                               synTransposeParams params,
+                               std::string node_name) {
+    AddNode_IOP<synTransposeParams>(
+        inputs, outputs, params, "transpose", node_name);
+  }
+
   inline void AddNodeBatchGemm(std::vector<synTensor> inputs,
                                std::vector<synTensor> outputs,
                                synGEMMParams params,


### PR DESCRIPTION
Add new custom OPs to fit KV_cache in shape of [batch_size, seq_len, head_num, head_dim] for Intel HPU block multi attention.
Affected OP list:
1. fused_rms_qkv_rope: to form QKV in shape of BTMH 
2. fused_sdpa_proj: do prefill with QKV shape of BTMH
3. fused_flatpa_proj: do decoding with KV of shape BTMH
4. llama_block_atten.py reference code with shape of BTMH
Add new test cases with new interface

Legacy BMTH shaped OPs are not affected for non-block attention scenarios.