### PR TITLE
[GCU] fix custom_engine compiler

### DIFF
--- a/backends/gcu/custom_engine/gcu_engine_compiler.cc
+++ b/backends/gcu/custom_engine/gcu_engine_compiler.cc
@@ -364,11 +364,11 @@ void GCUEngineCompiler::GCUEngineCompilerImpl::SetGraphOutputs() {
             inner_value_name.c_str()));
     graph_outputs.emplace_back(*(gcu_op_cache_.at(tensor)));
 
+    *(outputs_[i]) = *tensor;
     // set output shapes
     auto gcu_shape = gcu_op_cache_.at(tensor)->GetType().GetShape();
     tensor->Resize(common::make_ddim(gcu_shape));
     outputs_[i]->Resize(common::make_ddim(gcu_shape));
-    // *(outputs_[i]) = *tensor;
     VLOG(6) << "Found gcu builder output[" << i << "]: " << inner_value_name
             << ", external var name:" << external_value_name
             << ", dims:" << tensor->dims();


### PR DESCRIPTION
修复custom_engine用例失败问题，执行结果：
```bash
I0411 15:08:28.726022 771932 analysis_predictor.cc:1207] ======= pir optimization completed =======
TestPPOCRCls setUp: /usr/local/lib/python3.10/dist-packages/paddle_custom_device
======= Run PPOCRCls successfully =======
TestPPOCRCls custom_engine, steps: 100, avg cost: 1.9835400581359863ms, fps: 504.14913270757984.
TestPPOCRCls AOT, steps: 100, avg cost: 4.370512962341309ms, fps: 228.8060940710022.
The FPS improvement rate of custom_engine compared to AOT is: 220.34%.
=========================================
.
----------------------------------------------------------------------
Ran 1 test in 336.223s

OK
I0411 15:08:29.264765 771932 runtime.cc:149] Backend GCU finalize device:0
I0411 15:08:29.264783 771932 runtime.cc:101] Backend GCU Finalize
```