### PR TITLE
[NPU] Add full with tensor for npu

### DIFF
--- a/backends/npu/kernels/full_kernel.cc
+++ b/backends/npu/kernels/full_kernel.cc
@@ -176,6 +176,17 @@ void FullBatchSizeLikeKernel(const Context& dev_ctx,
   custom_kernel::FullLikeKernel<T, Context>(dev_ctx, x, val, dtype, out);
 }
 
+template <typename T, typename Context>
+void FullWithTensorKernel(const Context& dev_ctx,
+                          const phi::DenseTensor& value,
+                          const phi::IntArray& shape,
+                          phi::DataType dtype,
+                          phi::DenseTensor* out) {
+  out->Resize(common::make_ddim(shape.GetData()));
+  custom_kernel::FullKernel<T, Context>(
+      dev_ctx, shape, phi::Scalar(value), dtype, out);
+}
+
 }  // namespace custom_kernel
 
 PD_REGISTER_PLUGIN_KERNEL(full,
@@ -209,6 +220,20 @@ PD_REGISTER_PLUGIN_KERNEL(full_batch_size_like,
                           custom_kernel::FullBatchSizeLikeKernel,
                           int,
                           float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {
+  kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
+}
+
+PD_REGISTER_PLUGIN_KERNEL(full_with_tensor,
+                          npu,
+                          ALL_LAYOUT,
+                          custom_kernel::FullWithTensorKernel,
+                          bool,
+                          int,
+                          int64_t,
+                          float,
+                          double,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -23,6 +23,7 @@
 #include "kernels/funcs/format_utils.h"
 #include "kernels/funcs/npu_op_prepare.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/extension.h"
 #include "paddle/utils/blank.h"
 #include "paddle/utils/variant.h"
@@ -206,6 +207,18 @@ inline aclScalar* ConvertType(const phi::Scalar& at_scalar) {
   aclDataType acl_data_type = ConvertToNpuDtype(scalar_data_type);
   aclScalar* acl_scalar = nullptr;
   switch (scalar_data_type) {
+    case phi::DataType::FLOAT16: {
+      float value_f32 = at_scalar.to<float>();
+      phi::float16 value_f16 = phi::float16(value_f32);
+      acl_scalar = aclCreateScalar(&value_f16.x, acl_data_type);
+      break;
+    }
+    case phi::DataType::BFLOAT16: {
+      float value_f32 = at_scalar.to<float>();
+      phi::bfloat16 value_bf16 = phi::bfloat16(value_f32);
+      acl_scalar = aclCreateScalar(&value_bf16.x, acl_data_type);
+      break;
+    }
     case phi::DataType::FLOAT32: {
       float value = at_scalar.to<float>();
       acl_scalar = aclCreateScalar(&value, acl_data_type);

--- a/backends/npu/kernels/layer_norm_kernel.cc
+++ b/backends/npu/kernels/layer_norm_kernel.cc
@@ -61,11 +61,6 @@ void CastKernel(const Context& dev_ctx,
                 phi::DenseTensor* out);
 
 template <typename T, typename Context>
-void FillKernel(const Context& dev_ctx,
-                const phi::DenseTensor& x,
-                const phi::Scalar& val);
-
-template <typename T, typename Context>
 void AclopLayerNormNPUKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& x,
@@ -332,7 +327,6 @@ void AclnnLayerNormNPUKernel(
           .AddInput(value)
           .AddOutput(default_bias);
       runner.Run(stream);
-      // custom_kernel::FillKernel<T, Context>(dev_ctx, default_bias, value);
 
     } else {
       // CANN op Fill/FillD would raise error when output's numel is 1.

--- a/backends/npu/kernels/scale_kernel.cc
+++ b/backends/npu/kernels/scale_kernel.cc
@@ -23,11 +23,6 @@ void CastKernel(const Context& dev_ctx,
                 phi::DenseTensor* out);
 
 template <typename T, typename Context>
-void FillKernel(const Context& dev_ctx,
-                const phi::DenseTensor& x,
-                const phi::Scalar& val);
-
-template <typename T, typename Context>
 void AclopScaleKernel(const Context& dev_ctx,
                       const phi::DenseTensor& x,
                       const phi::Scalar& in_scale,

--- a/backends/npu/tests/unittests/test_full_with_tensor_op_on_npu.py
+++ b/backends/npu/tests/unittests/test_full_with_tensor_op_on_npu.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import paddle
+import numpy as np
+from tests.op_test import convert_uint16_to_float
+
+
+class TestFullWithTensor(unittest.TestCase):
+    def setUp(self):
+        self.dtypes = [
+            "bool",
+            "int32",
+            "int64",
+            "float32",
+            "float64",
+            "float16",
+            "bfloat16",
+        ]
+        self.shape = [5, 6]
+        self.place = paddle.CustomPlace("npu", 3)
+        self.value = 2
+
+    def get_expected_output(self, dtype):
+        dtype = dtype if dtype != "bfloat16" else "float32"
+        return np.full(self.shape, 2, dtype=dtype)
+
+    def test_static(self):
+        paddle.enable_static()
+        shapes = [
+            self.shape,
+            tuple(self.shape),
+            [paddle.to_tensor(shape_i) for shape_i in self.shape],
+            paddle.to_tensor(self.shape),
+        ]
+        for dtype in self.dtypes:
+            for shape in shapes:
+                out = paddle.full(
+                    shape=shape,
+                    fill_value=paddle.to_tensor(self.value, dtype=dtype),
+                    dtype=dtype,
+                )
+                exe = paddle.static.Executor(self.place)
+                exe.run(paddle.static.default_startup_program())
+                out_actual = exe.run(
+                    paddle.static.default_main_program(), feed={}, fetch_list=[out]
+                )[0]
+
+                if dtype == "bfloat16":
+                    out_actual = convert_uint16_to_float(out_actual)
+                out_expected = self.get_expected_output(dtype)
+                np.testing.assert_allclose(out_actual, out_expected)
+
+    def test_python_api(self):
+        paddle.disable_static()
+        shapes = [
+            self.shape,
+            tuple(self.shape),
+            [paddle.to_tensor(shape_i) for shape_i in self.shape],
+            paddle.to_tensor(self.shape),
+        ]
+        for dtype in self.dtypes:
+            for shape in shapes:
+                out = paddle.full(
+                    shape=shape,
+                    fill_value=paddle.to_tensor(self.value, dtype=dtype),
+                    dtype=dtype,
+                )
+                out_actual = (
+                    convert_uint16_to_float(out.numpy())
+                    if dtype == "bfloat16"
+                    else out.numpy()
+                )
+                out_expected = self.get_expected_output(dtype)
+                np.testing.assert_allclose(out_actual, out_expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 为 NPU 添加 full_with_tensor Kernel
1. 添加 full_with_tensor 及其单测
2. 添加 paddle::phi::float16 & bf16 转换为host type 和 acl type的逻辑