### PR TITLE
[INTEL_HPU] move out gather UT from unstable test suites

### DIFF
--- a/backends/intel_hpu/tests/config.py
+++ b/backends/intel_hpu/tests/config.py
@@ -20,5 +20,4 @@ skip_case_lst = {}
 # this list for the unstable test case to skip
 skip_case_lst = [
     "test_cast.py",
-    "test_gather.py",
 ]


### PR DESCRIPTION
test_gather is stable, it can be included into stable test suites and can be included in PR test suites
after this step, test_gather will be called by PR testing