### PR TITLE
[NPU] Fix slice op on NPU

### DIFF
--- a/backends/npu/kernels/funcs/npu_op_runner.h
+++ b/backends/npu/kernels/funcs/npu_op_runner.h
@@ -419,6 +419,11 @@ inline aclIntArray* ConvertType(const std::vector<int64_t>& at_array) {
   return array;
 }
 
+inline aclIntArray* ConvertType(const std::vector<int>& at_array) {
+  std::vector<int64_t> temp_array(at_array.begin(), at_array.end());
+  return ConvertType(temp_array);
+}
+
 inline aclIntArray *ConvertType(const phi::IntArray &phi_array) {
   static const auto aclCreateIntArray = GET_OP_API_FUNC(aclCreateIntArray);
   if (aclCreateIntArray == nullptr) {

--- a/backends/npu/kernels/slice_kernel.cc
+++ b/backends/npu/kernels/slice_kernel.cc
@@ -189,8 +189,7 @@ void SliceRawKernel(const Context& dev_ctx,
   }
 
   dev_ctx.template Alloc<T>(out);
-  EXEC_NPU_CMD(
-      aclnnSliceV2, dev_ctx, x, starts_array, ends_array, axes_t, steps, *out);
+  EXEC_NPU_CMD(aclnnSliceV2, dev_ctx, x, starts, ends, axes_t, steps, *out);
   if (out->dims().size() != out_dims.size()) {
     out->Resize(out_dims);
   }

--- a/backends/npu/tools/pr_ci_npu.sh
+++ b/backends/npu/tools/pr_ci_npu.sh
@@ -254,6 +254,10 @@ function run_paddlex() {
 
 
 function main() {
+    if [ "$(uname -m)" == "x86_64" ]; then
+        export ASCEND_RT_VISIBLE_DEVICES="12,13,14,15"
+    fi
+
     # skip paddlepaddle cpu install as npu docker image already have cpu whl package installed
     # custom_npu build and install
     cd ${CODE_ROOT}

--- a/backends/npu/tools/pr_ci_npu.sh
+++ b/backends/npu/tools/pr_ci_npu.sh
@@ -254,10 +254,6 @@ function run_paddlex() {
 
 
 function main() {
-    if [ "$(uname -m)" == "x86_64" ]; then
-        export ASCEND_RT_VISIBLE_DEVICES="12,13,14,15"
-    fi
-
     # skip paddlepaddle cpu install as npu docker image already have cpu whl package installed
     # custom_npu build and install
     cd ${CODE_ROOT}


### PR DESCRIPTION
当 starts = -1 时，aclnnSliceV2 与 paddle.slice 结果 size 不一致，导致 NPU 上多个模型推理异常。

解决方案是传入标准化过的切片。