### PR TITLE
Add dtype parameter to CumsumKernel

### DIFF
--- a/backends/npu/kernels/cum_kernel.cc
+++ b/backends/npu/kernels/cum_kernel.cc
@@ -72,13 +72,16 @@ void AclopCumsumKernel(const Context& dev_ctx,
                        bool flatten,
                        bool exclusive,
                        bool reverse,
+                       phi::DataType dtype,
                        phi::DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
 
   auto axis = axis_scalar.to<int>();
 
-  NPUAttributeMap attr_input = {
-      {"axis", axis}, {"exclusive", exclusive}, {"reverse", reverse}};
+  NPUAttributeMap attr_input = {{"axis", axis},
+                                {"exclusive", exclusive},
+                                {"reverse", reverse},
+                                {"dtype", dtype}};
 
   if (flatten) {
     PADDLE_ENFORCE_EQ(
@@ -105,11 +108,12 @@ void CumsumKernel(const Context& dev_ctx,
                   bool flatten,
                   bool exclusive,
                   bool reverse,
+                  phi::DataType dtype,
                   phi::DenseTensor* out) {
   DO_COMPATIBILITY(
       aclnnCumsumV2,
       (custom_kernel::AclopCumsumKernel<T, Context>(
-          dev_ctx, x, axis_scalar, flatten, exclusive, reverse, out)));
+          dev_ctx, x, axis_scalar, flatten, exclusive, reverse, dtype, out)));
   dev_ctx.template Alloc<T>(out);
   auto axis = axis_scalar.to<int64_t>();
 

--- a/backends/npu/kernels/cum_kernel.cc
+++ b/backends/npu/kernels/cum_kernel.cc
@@ -129,9 +129,11 @@ void CumsumKernel(const Context& dev_ctx,
     Tensor new_x(x);
     new_x.Resize(phi::make_ddim({x.numel()}));
 
-    EXEC_NPU_CMD(aclnnCumsumV2, dev_ctx, new_x, axis, exclusive, reverse, *out);
+    EXEC_NPU_CMD(
+        aclnnCumsumV2, dev_ctx, new_x, axis, exclusive, reverse, dtype, *out);
   } else {
-    EXEC_NPU_CMD(aclnnCumsumV2, dev_ctx, x, axis, exclusive, reverse, *out);
+    EXEC_NPU_CMD(
+        aclnnCumsumV2, dev_ctx, x, axis, exclusive, reverse, dtype, *out);
   }
 }
 

--- a/backends/npu/kernels/cum_kernel.cc
+++ b/backends/npu/kernels/cum_kernel.cc
@@ -81,7 +81,7 @@ void AclopCumsumKernel(const Context& dev_ctx,
   NPUAttributeMap attr_input = {{"axis", axis},
                                 {"exclusive", exclusive},
                                 {"reverse", reverse},
-                                {"dtype", dtype}};
+                                {"dtype", static_cast<int>(dtype)}};
 
   if (flatten) {
     PADDLE_ENFORCE_EQ(


### PR DESCRIPTION
此[PR](https://github.com/PaddlePaddle/Paddle/pull/72532)为cumsum算子增加dtype参数，现在customdevice中进行兼容。