### PR TITLE
[NPU] Fix strided slice bug: Not support INT_MIN:INT_MAX:1

### DIFF
--- a/backends/npu/kernels/strided_slice_kernel.cc
+++ b/backends/npu/kernels/strided_slice_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "kernels/funcs/npu_funcs.h"
 #include "kernels/funcs/npu_op_runner.h"
+#include "paddle/phi/kernels/funcs/slice_utils.h"
 
 namespace custom_kernel {
 template <typename T, typename Context>
@@ -187,10 +188,14 @@ void AclopStridedSliceCompute(const Context& dev_ctx,
 
   auto in_dims = x.dims();
 
-  // list<int>
+  // vector<int64_t>
+  std::vector<int64_t> axes_64 = std::vector<int64_t>(axes.begin(), axes.end());
   auto starts = starts_array.GetData();
   auto ends = ends_array.GetData();
   auto strides = strides_array.GetData();
+
+  phi::funcs::CheckAndUpdateSliceAttrs<int64_t>(
+      in_dims, axes_64, &starts, &ends, &strides);
 
   // out dims calculation
   std::vector<int64_t> out_dims_vector(in_dims.size(), -1);
@@ -360,10 +365,14 @@ void StridedSliceCompute(const Context& dev_ctx,
   auto stream = dev_ctx.stream();
   auto in_dims = x.dims();
 
-  // list<int>
+  // vector<int64_t>
+  std::vector<int64_t> axes_64 = std::vector<int64_t>(axes.begin(), axes.end());
   auto starts = starts_array.GetData();
   auto ends = ends_array.GetData();
   auto strides = strides_array.GetData();
+
+  phi::funcs::CheckAndUpdateSliceAttrs<int64_t>(
+      in_dims, axes_64, &starts, &ends, &strides);
 
   // out dims calculation
   std::vector<int64_t> out_dims_vector(in_dims.size(), -1);


### PR DESCRIPTION
修复 NPU 上系列模型报错广播维度不匹配：
```text
----------------------
Error Message Summary:
----------------------
InvalidArgumentError: Broadcast dimension mismatch. Operands could not be broadcast together with the shape of X = [1, 900, 4] and the shape of Y = [1, 1, 2]. Received [4] in X is not equal to [2] in Y at i:2.
  [Hint: Expected x_dims_array[i] == y_dims_array[i] || (x_dims_array[i] <= 1 && x_dims_array[i] != 0) || (y_dims_array[i] <= 1 && y_dims_array[i] != 0) == true, but received x_dims_array[i] == y_dims_array[i] || (x_dims_array[i] <= 1 && x_dims_array[i] != 0) || (y_dims_array[i] <= 1 && y_dims_array[i] != 0):0 != true:1.] (at /paddle/paddle/phi/kernels/funcs/common_shape.h:86)
  [operator < pd_kernel.phi_kernel > error]
```

问题在于 NPU 上 strided_slice kernel 不支持 过小和过大的切片组合，因此先调用 `phi::funcs::CheckAndUpdateSliceAttrs` 对输入参数进行规范化。