### PR TITLE
[NPU] Dynamically set jit compile opt in op runner

### DIFF
--- a/backends/npu/kernels/funcs/npu_op_runner.cc
+++ b/backends/npu/kernels/funcs/npu_op_runner.cc
@@ -50,6 +50,14 @@ FLAGS_DEFINE_bool(npu_scale_aclnn, false, "use aclnn scale kernel");
 FLAGS_DEFINE_bool(npu_split_aclnn, false, "use aclnn split kernel");
 FLAGS_DEFINE_bool(npu_jit_compile, true, "enable npu jit compile");
 
+namespace {
+const std::unordered_set<std::string> force_compile_set = {
+    "PriorBox",
+};
+
+bool current_jit_compile_opt = false;
+}  // namespace
+
 NpuOpRunner::NpuOpRunner() {}
 
 NpuOpRunner::NpuOpRunner(const std::string &op_type) : op_type_(op_type) {}
@@ -618,14 +626,15 @@ void NpuOpRunner::Run(aclrtStream stream, bool sync) const {
           << GetOpDescString(input_descs_, "Input")
           << GetOpDescString(output_descs_, "Output");
 
-  static std::once_flag jit_compile_flag;
-  std::call_once(jit_compile_flag, [&]() {
-    if (FLAGS_npu_jit_compile) {
-      aclSetCompileopt(ACL_OP_JIT_COMPILE, "enable");
-    } else {
-      aclSetCompileopt(ACL_OP_JIT_COMPILE, "disable");
-    }
-  });
+  static std::once_flag init_current_jit_compile_flag;
+  std::call_once(init_current_jit_compile_flag, InitJitCompileOpt);
+  if (ForceJitCompile(op_type_)) {
+    PADDLE_ENFORCE_NPU_SUCCESS(aclrtSynchronizeStream(stream));
+    SetJitCompileOpt(true);
+  } else {
+    SetJitCompileOpt(FLAGS_npu_jit_compile);
+  }
+
   SetDeterministic();
 
   aclError ret;
@@ -658,4 +667,27 @@ void NpuOpRunner::Run(aclrtStream stream, bool sync) const {
     PADDLE_THROW(phi::errors::PreconditionNotMet(
         "Operator %s contains Nan/Inf.", op_type_));
   }
+}
+
+void InitJitCompileOpt() {
+  if (FLAGS_npu_jit_compile) {
+    aclSetCompileopt(ACL_OP_JIT_COMPILE, "enable");
+  } else {
+    aclSetCompileopt(ACL_OP_JIT_COMPILE, "disable");
+  }
+  current_jit_compile_opt = FLAGS_npu_jit_compile;
+}
+
+void SetJitCompileOpt(bool new_value) {
+  if (current_jit_compile_opt == new_value) return;
+  if (new_value) {
+    aclSetCompileopt(ACL_OP_JIT_COMPILE, "enable");
+  } else {
+    aclSetCompileopt(ACL_OP_JIT_COMPILE, "disable");
+  }
+  current_jit_compile_opt = new_value;
+}
+
+bool ForceJitCompile(const std::string &op_name) {
+  return force_compile_set.count(op_name) > 0;
 }

--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -750,3 +750,9 @@ template <>
 struct cpp_type_to_acl_dtype<double> {
   static const aclDataType value() { return ACL_DOUBLE; }
 };
+
+void InitJitCompileOpt();
+
+void SetJitCompileOpt(bool new_value);
+
+bool ForceJitCompile(const std::string& op_name);


### PR DESCRIPTION
NPU 下设置环境变量 `FLAGS_npu_jit_compile=0`，prior_box op 在执行时报错 `ExternalError:  ACL error, the error code is : 500002.`。解决方案是强制进行 jit 编译。