### PR TITLE
[INTEL_HPU] support fp8 version of fused_rms_qkv_rope_t

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_fp8_rms_qkv_rope_t.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_fp8_rms_qkv_rope_t.cc
@@ -1,0 +1,439 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+struct FusedFp8RmsQkvRopeParams {
+  ns_LayerNormKernel::Params rmsnorm_params;
+
+  int head_dim;
+  int num_head;
+  int kv_num_head;
+  float scale;
+};
+
+class FusedFp8RmsQkvRopeT : public HpuFusedOperator {
+ public:
+  explicit FusedFp8RmsQkvRopeT(synDataType dtype)
+      : HpuFusedOperator("fused_fp8_rms_qkv_rope_t_fwd_"), dtype_(dtype) {}
+  template <typename T>
+  void AddNode(ConvertTensors& ct, FusedFp8RmsQkvRopeParams& params) {
+    auto ins = ct.GetTensors();
+    auto outs = ct.GetTensors(false);
+
+    synSectionHandle section = createSection();
+    auto src = createTensorFromCT(&ct, 0);
+    auto residual = createTensorFromCT(&ct, 4, true, section);
+    auto residual_out = createTensorFromCT(&ct, 2, false, section);
+
+    std::vector<synTensor> add_residual_in;
+    add_residual_in.push_back(src);
+    add_residual_in.push_back(residual);
+
+    std::vector<synTensor> add_residual_out;
+    add_residual_out.push_back(residual_out);
+
+    AddNodeAdd<T>(add_residual_in, add_residual_out, guid_ + "add_residual");
+
+    auto ln_scales = createTensorFromCT(&ct, 1);
+
+    std::vector<synTensor> rmsnorm_inputs;
+    rmsnorm_inputs.push_back(residual_out);
+    rmsnorm_inputs.push_back(ln_scales);
+
+    auto tmp_dims = ins[0].dims;
+    tmp_dims[2] = 1;
+    auto norm_out = createTensorNoPresist("norm_out", dtype_, ins[0].dims);
+    auto norm_var = createTensorNoPresist("norm_var", dtype_, tmp_dims);
+
+    std::vector<synTensor> rmsnorm_outputs;
+    rmsnorm_outputs.push_back(norm_out);
+    rmsnorm_outputs.push_back(norm_var);
+
+    AddNodeRmsNorm<T>(rmsnorm_inputs,
+                      rmsnorm_outputs,
+                      params.rmsnorm_params,
+                      guid_ + "rmsnorm");
+
+    // cast norm_out to fp8
+    PD_CHECK(ins[2].type == syn_type_fp8_143,
+             "[RUNTIME] input tensor qkv_weights dtype is not fp8_e4m3fn");
+
+    ns_CastKernel::Params cast_to_fp8_params;
+    cast_to_fp8_params.round_mode = CAST_ROUND_HALF_NE;
+    auto norm_out_fp8 =
+        createTensorNoPresist("norm_out_fp8", ins[2].type, ins[0].dims);
+    std::vector<synTensor> convert_to_fp8_inputs;
+    convert_to_fp8_inputs.push_back(norm_out);
+    std::vector<synTensor> convert_to_fp8_outputs;
+    convert_to_fp8_outputs.push_back(norm_out_fp8);
+
+    AddNodeConvertToFP8<T>(convert_to_fp8_inputs,
+                           convert_to_fp8_outputs,
+                           cast_to_fp8_params,
+                           guid_ + "convert_to_fp8");
+
+    // add scale values
+    ns_ConstantKernel::Params const_params;
+    const_params.constant.f = 1.0;
+    std::vector<int64_t> scale_dims = {1};
+    auto scale_one =
+        createTensorNoPresist("scale_one", syn_type_float, scale_dims);
+    std::vector<synTensor> scale_one_outputs;
+    scale_one_outputs.push_back(scale_one);
+    AddNodeFull<float>(scale_one_outputs, const_params, guid_ + "scale_one");
+
+    const_params.constant.f = params.scale;
+    auto scale_weight =
+        createTensorNoPresist("scale_weight", syn_type_float, scale_dims);
+    std::vector<synTensor> scale_weight_outputs;
+    scale_weight_outputs.push_back(scale_weight);
+    AddNodeFull<float>(
+        scale_weight_outputs, const_params, guid_ + "scale_weight");
+
+    // add fp8_gemm node
+    auto qkv_weights = createTensorFromCT(&ct, 2);
+    std::vector<synTensor> mul_inputs;
+    mul_inputs.push_back(norm_out_fp8);
+    mul_inputs.push_back(qkv_weights);
+    mul_inputs.push_back(scale_one);
+    mul_inputs.push_back(scale_weight);
+
+    auto wt_dims = ins[2].dims;
+    tmp_dims[2] = wt_dims[0];
+
+    auto qkv_out = createTensorNoPresist("qkv_out", dtype_, tmp_dims);
+    std::vector<synTensor> mul_outputs;
+    mul_outputs.push_back(qkv_out);
+
+    synGEMMParams gemm_params;
+    gemm_params.transpose_a = false;
+    gemm_params.transpose_b = true;
+    AddNodeFP8Gemm<T>(mul_inputs, mul_outputs, gemm_params, guid_ + "fp8_gemm");
+
+    auto reshape_dims = ins[0].dims;
+    reshape_dims[2] = params.num_head + 2 * params.kv_num_head;
+    reshape_dims.push_back(params.head_dim);
+
+    std::vector<synTensor> reshape_outputs;
+    auto reshape_out =
+        createTensorNoPresist("reshape_out", dtype_, reshape_dims);
+    reshape_outputs.push_back(reshape_out);
+
+    AddNodeReshape(mul_outputs, reshape_outputs, guid_ + "reshape_qkv");
+
+    auto kv_dims = outs[1].dims;
+    kv_dims.erase(kv_dims.begin());
+    auto q_split = createTensorNoPresist("q_split", dtype_, outs[0].dims);
+    auto k_split = createTensorNoPresist("k_split", dtype_, kv_dims);
+    auto v_split = createTensorNoPresist("v_split", dtype_, kv_dims);
+    std::vector<synTensor> split_outpus;
+    split_outpus.push_back(q_split);
+    split_outpus.push_back(k_split);
+    split_outpus.push_back(v_split);
+
+    synSplitParams splitParams;
+    splitParams.axis = 1;
+    AddNodeSplit(reshape_outputs, split_outpus, splitParams, guid_ + "split");
+
+    std::vector<synTensor> rotary_embs_inputs;
+    auto rotary_embs_c = createTensorFromCT(&ct, 3);
+    rotary_embs_inputs.push_back(rotary_embs_c);
+
+    auto rotary_embs_dims = ins[3].dims;
+    rotary_embs_dims[0] = 1;
+
+    std::vector<synTensor> cos_inputs;
+    auto cos_in = createTensorNoPresist("cos_in", dtype_, rotary_embs_dims);
+    cos_inputs.push_back(cos_in);
+
+    synSliceParamsV2 sliceParams;
+    for (uint64_t i = 0; i < rotary_embs_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = rotary_embs_dims[rotary_embs_dims.size() - 1 - i];
+    }
+    AddNodeSlice(
+        rotary_embs_inputs, cos_inputs, sliceParams, guid_ + "slice_cos");
+
+    std::vector<synTensor> sin_inputs;
+    auto sin_in = createTensorNoPresist("sin_in", dtype_, rotary_embs_dims);
+    sin_inputs.push_back(sin_in);
+    sliceParams.starts[rotary_embs_dims.size() - 1] = 1;
+    sliceParams.ends[rotary_embs_dims.size() - 1] = 2;
+    AddNodeSlice(
+        rotary_embs_inputs, sin_inputs, sliceParams, guid_ + "slice_sin");
+
+    rotary_embs_dims.erase(rotary_embs_dims.begin());
+    auto sin_sq =
+        createTensorNoPresist("sin_squeezed", dtype_, rotary_embs_dims);
+    std::vector<synTensor> sin_squeezed;
+    sin_squeezed.push_back(sin_sq);
+
+    synSqueezeParams squeezeParams;
+    squeezeParams.axis = 4;
+    AddNodeSqueeze(
+        sin_inputs, sin_squeezed, squeezeParams, guid_ + "squeeze_sin");
+
+    auto cos_sq =
+        createTensorNoPresist("cos_squeezed", dtype_, rotary_embs_dims);
+    std::vector<synTensor> cos_squeezed;
+    cos_squeezed.push_back(cos_sq);
+    AddNodeSqueeze(
+        cos_inputs, cos_squeezed, squeezeParams, guid_ + "squeeze_cos");
+
+    std::vector<synTensor> inputs_q;
+    std::vector<synTensor> outputs_q;
+    inputs_q.push_back(q_split);
+    inputs_q.push_back(sin_sq);
+    inputs_q.push_back(cos_sq);
+
+    auto q_states = createTensorFromCT(&ct, 0, false);
+    outputs_q.push_back(q_states);
+
+    ns_RoPESt2::ParamsV2 ropeParams;
+    ropeParams.offset = 0;
+    ropeParams.mode = ROTARY_POS_EMBEDDING_MODE_BLOCKWISE;
+    AddNodeRope<T>(inputs_q, outputs_q, ropeParams, guid_ + "rope_q");
+
+    std::vector<synTensor> inputs_k;
+    std::vector<synTensor> outputs_k;
+    inputs_k.push_back(k_split);
+    inputs_k.push_back(sin_sq);
+    inputs_k.push_back(cos_sq);
+
+    auto k_rope = createTensorNoPresist("k_rope", dtype_, kv_dims);
+    outputs_k.push_back(k_rope);
+    AddNodeRope<T>(inputs_k, outputs_k, ropeParams, guid_ + "rope_k");
+
+    std::vector<synTensor> inputs_concat;
+    std::vector<synTensor> outputs_concat;
+    inputs_concat.push_back(k_rope);
+    inputs_concat.push_back(v_split);
+
+    kv_dims[0] *= 2;
+    auto kv_concat = createTensorNoPresist("kv_concat", dtype_, kv_dims);
+    outputs_concat.push_back(kv_concat);
+
+    synConcatenateParams concatParams;
+    concatParams.axis = 3;
+    AddNodeConcat(
+        inputs_concat, outputs_concat, concatParams, guid_ + "concat");
+
+    std::vector<synTensor> outputs_stack;
+
+    auto kv_state = createTensorFromCT(&ct, 1, false);
+    outputs_stack.push_back(kv_state);
+
+    AddNodeReshape(outputs_concat, outputs_stack, guid_ + "reshaped_kv");
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedFp8RmsQkvRopeTKernel(const Context& dev_ctx,
+                               const phi::DenseTensor& src,
+                               const phi::DenseTensor& residual,
+                               const phi::DenseTensor& ln_scales,
+                               const phi::DenseTensor& qkv_weights,
+                               const phi::DenseTensor& rotary_embs,
+                               phi::DenseTensor* query_states,
+                               phi::DenseTensor* key_value_states,
+                               const phi::Scalar& epsilon,
+                               const phi::Scalar& head_dim,
+                               const phi::Scalar& num_head,
+                               float scale) {
+  std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
+  std::vector<int64_t> qkv_weights_dims =
+      phi::vectorize<int64_t>(qkv_weights.dims());
+
+  int head_dim_ = head_dim.to<int>();
+  int num_head_ = num_head.to<int>();
+  const int64_t fused_hidden_size = qkv_weights_dims[0];
+  const int kv_num_head =
+      (fused_hidden_size - num_head_ * head_dim_) / head_dim_ / 2;
+
+  ConvertTensors ct;
+  ct.Add(src);
+  ct.Add(ln_scales);
+  ct.Add(qkv_weights);
+  ct.Add(rotary_embs);
+  ct.Add(residual);
+  ct.Add(query_states, false);
+  ct.Add(key_value_states, false);
+  ct.Add(residual, false);
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      "fused_fp8_rms_qkv_rope_t_fwd_", {src_dims}, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedFp8RmsQkvRopeParams params;
+    memset(reinterpret_cast<void*>(&params),
+           0x00,
+           sizeof(FusedFp8RmsQkvRopeParams));
+    params.rmsnorm_params.epsValid = true;
+    params.rmsnorm_params.eps = epsilon.to<float>();
+    params.head_dim = head_dim_;
+    params.num_head = num_head_;
+    params.kv_num_head = kv_num_head;
+    params.scale = scale;
+
+    FusedFp8RmsQkvRopeT op(op_info.datatype_);
+    op.AddNode<T>(ct, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedFp8RmsQkvRopeTKernel(const Context& dev_ctx,
+                                   const phi::DenseTensor& src,
+                                   const phi::DenseTensor& residual,
+                                   const phi::DenseTensor& ln_scales,
+                                   const phi::DenseTensor& qkv_weights,
+                                   const phi::DenseTensor& rotary_embs,
+                                   phi::DenseTensor* query_states,
+                                   phi::DenseTensor* key_value_states,
+                                   const phi::Scalar& epsilon,
+                                   const phi::Scalar& head_dim,
+                                   const phi::Scalar& num_head,
+                                   float scale) {
+  if (src.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedFp8RmsQkvRopeTKernel<phi::dtype::bfloat16>(
+        dev_ctx,
+        src,
+        residual,
+        ln_scales,
+        qkv_weights,
+        rotary_embs,
+        query_states,
+        key_value_states,
+        epsilon,
+        head_dim,
+        num_head,
+        scale);
+  } else {
+    throw std::runtime_error(
+        "Unsupported data type for FusedFp8RmsQkvRopeTKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedFp8RmsQkvRopeT(
+    const paddle::Tensor& src,
+    const paddle::Tensor& ln_scales,
+    const paddle::Tensor& qkv_weights,
+    const paddle::Tensor& rotary_embs,
+    const paddle::Tensor& residual,
+    float epsilon,
+    int head_dim,
+    int num_head,
+    float scale) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
+  auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto ln_scales_tensor =
+      static_cast<const phi::DenseTensor*>(ln_scales.impl().get());
+  auto qkv_weights_tensor =
+      static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
+  auto rotary_embs_tensor =
+      static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
+  auto residual_tensor =
+      static_cast<const phi::DenseTensor*>(residual.impl().get());
+
+  // allocate memory on device.
+  int64_t bsz = src.dims()[0];
+  int64_t seq_len = src.dims()[1];
+  int64_t fused_hidden_size = qkv_weights.dims()[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+
+  std::shared_ptr<phi::DenseTensor> query_states =
+      std::make_shared<phi::DenseTensor>();
+  query_states->Resize(phi::make_ddim({bsz, seq_len, num_head, head_dim}));
+  dev_ctx->Alloc(query_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> key_value_states =
+      std::make_shared<phi::DenseTensor>();
+  key_value_states->Resize(
+      phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
+  dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
+
+  CallFusedFp8RmsQkvRopeTKernel(*dev_ctx,
+                                *src_tensor,
+                                *residual_tensor,
+                                *ln_scales_tensor,
+                                *qkv_weights_tensor,
+                                *rotary_embs_tensor,
+                                query_states.get(),
+                                key_value_states.get(),
+                                phi::Scalar(epsilon),
+                                phi::Scalar(head_dim),
+                                phi::Scalar(num_head),
+                                scale);
+  return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
+}
+
+std::vector<std::vector<int64_t>> FusedFp8RmsQkvRopeTShape(
+    const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& ln_scales_shape,
+    const std::vector<int64_t>& qkv_weights_shape,
+    const std::vector<int64_t>& rotary_embs_shape,
+    const std::vector<int64_t>& residual_shape,
+    float epsilon,
+    int head_dim,
+    int num_head,
+    float scale) {
+  int64_t bsz = src_shape[0];
+  int64_t seq_len = src_shape[1];
+  int64_t fused_hidden_size = qkv_weights_shape[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+  return {{bsz, seq_len, num_head, head_dim},
+          {2, bsz, seq_len, kv_num_head, head_dim}};
+}
+
+std::vector<paddle::DataType> FusedFp8RmsQkvRopeTDtype(
+    const paddle::DataType& src_dtype,
+    const paddle::DataType& ln_scales_dtype,
+    const paddle::DataType& qkv_weights_dtype,
+    const paddle::DataType& rotary_embs_dtype,
+    const paddle::DataType& residual_dtype) {
+  return {src_dtype, src_dtype};
+}
+
+PD_BUILD_OP(fused_fp8_rms_qkv_rope_t)
+    .Inputs({"src", "ln_scales", "qkv_weights", "rotary_embs", "residual"})
+    .Outputs({"query_states", "key_value_states"})
+    .Attrs({"epsilon: float", "head_dim: int", "num_head: int", "scale: float"})
+    .SetKernelFn(PD_KERNEL(FusedFp8RmsQkvRopeT))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFp8RmsQkvRopeTShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFp8RmsQkvRopeTDtype));

--- a/backends/intel_hpu/custom_ops/tests/test_fused_fp8_rms_qkv_rope_t.py
+++ b/backends/intel_hpu/custom_ops/tests/test_fused_fp8_rms_qkv_rope_t.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddlenlp_ops
+
+import os
+
+intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 0)
+
+paddle.seed(2025)
+
+
+class TestFusedFp8RmsQkvRopeT(unittest.TestCase):
+    def __init__(self):
+        self.head_dim = 128
+        self.num_head = 32
+        self.kv_num_heads = 32
+        self.hidden_size = 4096
+
+        self.epsilon = 1e-06
+
+        self.use_neox = True
+        self.position_offset = 0
+        self.rope_theta = 10000
+
+        self.init_block_prefill_params()
+        self.create_tensors()
+
+    def init_block_prefill_params(self):
+        self.batch_size = 1
+        self.seq_len = 34
+        position_id = paddle.arange(self.seq_len, dtype=paddle.int64).to(paddle.int64)
+        self.position_ids = paddle.expand(
+            position_id, shape=[self.batch_size, self.seq_len]
+        )
+
+    def create_tensors(self):
+        self.input_ids = paddle.zeros(
+            [self.batch_size, self.seq_len], dtype=paddle.bfloat16
+        )
+        self.src = (
+            240
+            * paddle.rand(
+                [self.batch_size, self.seq_len, self.hidden_size], dtype=paddle.float32
+            )
+        ).to(paddle.bfloat16)
+        self.residual = paddle.zeros_like(self.src, dtype=paddle.bfloat16)
+
+        self.ln_scales = paddle.rand([self.hidden_size], dtype=paddle.bfloat16)
+        self.qkv_weights = (
+            240
+            * paddle.rand(
+                [self.hidden_size * 3, self.hidden_size], dtype=paddle.float32
+            )
+        ).to(paddle.bfloat16)
+        self.head_dim_shape_tensor = paddle.ones(self.head_dim, dtype="int8")
+
+        self.new_rope = paddlenlp_ops.fused_get_rotary_embedding(
+            self.input_ids,
+            self.position_ids,
+            self.head_dim_shape_tensor,
+            self.position_offset,
+            self.rope_theta,
+            self.use_neox,
+        ).to(paddle.bfloat16)
+
+    def get_similarity(self, x, y):
+        x = x.cpu().to("float32")
+        y = y.cpu().to("float32")
+        return paddle.nn.functional.cosine_similarity(
+            x.flatten(), y.flatten(), axis=0
+        ).item()
+
+    def check_result(self):
+        ref_query_states, ref_key_value_states = paddlenlp_ops.fused_rms_qkv_rope_t(
+            self.src,
+            self.ln_scales,
+            self.qkv_weights,
+            self.new_rope.transpose([0, 1, 3, 2, 4]),
+            self.residual,
+            self.epsilon,
+            self.head_dim,
+            self.num_head,
+        )
+
+        qkv_weights_fp8 = self.qkv_weights.to(paddle.float8_e4m3fn)
+        query_states, key_value_states = paddlenlp_ops.fused_fp8_rms_qkv_rope_t(
+            self.src,
+            self.ln_scales,
+            qkv_weights_fp8,
+            self.new_rope.transpose([0, 1, 3, 2, 4]),
+            self.residual,
+            self.epsilon,
+            self.head_dim,
+            self.num_head,
+            1.0,
+        )
+
+        similarity_query = self.get_similarity(ref_query_states, query_states)
+        similarity_key_value = self.get_similarity(
+            ref_key_value_states, key_value_states
+        )
+
+        assert not paddle.any(paddle.isnan(query_states)).item()
+        assert not paddle.any(paddle.isnan(key_value_states)).item()
+        assert not paddle.any(paddle.isinf(query_states)).item()
+        assert not paddle.any(paddle.isinf(key_value_states)).item()
+
+        assert abs(1 - similarity_query) < 1e-4
+        assert abs(1 - similarity_key_value) < 1e-4
+
+        print(
+            f"TestFusedFp8RmsQkvRopeT passed! Similarities are {similarity_query} and {similarity_key_value}."
+        )
+
+
+if __name__ == "__main__":
+    test = TestFusedFp8RmsQkvRopeT()
+    test.check_result()

--- a/backends/intel_hpu/kernels/hpu_funcs.h
+++ b/backends/intel_hpu/kernels/hpu_funcs.h
@@ -239,6 +239,25 @@ class HpuFusedOperator : public HpuOperator {
         inputs, outputs, params, guid, node_name);
   }
 
+  template <typename T>
+  void AddNodeConvertToFP8(std::vector<synTensor> inputs,
+                           std::vector<synTensor> outputs,
+                           ns_CastKernel::Params params,
+                           std::string node_name) {
+    std::string guid = "convert_to_fp8_" + guid_dtype<T>();
+    AddNode_IOP<ns_CastKernel::Params>(
+        inputs, outputs, params, guid, node_name);
+  }
+
+  template <typename T>
+  void AddNodeFP8Gemm(std::vector<synTensor> inputs,
+                      std::vector<synTensor> outputs,
+                      synGEMMParams params,
+                      std::string node_name) {
+    std::string guid = "fp8_gemm_" + guid_dtype<T>();
+    AddNode_IOP<synGEMMParams>(inputs, outputs, params, guid, node_name);
+  }
+
   inline void AddNodeGemm(std::vector<synTensor> inputs,
                           std::vector<synTensor> outputs,
                           synGEMMParams params,


### PR DESCRIPTION
1. Support fp8 version of fused_rms_qkv_rope_t. Its major difference from original fused_rms_qkv_rope_t is its gemm is in fp8 and it has one extra parameter scale.
2. Add corresponding test.