### PR TITLE
[MLU] Fix ArangeTensorKernel: Handle args from various devices

### DIFF
--- a/backends/mlu/kernels/arange_kernel.cc
+++ b/backends/mlu/kernels/arange_kernel.cc
@@ -12,47 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "kernels/funcs/mlu_baseop.h"
 #include "kernels/funcs/range_op.h"
+#include "paddle/phi/common/scalar.h"
 
 namespace custom_kernel {
 
-template <typename T, typename Context>
-void ArangeTensorKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& start_t,
-                        const phi::DenseTensor& end_t,
-                        const phi::DenseTensor& step_t,
-                        phi::DenseTensor* out) {
-  T* h_start_ptr = nullptr;
-  T* h_end_ptr = nullptr;
-  T* h_step_ptr = nullptr;
-
-  if (start_t.place().GetType() == phi::AllocationType::CPU) {  // tensor at CPU
-    h_start_ptr = reinterpret_cast<T*>(const_cast<void*>(GetBasePtr(&start_t)));
-    h_end_ptr = reinterpret_cast<T*>(const_cast<void*>(GetBasePtr(&end_t)));
-    h_step_ptr = reinterpret_cast<T*>(const_cast<void*>(GetBasePtr(&step_t)));
-  } else {
-    phi::DenseTensor n;
-    n.Resize(start_t.dims());
-    T* n_data = dev_ctx.template HostAlloc<T>(&n);
-    TensorCopy(dev_ctx, start_t, true, &n, phi::CPUPlace());
-    h_start_ptr = new T(n_data[0]);
-    TensorCopy(dev_ctx, end_t, true, &n, phi::CPUPlace());
-    h_end_ptr = new T(n_data[0]);
-    TensorCopy(dev_ctx, step_t, true, &n, phi::CPUPlace());
-    h_step_ptr = new T(n_data[0]);
-  }
-
-  T start_value = h_start_ptr[0];
-  T end_value = h_end_ptr[0];
-  T step_value = h_step_ptr[0];
-
-  ArangeRawKernel<T>(dev_ctx, start_value, end_value, step_value, out);
-  if (start_t.place().GetType() != phi::AllocationType::CPU) {
-    delete h_start_ptr;
-    delete h_end_ptr;
-    delete h_step_ptr;
-  }
-}
+using phi::Scalar;
 
 template <typename T, typename Context>
 void ArangeKernel(const Context& dev_ctx,
@@ -65,6 +31,16 @@ void ArangeKernel(const Context& dev_ctx,
   T step_value = step.to<T>();
 
   ArangeRawKernel<T>(dev_ctx, start_value, end_value, step_value, out);
+}
+
+template <typename T, typename Context>
+void ArangeTensorKernel(const Context& dev_ctx,
+                        const phi::DenseTensor& start_t,
+                        const phi::DenseTensor& end_t,
+                        const phi::DenseTensor& step_t,
+                        phi::DenseTensor* out) {
+  custom_kernel::ArangeKernel<T, Context>(
+      dev_ctx, Scalar(start_t), Scalar(end_t), Scalar(step_t), out);
 }
 
 }  // namespace custom_kernel


### PR DESCRIPTION
 ArangeTensorKernel 拿到的 start step end 参数可能存放在不同的设备上，原实现冗长且无法正确处理这种情况，导致 GroundingDINO-T 模型推理报错：

```text
GroundingDINO-T_mlu_infer.sh: line 6: 38186 Segmentation fault      (core dumped) python main.py -c paddlex/configs/modules/open_vocabulary_detection/GroundingDINO-T.yaml -o Global.mode=predict -o Global.device=mlu:${cudaid:-0} -o Predict.model_dir=None -o Global.output=./output/open_vocabulary_detection/GroundingDINO-T -o Predict.input=./input_datas/GroundingDINO-T/open_vocabulary_detection.jpg
--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::pybind::eager_api_arange(_object*, _object*, _object*)
1   arange_ad_func(paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, phi::DataType, phi::Place)
2   paddle::experimental::arange(paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, phi::DataType, phi::Place const&)
3   void custom_kernel::ArangeTensorKernel<long, phi::CustomContext>(phi::CustomContext const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor*)

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1748918582 (unix time) try "date -d @1748918582" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0x0) received by PID 38186 (TID 0x7f69c4b23740) from PID 0 ***]
```