### PR TITLE
[MLU] Add wait before do tensor_copy

### DIFF
--- a/backends/mlu/kernels/expand_as_kernel.cc
+++ b/backends/mlu/kernels/expand_as_kernel.cc
@@ -22,8 +22,10 @@ template <typename T, typename Context>
 void ExpandAsKernel(const Context& dev_ctx,
                     const phi::DenseTensor& x,
                     const paddle::optional<phi::DenseTensor>& y,
-                    const std::vector<int>& target_shape,
+                    const std::vector<int64_t>& target_shape_64,
                     phi::DenseTensor* out) {
+  std::vector<int> target_shape =
+      std::vector<int>(target_shape_64.begin(), target_shape_64.end());
   auto rank = x.dims().size();
   auto target_rank = target_shape.size();
   PADDLE_ENFORCE_GE(target_rank,

--- a/backends/mlu/kernels/funcs/mlu_funcs.h
+++ b/backends/mlu/kernels/funcs/mlu_funcs.h
@@ -29,6 +29,7 @@ inline void TensorCopy(const Context& dev_ctx,
                        bool blocking,
                        phi::DenseTensor* dst,
                        const phi::Place& dst_place = phi::CustomPlace()) {
+  dev_ctx.Wait();
   auto* src_ptr = src.data();
   const auto& src_place = src.place();
   auto dst_place_ = dst_place;

--- a/backends/mlu/kernels/memcpy_kernel.cc
+++ b/backends/mlu/kernels/memcpy_kernel.cc
@@ -53,7 +53,7 @@ void MemcpyD2HKernel(const Context& dev_ctx,
                      const phi::DenseTensor& x,
                      int dst_place_type,
                      phi::DenseTensor* out) {
-  TensorCopy(dev_ctx, x, false, out, phi::CPUPlace());
+  TensorCopy(dev_ctx, x, true, out, phi::CPUPlace());
 }
 
 template <typename T, typename Context>

--- a/backends/mlu/tools/disable_ut_mlu
+++ b/backends/mlu/tools/disable_ut_mlu
@@ -14,4 +14,3 @@ test_rms_norm_op_mlu
 test_sync_batch_norm_op_mlu
 test_unsqueeze_op_mlu
 test_LeNet_MNIST
-test_multinomial_op_mlu


### PR DESCRIPTION
在 MLU 进行 tensor_copy 时，如果待拷贝的 Tensor 很大，可能出现以下情况：
1. 前一个异步计算 kernel 还没执行结束，就开始从 src 开始拷贝
2. 当前异步 memcpy 还没执行结束，下一个 kernel 就从 dst 读取数据

第一个问题情景： op1 和 memcpy 都在 mlu 上，如果拷贝的 op 执行的是同步拷贝会立即执行，此时op1可能尚未开始执行或者还没有执行结束，mlu 上自带的任务队列就无法保证这两个 op 之间的同步关系；
第二个问题情景： op1-memcpy_h2d 在mlu上，op2 在cpu 上，op1 如果是异步拷贝，op2 执行时可能op1 还没有拷贝结束。

场景一通过在拷贝前插入同步语句解决，场景二在memcpy_h2d 使用同步拷贝解决。
