### PR TITLE
[INTEL_HPU] separate rmsNorm from fused kernels

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_block_attention.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_block_attention.cc
@@ -22,7 +22,6 @@
 namespace custom_kernel {
 
 struct FusedBlockAttentionParams {
-  ns_LayerNormKernel::Params rmsnorm_params;
   ns_ConstantKernel::Params const_params;
   ns_GatherKernel::Params index_select_params;
   ns_Reduction::Params reduce_params;
@@ -1488,7 +1487,6 @@ void FusedBlockAttentionKernel(
     const paddle::optional<phi::DenseTensor>& qkv_biases,
     const phi::DenseTensor& linear_weights,
     phi::DenseTensor* out_linear,
-    const phi::Scalar& epsilon,
     const phi::Scalar& head_dim,
     const phi::Scalar& num_head,
     const phi::Scalar& scaling_factor) {
@@ -1541,8 +1539,6 @@ void FusedBlockAttentionKernel(
     memset(reinterpret_cast<void*>(&params),
            0x00,
            sizeof(FusedBlockAttentionParams));
-    params.rmsnorm_params.epsValid = true;
-    params.rmsnorm_params.eps = epsilon.to<float>();
     params.const_params.constant.f = scaling_factor.to<float>();
     params.index_select_params.axis = 3;
     params.reduce_params.reductionDimension = 0;
@@ -1595,7 +1591,6 @@ void CallFusedBlockAttentionKernel(
     const paddle::optional<phi::DenseTensor>& qkv_biases,
     const phi::DenseTensor& linear_weights,
     phi::DenseTensor* out_linear,
-    const phi::Scalar& epsilon,
     const phi::Scalar& head_dim,
     const phi::Scalar& num_head,
     const phi::Scalar& scaling_factor) {
@@ -1616,7 +1611,6 @@ void CallFusedBlockAttentionKernel(
         qkv_biases,
         linear_weights,
         out_linear,
-        epsilon,
         head_dim,
         num_head,
         scaling_factor);
@@ -1637,7 +1631,6 @@ void CallFusedBlockAttentionKernel(
         qkv_biases,
         linear_weights,
         out_linear,
-        epsilon,
         head_dim,
         num_head,
         scaling_factor);
@@ -1661,7 +1654,6 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
     const paddle::Tensor& qkv_weights,
     const paddle::optional<paddle::Tensor>& qkv_biases,
     const paddle::Tensor& linear_weights,
-    float epsilon,
     int head_dim,
     int num_head,
     float scaling_factor) {
@@ -1722,7 +1714,6 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
                                 qkv_biases_tensor,
                                 *linear_weights_tensor,
                                 out_linear.get(),
-                                phi::Scalar(epsilon),
                                 phi::Scalar(head_dim),
                                 phi::Scalar(num_head),
                                 phi::Scalar(scaling_factor));
@@ -1743,7 +1734,6 @@ std::vector<std::vector<int64_t>> FusedBlockAttentionShape(
     const std::vector<int64_t>& qkv_weights_shape,
     const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
     const std::vector<int64_t>& linear_weights_shape,
-    float epsilon,
     int head_dim,
     int num_head,
     float scaling_factor) {
@@ -1784,10 +1774,7 @@ PD_BUILD_OP(fused_block_attention)
              paddle::Optional("qkv_biases"),
              "linear_weights"})
     .Outputs({"out_linear"})
-    .Attrs({"epsilon: float",
-            "head_dim: int",
-            "num_head: int",
-            "scaling_factor: float"})
+    .Attrs({"head_dim: int", "num_head: int", "scaling_factor: float"})
     .SetKernelFn(PD_KERNEL(FusedBlockAttentionForward))
     .SetInferShapeFn(PD_INFER_SHAPE(FusedBlockAttentionShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedBlockAttentionDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
@@ -227,7 +227,6 @@ void FusedQkvRopeKernel(const Context& dev_ctx,
                         const paddle::optional<phi::DenseTensor>& scale_weight,
                         phi::DenseTensor* query_states,
                         phi::DenseTensor* key_value_states,
-                        const phi::Scalar& epsilon,
                         const phi::Scalar& head_dim,
                         const phi::Scalar& num_head) {
   std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
@@ -309,7 +308,6 @@ void CallFusedQkvRopeKernel(
     const paddle::optional<phi::DenseTensor>& scale_weight,
     phi::DenseTensor* query_states,
     phi::DenseTensor* key_value_states,
-    const phi::Scalar& epsilon,
     const phi::Scalar& head_dim,
     const phi::Scalar& num_head) {
   if (src.dtype() == phi::DataType::FLOAT16) {
@@ -322,7 +320,6 @@ void CallFusedQkvRopeKernel(
                                                            scale_weight,
                                                            query_states,
                                                            key_value_states,
-                                                           epsilon,
                                                            head_dim,
                                                            num_head);
   } else if (src.dtype() == phi::DataType::BFLOAT16) {
@@ -335,7 +332,6 @@ void CallFusedQkvRopeKernel(
                                                             scale_weight,
                                                             query_states,
                                                             key_value_states,
-                                                            epsilon,
                                                             head_dim,
                                                             num_head);
   } else {
@@ -348,7 +344,6 @@ std::vector<paddle::Tensor> FusedQkvRopeImpl(
     const paddle::Tensor& qkv_weights,
     const paddle::optional<paddle::Tensor>& qkv_biases,
     const paddle::Tensor& rotary_embs,
-    float epsilon,
     int head_dim,
     int num_head) {
   auto dev_ctx = static_cast<const phi::CustomContext*>(
@@ -392,7 +387,6 @@ std::vector<paddle::Tensor> FusedQkvRopeImpl(
                          paddle::optional<phi::DenseTensor>(),
                          query_states.get(),
                          key_value_states.get(),
-                         phi::Scalar(epsilon),
                          phi::Scalar(head_dim),
                          phi::Scalar(num_head));
   return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
@@ -403,7 +397,6 @@ std::vector<std::vector<int64_t>> FusedQkvRopeShape(
     const std::vector<int64_t>& qkv_weights_shape,
     const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
     const std::vector<int64_t>& rotary_embs_shape,
-    float epsilon,
     int head_dim,
     int num_head) {
   int64_t bsz = src_shape[0];
@@ -426,7 +419,7 @@ PD_BUILD_OP(fused_qkv_rope)
     .Inputs(
         {"src", "qkv_weights", paddle::Optional("qkv_biases"), "rotary_embs"})
     .Outputs({"query_states", "key_value_states"})
-    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .Attrs({"head_dim: int", "num_head: int"})
     .SetKernelFn(PD_KERNEL(FusedQkvRopeImpl))
     .SetInferShapeFn(PD_INFER_SHAPE(FusedQkvRopeShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedQkvRopeDtype));
@@ -438,7 +431,6 @@ std::vector<paddle::Tensor> FusedFp8QkvRopeImpl(
     const paddle::Tensor& rotary_embs,
     const paddle::Tensor& scale_input,
     const paddle::Tensor& scale_weight,
-    float epsilon,
     int head_dim,
     int num_head) {
   auto dev_ctx = static_cast<const phi::CustomContext*>(
@@ -489,7 +481,6 @@ std::vector<paddle::Tensor> FusedFp8QkvRopeImpl(
                          scale_weight_tensor,
                          query_states.get(),
                          key_value_states.get(),
-                         phi::Scalar(epsilon),
                          phi::Scalar(head_dim),
                          phi::Scalar(num_head));
   return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
@@ -502,7 +493,6 @@ std::vector<std::vector<int64_t>> FusedFp8QkvRopeShape(
     const std::vector<int64_t>& rotary_embs_shape,
     const std::vector<int64_t>& scale_input_shape,
     const std::vector<int64_t>& scale_weight_shape,
-    float epsilon,
     int head_dim,
     int num_head) {
   int64_t bsz = src_shape[0];
@@ -531,7 +521,7 @@ PD_BUILD_OP(fused_fp8_qkv_rope_t)
              "scale_input",
              "scale_weight"})
     .Outputs({"query_states", "key_value_states"})
-    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .Attrs({"head_dim: int", "num_head: int"})
     .SetKernelFn(PD_KERNEL(FusedFp8QkvRopeImpl))
     .SetInferShapeFn(PD_INFER_SHAPE(FusedFp8QkvRopeShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedFp8QkvRopeDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
@@ -83,7 +83,7 @@ class FusedRmsQkvRopeT : public HpuFusedOperator {
       }
       linear_inputs.push_back(scale_input);
       linear_inputs.push_back(scale_weight);
-      AddNodeFusedFp8Gemm<T>(
+      AddNodeFusedFP8Gemm<T>(
           linear_inputs, linear_outputs, gemm_params, guid_ + "fp8_gemm");
 
       if (params.with_qkv_biases) {

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
@@ -21,9 +21,7 @@
 
 namespace custom_kernel {
 
-struct FusedRmsQkvRopeParams {
-  ns_LayerNormKernel::Params rmsnorm_params;
-
+struct FusedQkvRopeParams {
   int head_dim;
   int num_head;
   int kv_num_head;
@@ -32,12 +30,12 @@ struct FusedRmsQkvRopeParams {
   bool use_fp8 = false;
 };
 
-class FusedRmsQkvRopeT : public HpuFusedOperator {
+class FusedQkvRope : public HpuFusedOperator {
  public:
-  explicit FusedRmsQkvRopeT(std::string guid_prefix, synDataType dtype)
+  explicit FusedQkvRope(std::string guid_prefix, synDataType dtype)
       : HpuFusedOperator(guid_prefix), dtype_(dtype) {}
   template <typename T>
-  void AddNode(ConvertTensors& ct, FusedRmsQkvRopeParams& params) {
+  void AddNode(ConvertTensors& ct, FusedQkvRopeParams& params) {
     auto ins = ct.GetTensors();
     auto outs = ct.GetTensors(false);
 
@@ -220,19 +218,18 @@ class FusedRmsQkvRopeT : public HpuFusedOperator {
 };
 
 template <typename T, typename Context>
-void FusedRmsQkvRopeTKernel(
-    const Context& dev_ctx,
-    const phi::DenseTensor& src,
-    const phi::DenseTensor& qkv_weights,
-    const paddle::optional<phi::DenseTensor>& qkv_biases,
-    const phi::DenseTensor& rotary_embs,
-    const paddle::optional<phi::DenseTensor>& scale_input,
-    const paddle::optional<phi::DenseTensor>& scale_weight,
-    phi::DenseTensor* query_states,
-    phi::DenseTensor* key_value_states,
-    const phi::Scalar& epsilon,
-    const phi::Scalar& head_dim,
-    const phi::Scalar& num_head) {
+void FusedQkvRopeKernel(const Context& dev_ctx,
+                        const phi::DenseTensor& src,
+                        const phi::DenseTensor& qkv_weights,
+                        const paddle::optional<phi::DenseTensor>& qkv_biases,
+                        const phi::DenseTensor& rotary_embs,
+                        const paddle::optional<phi::DenseTensor>& scale_input,
+                        const paddle::optional<phi::DenseTensor>& scale_weight,
+                        phi::DenseTensor* query_states,
+                        phi::DenseTensor* key_value_states,
+                        const phi::Scalar& epsilon,
+                        const phi::Scalar& head_dim,
+                        const phi::Scalar& num_head) {
   std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
   std::vector<int64_t> qkv_weights_dims =
       phi::vectorize<int64_t>(qkv_weights.dims());
@@ -250,22 +247,22 @@ void FusedRmsQkvRopeTKernel(
   ct.Add(query_states, false);
   ct.Add(key_value_states, false);
 
-  std::string guid_prefix = "fused_rms_qkv_rope_t_fwd_";
+  std::string guid_prefix = "fused_qkv_rope_fwd_";
   if (qkv_biases) {
     ct.Add(qkv_biases.get());
-    guid_prefix = "fused_rms_qkv_bias_rope_t_fwd_";
+    guid_prefix = "fused_qkv_bias_rope_fwd_";
   }
 
   if (scale_input && scale_weight) {
     ct.Add(scale_input.get());
     ct.Add(scale_weight.get());
-    guid_prefix = "fused_fp8_rms_qkv_rope_t_fwd_";
+    guid_prefix = "fused_fp8_qkv_rope_fwd_";
     if (qkv_biases) {
-      guid_prefix = "fused_fp8_rms_qkv_bias_rope_t_fwd_";
+      guid_prefix = "fused_fp8_qkv_bias_rope_fwd_";
     }
   } else if (scale_input || scale_weight) {
     throw std::runtime_error(
-        "Need both scale_input and scale_weight for FusedFp8RmsQkvRopeTKernel");
+        "Need both scale_input and scale_weight for FusedFp8QkvRopeKernel");
   }
 
   OpCacheOperator op_info;
@@ -274,11 +271,8 @@ void FusedRmsQkvRopeTKernel(
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    FusedRmsQkvRopeParams params;
-    memset(
-        reinterpret_cast<void*>(&params), 0x00, sizeof(FusedRmsQkvRopeParams));
-    params.rmsnorm_params.epsValid = true;
-    params.rmsnorm_params.eps = epsilon.to<float>();
+    FusedQkvRopeParams params;
+    memset(reinterpret_cast<void*>(&params), 0x00, sizeof(FusedQkvRopeParams));
     params.head_dim = head_dim_;
     params.num_head = num_head_;
     params.kv_num_head = kv_num_head;
@@ -289,7 +283,7 @@ void FusedRmsQkvRopeTKernel(
       params.use_fp8 = true;
     }
 
-    FusedRmsQkvRopeT op(guid_prefix, op_info.datatype_);
+    FusedQkvRope op(guid_prefix, op_info.datatype_);
     op.AddNode<T>(ct, params);
     op.Compile();
     op_info.setOp(op);
@@ -305,7 +299,7 @@ void FusedRmsQkvRopeTKernel(
 }  // namespace custom_kernel
 
 template <typename Context>
-void CallFusedRmsQkvRopeTKernel(
+void CallFusedQkvRopeKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& src,
     const phi::DenseTensor& qkv_weights,
@@ -319,39 +313,37 @@ void CallFusedRmsQkvRopeTKernel(
     const phi::Scalar& head_dim,
     const phi::Scalar& num_head) {
   if (src.dtype() == phi::DataType::FLOAT16) {
-    custom_kernel::FusedRmsQkvRopeTKernel<phi::dtype::float16>(dev_ctx,
-                                                               src,
-                                                               qkv_weights,
-                                                               qkv_biases,
-                                                               rotary_embs,
-                                                               scale_input,
-                                                               scale_weight,
-                                                               query_states,
-                                                               key_value_states,
-                                                               epsilon,
-                                                               head_dim,
-                                                               num_head);
+    custom_kernel::FusedQkvRopeKernel<phi::dtype::float16>(dev_ctx,
+                                                           src,
+                                                           qkv_weights,
+                                                           qkv_biases,
+                                                           rotary_embs,
+                                                           scale_input,
+                                                           scale_weight,
+                                                           query_states,
+                                                           key_value_states,
+                                                           epsilon,
+                                                           head_dim,
+                                                           num_head);
   } else if (src.dtype() == phi::DataType::BFLOAT16) {
-    custom_kernel::FusedRmsQkvRopeTKernel<phi::dtype::bfloat16>(
-        dev_ctx,
-        src,
-        qkv_weights,
-        qkv_biases,
-        rotary_embs,
-        scale_input,
-        scale_weight,
-        query_states,
-        key_value_states,
-        epsilon,
-        head_dim,
-        num_head);
+    custom_kernel::FusedQkvRopeKernel<phi::dtype::bfloat16>(dev_ctx,
+                                                            src,
+                                                            qkv_weights,
+                                                            qkv_biases,
+                                                            rotary_embs,
+                                                            scale_input,
+                                                            scale_weight,
+                                                            query_states,
+                                                            key_value_states,
+                                                            epsilon,
+                                                            head_dim,
+                                                            num_head);
   } else {
-    throw std::runtime_error(
-        "Unsupported data type for FusedRmsQkvRopeTKernel");
+    throw std::runtime_error("Unsupported data type for FusedQkvRopeKernel");
   }
 }
 
-std::vector<paddle::Tensor> FusedRmsQkvRopeTImpl(
+std::vector<paddle::Tensor> FusedQkvRopeImpl(
     const paddle::Tensor& src,
     const paddle::Tensor& qkv_weights,
     const paddle::optional<paddle::Tensor>& qkv_biases,
@@ -391,22 +383,22 @@ std::vector<paddle::Tensor> FusedRmsQkvRopeTImpl(
       phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
   dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
 
-  CallFusedRmsQkvRopeTKernel(*dev_ctx,
-                             *src_tensor,
-                             *qkv_weights_tensor,
-                             qkv_biases_tensor,
-                             *rotary_embs_tensor,
-                             paddle::optional<phi::DenseTensor>(),
-                             paddle::optional<phi::DenseTensor>(),
-                             query_states.get(),
-                             key_value_states.get(),
-                             phi::Scalar(epsilon),
-                             phi::Scalar(head_dim),
-                             phi::Scalar(num_head));
+  CallFusedQkvRopeKernel(*dev_ctx,
+                         *src_tensor,
+                         *qkv_weights_tensor,
+                         qkv_biases_tensor,
+                         *rotary_embs_tensor,
+                         paddle::optional<phi::DenseTensor>(),
+                         paddle::optional<phi::DenseTensor>(),
+                         query_states.get(),
+                         key_value_states.get(),
+                         phi::Scalar(epsilon),
+                         phi::Scalar(head_dim),
+                         phi::Scalar(num_head));
   return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
 }
 
-std::vector<std::vector<int64_t>> FusedRmsQkvRopeTShape(
+std::vector<std::vector<int64_t>> FusedQkvRopeShape(
     const std::vector<int64_t>& src_shape,
     const std::vector<int64_t>& qkv_weights_shape,
     const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
@@ -422,7 +414,7 @@ std::vector<std::vector<int64_t>> FusedRmsQkvRopeTShape(
           {2, bsz, seq_len, kv_num_head, head_dim}};
 }
 
-std::vector<paddle::DataType> FusedRmsQkvRopeTDtype(
+std::vector<paddle::DataType> FusedQkvRopeDtype(
     const paddle::DataType& src_dtype,
     const paddle::DataType& qkv_weights_dtype,
     const paddle::optional<paddle::DataType>& qkv_biases_dtype,
@@ -435,11 +427,11 @@ PD_BUILD_OP(fused_qkv_rope)
         {"src", "qkv_weights", paddle::Optional("qkv_biases"), "rotary_embs"})
     .Outputs({"query_states", "key_value_states"})
     .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
-    .SetKernelFn(PD_KERNEL(FusedRmsQkvRopeTImpl))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedRmsQkvRopeTShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(FusedRmsQkvRopeTDtype));
+    .SetKernelFn(PD_KERNEL(FusedQkvRopeImpl))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedQkvRopeShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedQkvRopeDtype));
 
-std::vector<paddle::Tensor> FusedFp8RmsQkvRopeTImpl(
+std::vector<paddle::Tensor> FusedFp8QkvRopeImpl(
     const paddle::Tensor& src,
     const paddle::Tensor& qkv_weights,
     const paddle::optional<paddle::Tensor>& qkv_biases,
@@ -488,22 +480,22 @@ std::vector<paddle::Tensor> FusedFp8RmsQkvRopeTImpl(
       phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
   dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
 
-  CallFusedRmsQkvRopeTKernel(*dev_ctx,
-                             *src_tensor,
-                             *qkv_weights_tensor,
-                             qkv_biases_tensor,
-                             *rotary_embs_tensor,
-                             scale_input_tensor,
-                             scale_weight_tensor,
-                             query_states.get(),
-                             key_value_states.get(),
-                             phi::Scalar(epsilon),
-                             phi::Scalar(head_dim),
-                             phi::Scalar(num_head));
+  CallFusedQkvRopeKernel(*dev_ctx,
+                         *src_tensor,
+                         *qkv_weights_tensor,
+                         qkv_biases_tensor,
+                         *rotary_embs_tensor,
+                         scale_input_tensor,
+                         scale_weight_tensor,
+                         query_states.get(),
+                         key_value_states.get(),
+                         phi::Scalar(epsilon),
+                         phi::Scalar(head_dim),
+                         phi::Scalar(num_head));
   return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
 }
 
-std::vector<std::vector<int64_t>> FusedFp8RmsQkvRopeTShape(
+std::vector<std::vector<int64_t>> FusedFp8QkvRopeShape(
     const std::vector<int64_t>& src_shape,
     const std::vector<int64_t>& qkv_weights_shape,
     const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
@@ -521,7 +513,7 @@ std::vector<std::vector<int64_t>> FusedFp8RmsQkvRopeTShape(
           {2, bsz, seq_len, kv_num_head, head_dim}};
 }
 
-std::vector<paddle::DataType> FusedFp8RmsQkvRopeTDtype(
+std::vector<paddle::DataType> FusedFp8QkvRopeDtype(
     const paddle::DataType& src_dtype,
     const paddle::DataType& qkv_weights_dtype,
     const paddle::optional<paddle::DataType>& qkv_biases_dtype,
@@ -540,6 +532,6 @@ PD_BUILD_OP(fused_fp8_qkv_rope_t)
              "scale_weight"})
     .Outputs({"query_states", "key_value_states"})
     .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
-    .SetKernelFn(PD_KERNEL(FusedFp8RmsQkvRopeTImpl))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedFp8RmsQkvRopeTShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFp8RmsQkvRopeTDtype));
+    .SetKernelFn(PD_KERNEL(FusedFp8QkvRopeImpl))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFp8QkvRopeShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFp8QkvRopeDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_qkv_rope.cc
@@ -1,0 +1,545 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "habanalabs/perf_lib_layer_params.h"
+#include "kernels/funcs.h"
+#include "kernels/hpu_funcs.h"
+#include "kernels/hpu_operator.h"
+#include "paddle/extension.h"
+#include "utils/utils.h"
+
+namespace custom_kernel {
+
+struct FusedRmsQkvRopeParams {
+  ns_LayerNormKernel::Params rmsnorm_params;
+
+  int head_dim;
+  int num_head;
+  int kv_num_head;
+
+  bool with_qkv_biases = false;
+  bool use_fp8 = false;
+};
+
+class FusedRmsQkvRopeT : public HpuFusedOperator {
+ public:
+  explicit FusedRmsQkvRopeT(std::string guid_prefix, synDataType dtype)
+      : HpuFusedOperator(guid_prefix), dtype_(dtype) {}
+  template <typename T>
+  void AddNode(ConvertTensors& ct, FusedRmsQkvRopeParams& params) {
+    auto ins = ct.GetTensors();
+    auto outs = ct.GetTensors(false);
+
+    int src_index = 0;
+    int qkv_weights_index = 1;
+    int rotary_embs_index = 2;
+    int qkv_biases_index = 3;
+
+    auto src = createTensorFromCT(&ct, src_index);
+    auto qkv_weights = createTensorFromCT(&ct, qkv_weights_index);
+
+    std::vector<synTensor> linear_inputs;
+    linear_inputs.push_back(src);
+    linear_inputs.push_back(qkv_weights);
+    if (params.with_qkv_biases) {
+      auto qkv_biases = createTensorFromCT(&ct, qkv_biases_index);
+      linear_inputs.push_back(qkv_biases);
+    }
+
+    auto tmp_dims = ins[src_index].dims;
+    auto wt_dims = ins[qkv_weights_index].dims;
+    tmp_dims[2] = wt_dims[0];
+    auto qkv_out = createTensorNoPresist("qkv_out", dtype_, tmp_dims);
+    std::vector<synTensor> linear_outputs;
+    linear_outputs.push_back(qkv_out);
+
+    if (!params.use_fp8) {
+      AddNodeLinear<T>(linear_inputs, linear_outputs, guid_ + "linear");
+    } else {
+      int scale_input_index =
+          (params.with_qkv_biases ? (qkv_biases_index + 1)
+                                  : (rotary_embs_index + 1));
+      auto scale_input = createTensorFromCT(&ct, scale_input_index);
+      auto scale_weight = createTensorFromCT(&ct, scale_input_index + 1);
+      synGEMMParams gemm_params;
+      gemm_params.transpose_a = false;
+      gemm_params.transpose_b = true;
+
+      synTensor qkv_biases;
+      if (params.with_qkv_biases) {
+        qkv_biases = linear_inputs.back();
+        linear_inputs.pop_back();
+      }
+      linear_inputs.push_back(scale_input);
+      linear_inputs.push_back(scale_weight);
+      AddNodeFusedFp8Gemm<T>(
+          linear_inputs, linear_outputs, gemm_params, guid_ + "fp8_gemm");
+
+      if (params.with_qkv_biases) {
+        auto qkv_out_with_bias =
+            createTensorNoPresist("qkv_out_with_bias", dtype_, tmp_dims);
+        std::vector<synTensor> qkv_add_inputs;
+        qkv_add_inputs.push_back(qkv_out);
+        qkv_add_inputs.push_back(qkv_biases);
+        std::vector<synTensor> qkv_add_outputs = {qkv_out_with_bias};
+        AddNodeAdd<T>(qkv_add_inputs, qkv_add_outputs, guid_ + "add_bias");
+        qkv_out = qkv_out_with_bias;
+      }
+    }
+
+    auto reshape_dims = ins[src_index].dims;
+    reshape_dims[2] = params.num_head + 2 * params.kv_num_head;
+    reshape_dims.push_back(params.head_dim);
+
+    std::vector<synTensor> reshape_outputs;
+    auto reshape_out =
+        createTensorNoPresist("reshape_out", dtype_, reshape_dims);
+    reshape_outputs.push_back(reshape_out);
+    AddNodeReshape(linear_outputs, reshape_outputs, guid_ + "reshape_qkv");
+
+    auto kv_dims = outs[1].dims;
+    kv_dims.erase(kv_dims.begin());
+    auto q_split = createTensorNoPresist("q_split", dtype_, outs[0].dims);
+    auto k_split = createTensorNoPresist("k_split", dtype_, kv_dims);
+    auto v_split = createTensorNoPresist("v_split", dtype_, kv_dims);
+    std::vector<synTensor> split_outpus;
+    split_outpus.push_back(q_split);
+    split_outpus.push_back(k_split);
+    split_outpus.push_back(v_split);
+
+    synSplitParams splitParams;
+    splitParams.axis = 1;
+    AddNodeSplit(reshape_outputs, split_outpus, splitParams, guid_ + "split");
+
+    std::vector<synTensor> rotary_embs_inputs;
+    auto rotary_embs_c = createTensorFromCT(&ct, rotary_embs_index);
+    rotary_embs_inputs.push_back(rotary_embs_c);
+
+    auto rotary_embs_dims = ins[rotary_embs_index].dims;
+    rotary_embs_dims[0] = 1;
+
+    std::vector<synTensor> cos_inputs;
+    auto cos_in = createTensorNoPresist("cos_in", dtype_, rotary_embs_dims);
+    cos_inputs.push_back(cos_in);
+
+    synSliceParamsV2 sliceParams;
+    for (uint64_t i = 0; i < rotary_embs_dims.size(); i++) {
+      sliceParams.axes[i] = i;
+      sliceParams.steps[i] = 1;
+      sliceParams.starts[i] = 0;
+      sliceParams.ends[i] = rotary_embs_dims[rotary_embs_dims.size() - 1 - i];
+    }
+    AddNodeSlice(
+        rotary_embs_inputs, cos_inputs, sliceParams, guid_ + "slice_cos");
+
+    std::vector<synTensor> sin_inputs;
+    auto sin_in = createTensorNoPresist("sin_in", dtype_, rotary_embs_dims);
+    sin_inputs.push_back(sin_in);
+    sliceParams.starts[rotary_embs_dims.size() - 1] = 1;
+    sliceParams.ends[rotary_embs_dims.size() - 1] = 2;
+    AddNodeSlice(
+        rotary_embs_inputs, sin_inputs, sliceParams, guid_ + "slice_sin");
+
+    rotary_embs_dims.erase(rotary_embs_dims.begin());
+    auto sin_sq =
+        createTensorNoPresist("sin_squeezed", dtype_, rotary_embs_dims);
+    std::vector<synTensor> sin_squeezed;
+    sin_squeezed.push_back(sin_sq);
+
+    synSqueezeParams squeezeParams;
+    squeezeParams.axis = 4;
+    AddNodeSqueeze(
+        sin_inputs, sin_squeezed, squeezeParams, guid_ + "squeeze_sin");
+
+    auto cos_sq =
+        createTensorNoPresist("cos_squeezed", dtype_, rotary_embs_dims);
+    std::vector<synTensor> cos_squeezed;
+    cos_squeezed.push_back(cos_sq);
+    AddNodeSqueeze(
+        cos_inputs, cos_squeezed, squeezeParams, guid_ + "squeeze_cos");
+
+    std::vector<synTensor> inputs_q;
+    std::vector<synTensor> outputs_q;
+    inputs_q.push_back(q_split);
+    inputs_q.push_back(sin_sq);
+    inputs_q.push_back(cos_sq);
+
+    auto q_states = createTensorFromCT(&ct, 0, false);
+    outputs_q.push_back(q_states);
+
+    ns_RoPESt2::ParamsV2 ropeParams;
+    ropeParams.offset = 0;
+    ropeParams.mode = ROTARY_POS_EMBEDDING_MODE_BLOCKWISE;
+    AddNodeRope<T>(inputs_q, outputs_q, ropeParams, guid_ + "rope_q");
+
+    std::vector<synTensor> inputs_k;
+    std::vector<synTensor> outputs_k;
+    inputs_k.push_back(k_split);
+    inputs_k.push_back(sin_sq);
+    inputs_k.push_back(cos_sq);
+
+    auto k_rope = createTensorNoPresist("k_rope", dtype_, kv_dims);
+    outputs_k.push_back(k_rope);
+    AddNodeRope<T>(inputs_k, outputs_k, ropeParams, guid_ + "rope_k");
+
+    std::vector<synTensor> inputs_concat;
+    std::vector<synTensor> outputs_concat;
+    inputs_concat.push_back(k_rope);
+    inputs_concat.push_back(v_split);
+
+    kv_dims[0] *= 2;
+    auto kv_concat = createTensorNoPresist("kv_concat", dtype_, kv_dims);
+    outputs_concat.push_back(kv_concat);
+
+    synConcatenateParams concatParams;
+    concatParams.axis = 3;
+    AddNodeConcat(
+        inputs_concat, outputs_concat, concatParams, guid_ + "concat");
+
+    std::vector<synTensor> outputs_stack;
+
+    auto kv_state = createTensorFromCT(&ct, 1, false);
+    outputs_stack.push_back(kv_state);
+
+    AddNodeReshape(outputs_concat, outputs_stack, guid_ + "reshaped_kv");
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
+template <typename T, typename Context>
+void FusedRmsQkvRopeTKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& src,
+    const phi::DenseTensor& qkv_weights,
+    const paddle::optional<phi::DenseTensor>& qkv_biases,
+    const phi::DenseTensor& rotary_embs,
+    const paddle::optional<phi::DenseTensor>& scale_input,
+    const paddle::optional<phi::DenseTensor>& scale_weight,
+    phi::DenseTensor* query_states,
+    phi::DenseTensor* key_value_states,
+    const phi::Scalar& epsilon,
+    const phi::Scalar& head_dim,
+    const phi::Scalar& num_head) {
+  std::vector<int64_t> src_dims = phi::vectorize<int64_t>(src.dims());
+  std::vector<int64_t> qkv_weights_dims =
+      phi::vectorize<int64_t>(qkv_weights.dims());
+
+  int head_dim_ = head_dim.to<int>();
+  int num_head_ = num_head.to<int>();
+  const int64_t fused_hidden_size = qkv_weights_dims[0];
+  const int kv_num_head =
+      (fused_hidden_size - num_head_ * head_dim_) / head_dim_ / 2;
+
+  ConvertTensors ct;
+  ct.Add(src);
+  ct.Add(qkv_weights);
+  ct.Add(rotary_embs);
+  ct.Add(query_states, false);
+  ct.Add(key_value_states, false);
+
+  std::string guid_prefix = "fused_rms_qkv_rope_t_fwd_";
+  if (qkv_biases) {
+    ct.Add(qkv_biases.get());
+    guid_prefix = "fused_rms_qkv_bias_rope_t_fwd_";
+  }
+
+  if (scale_input && scale_weight) {
+    ct.Add(scale_input.get());
+    ct.Add(scale_weight.get());
+    guid_prefix = "fused_fp8_rms_qkv_rope_t_fwd_";
+    if (qkv_biases) {
+      guid_prefix = "fused_fp8_rms_qkv_bias_rope_t_fwd_";
+    }
+  } else if (scale_input || scale_weight) {
+    throw std::runtime_error(
+        "Need both scale_input and scale_weight for FusedFp8RmsQkvRopeTKernel");
+  }
+
+  OpCacheOperator op_info;
+  op_info.prepareOpInfo<T, nullptr_t>(
+      guid_prefix, {src_dims, qkv_weights_dims}, nullptr);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedRmsQkvRopeParams params;
+    memset(
+        reinterpret_cast<void*>(&params), 0x00, sizeof(FusedRmsQkvRopeParams));
+    params.rmsnorm_params.epsValid = true;
+    params.rmsnorm_params.eps = epsilon.to<float>();
+    params.head_dim = head_dim_;
+    params.num_head = num_head_;
+    params.kv_num_head = kv_num_head;
+    if (qkv_biases) {
+      params.with_qkv_biases = true;
+    }
+    if (scale_input) {
+      params.use_fp8 = true;
+    }
+
+    FusedRmsQkvRopeT op(guid_prefix, op_info.datatype_);
+    op.AddNode<T>(ct, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+}  // namespace custom_kernel
+
+template <typename Context>
+void CallFusedRmsQkvRopeTKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& src,
+    const phi::DenseTensor& qkv_weights,
+    const paddle::optional<phi::DenseTensor>& qkv_biases,
+    const phi::DenseTensor& rotary_embs,
+    const paddle::optional<phi::DenseTensor>& scale_input,
+    const paddle::optional<phi::DenseTensor>& scale_weight,
+    phi::DenseTensor* query_states,
+    phi::DenseTensor* key_value_states,
+    const phi::Scalar& epsilon,
+    const phi::Scalar& head_dim,
+    const phi::Scalar& num_head) {
+  if (src.dtype() == phi::DataType::FLOAT16) {
+    custom_kernel::FusedRmsQkvRopeTKernel<phi::dtype::float16>(dev_ctx,
+                                                               src,
+                                                               qkv_weights,
+                                                               qkv_biases,
+                                                               rotary_embs,
+                                                               scale_input,
+                                                               scale_weight,
+                                                               query_states,
+                                                               key_value_states,
+                                                               epsilon,
+                                                               head_dim,
+                                                               num_head);
+  } else if (src.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedRmsQkvRopeTKernel<phi::dtype::bfloat16>(
+        dev_ctx,
+        src,
+        qkv_weights,
+        qkv_biases,
+        rotary_embs,
+        scale_input,
+        scale_weight,
+        query_states,
+        key_value_states,
+        epsilon,
+        head_dim,
+        num_head);
+  } else {
+    throw std::runtime_error(
+        "Unsupported data type for FusedRmsQkvRopeTKernel");
+  }
+}
+
+std::vector<paddle::Tensor> FusedRmsQkvRopeTImpl(
+    const paddle::Tensor& src,
+    const paddle::Tensor& qkv_weights,
+    const paddle::optional<paddle::Tensor>& qkv_biases,
+    const paddle::Tensor& rotary_embs,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
+  auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto qkv_weights_tensor =
+      static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
+  auto rotary_embs_tensor =
+      static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
+
+  auto qkv_biases_tensor = paddle::optional<phi::DenseTensor>();
+  if (qkv_biases) {
+    auto qkv_biases_dt =
+        static_cast<phi::DenseTensor*>(qkv_biases->impl().get());
+    qkv_biases_tensor = paddle::optional<phi::DenseTensor>(*qkv_biases_dt);
+  }
+
+  // allocate memory on device.
+  int64_t bsz = src.dims()[0];
+  int64_t seq_len = src.dims()[1];
+  int64_t fused_hidden_size = qkv_weights.dims()[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+
+  std::shared_ptr<phi::DenseTensor> query_states =
+      std::make_shared<phi::DenseTensor>();
+  query_states->Resize(phi::make_ddim({bsz, seq_len, num_head, head_dim}));
+  dev_ctx->Alloc(query_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> key_value_states =
+      std::make_shared<phi::DenseTensor>();
+  key_value_states->Resize(
+      phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
+  dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
+
+  CallFusedRmsQkvRopeTKernel(*dev_ctx,
+                             *src_tensor,
+                             *qkv_weights_tensor,
+                             qkv_biases_tensor,
+                             *rotary_embs_tensor,
+                             paddle::optional<phi::DenseTensor>(),
+                             paddle::optional<phi::DenseTensor>(),
+                             query_states.get(),
+                             key_value_states.get(),
+                             phi::Scalar(epsilon),
+                             phi::Scalar(head_dim),
+                             phi::Scalar(num_head));
+  return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
+}
+
+std::vector<std::vector<int64_t>> FusedRmsQkvRopeTShape(
+    const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& qkv_weights_shape,
+    const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
+    const std::vector<int64_t>& rotary_embs_shape,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  int64_t bsz = src_shape[0];
+  int64_t seq_len = src_shape[1];
+  int64_t fused_hidden_size = qkv_weights_shape[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+  return {{bsz, seq_len, num_head, head_dim},
+          {2, bsz, seq_len, kv_num_head, head_dim}};
+}
+
+std::vector<paddle::DataType> FusedRmsQkvRopeTDtype(
+    const paddle::DataType& src_dtype,
+    const paddle::DataType& qkv_weights_dtype,
+    const paddle::optional<paddle::DataType>& qkv_biases_dtype,
+    const paddle::DataType& rotary_embs_dtype) {
+  return {src_dtype, src_dtype};
+}
+
+PD_BUILD_OP(fused_qkv_rope)
+    .Inputs(
+        {"src", "qkv_weights", paddle::Optional("qkv_biases"), "rotary_embs"})
+    .Outputs({"query_states", "key_value_states"})
+    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .SetKernelFn(PD_KERNEL(FusedRmsQkvRopeTImpl))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedRmsQkvRopeTShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedRmsQkvRopeTDtype));
+
+std::vector<paddle::Tensor> FusedFp8RmsQkvRopeTImpl(
+    const paddle::Tensor& src,
+    const paddle::Tensor& qkv_weights,
+    const paddle::optional<paddle::Tensor>& qkv_biases,
+    const paddle::Tensor& rotary_embs,
+    const paddle::Tensor& scale_input,
+    const paddle::Tensor& scale_weight,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
+  auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto qkv_weights_tensor =
+      static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
+  auto rotary_embs_tensor =
+      static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
+
+  auto qkv_biases_tensor = paddle::optional<phi::DenseTensor>();
+  if (qkv_biases) {
+    auto qkv_biases_dt =
+        static_cast<phi::DenseTensor*>(qkv_biases->impl().get());
+    qkv_biases_tensor = paddle::optional<phi::DenseTensor>(*qkv_biases_dt);
+  }
+
+  auto _scale_input =
+      static_cast<const phi::DenseTensor*>(scale_input.impl().get());
+  auto scale_input_tensor = paddle::optional<phi::DenseTensor>(*_scale_input);
+  auto _scale_weight =
+      static_cast<const phi::DenseTensor*>(scale_weight.impl().get());
+  auto scale_weight_tensor = paddle::optional<phi::DenseTensor>(*_scale_weight);
+
+  // allocate memory on device.
+  int64_t bsz = src.dims()[0];
+  int64_t seq_len = src.dims()[1];
+  int64_t fused_hidden_size = qkv_weights.dims()[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+
+  std::shared_ptr<phi::DenseTensor> query_states =
+      std::make_shared<phi::DenseTensor>();
+  query_states->Resize(phi::make_ddim({bsz, seq_len, num_head, head_dim}));
+  dev_ctx->Alloc(query_states.get(), src_tensor->dtype());
+
+  std::shared_ptr<phi::DenseTensor> key_value_states =
+      std::make_shared<phi::DenseTensor>();
+  key_value_states->Resize(
+      phi::make_ddim({2, bsz, seq_len, kv_num_head, head_dim}));
+  dev_ctx->Alloc(key_value_states.get(), src_tensor->dtype());
+
+  CallFusedRmsQkvRopeTKernel(*dev_ctx,
+                             *src_tensor,
+                             *qkv_weights_tensor,
+                             qkv_biases_tensor,
+                             *rotary_embs_tensor,
+                             scale_input_tensor,
+                             scale_weight_tensor,
+                             query_states.get(),
+                             key_value_states.get(),
+                             phi::Scalar(epsilon),
+                             phi::Scalar(head_dim),
+                             phi::Scalar(num_head));
+  return {paddle::Tensor(query_states), paddle::Tensor(key_value_states)};
+}
+
+std::vector<std::vector<int64_t>> FusedFp8RmsQkvRopeTShape(
+    const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& qkv_weights_shape,
+    const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
+    const std::vector<int64_t>& rotary_embs_shape,
+    const std::vector<int64_t>& scale_input_shape,
+    const std::vector<int64_t>& scale_weight_shape,
+    float epsilon,
+    int head_dim,
+    int num_head) {
+  int64_t bsz = src_shape[0];
+  int64_t seq_len = src_shape[1];
+  int64_t fused_hidden_size = qkv_weights_shape[0];
+  int kv_num_head = (fused_hidden_size - num_head * head_dim) / head_dim / 2;
+  return {{bsz, seq_len, num_head, head_dim},
+          {2, bsz, seq_len, kv_num_head, head_dim}};
+}
+
+std::vector<paddle::DataType> FusedFp8RmsQkvRopeTDtype(
+    const paddle::DataType& src_dtype,
+    const paddle::DataType& qkv_weights_dtype,
+    const paddle::optional<paddle::DataType>& qkv_biases_dtype,
+    const paddle::DataType& rotary_embs_dtype,
+    const paddle::DataType& scale_input_dtype,
+    const paddle::DataType& scale_weight_dtype) {
+  return {src_dtype, src_dtype};
+}
+
+PD_BUILD_OP(fused_fp8_qkv_rope_t)
+    .Inputs({"src",
+             "qkv_weights",
+             paddle::Optional("qkv_biases"),
+             "rotary_embs",
+             "scale_input",
+             "scale_weight"})
+    .Outputs({"query_states", "key_value_states"})
+    .Attrs({"epsilon: float", "head_dim: int", "num_head: int"})
+    .SetKernelFn(PD_KERNEL(FusedFp8RmsQkvRopeTImpl))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedFp8RmsQkvRopeTShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedFp8RmsQkvRopeTDtype));

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_rms_block_attention.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_rms_block_attention.cc
@@ -21,7 +21,7 @@
 
 namespace custom_kernel {
 
-struct FusedBlockAttentionParams {
+struct FusedRmsBlockAttentionParams {
   ns_LayerNormKernel::Params rmsnorm_params;
   ns_ConstantKernel::Params const_params;
   ns_GatherKernel::Params index_select_params;
@@ -35,29 +35,31 @@ struct FusedBlockAttentionParams {
   bool with_qkv_biases = false;
 };
 
-class FusedMHABlockAttention : public HpuFusedOperator {
+class FusedRmsMHABlockAttention : public HpuFusedOperator {
  public:
-  explicit FusedMHABlockAttention(std::string guid_prefix, synDataType dtype)
+  explicit FusedRmsMHABlockAttention(std::string guid_prefix, synDataType dtype)
       : HpuFusedOperator(guid_prefix, false), dtype_(dtype) {}
   template <typename T>
-  void AddNode(ConvertTensors& ct, FusedBlockAttentionParams& params) {
+  void AddNode(ConvertTensors& ct, FusedRmsBlockAttentionParams& params) {
     auto ins = ct.GetTensors();
     auto outs = ct.GetTensors(false);
 
     int index_base = 0;
     int src_index = (index_base++);             // 0
-    int rotary_embs_index = (index_base++);     // 1
-    int key_cache_index = (index_base++);       // 2
-    int value_cache_index = (index_base++);     // 3
-    int block_groups_index = (index_base++);    // 4
-    int block_list_index = (index_base++);      // 5
-    int block_mapping_index = (index_base++);   // 6
-    int block_bias_index = (index_base++);      // 7
-    int block_indices_index = (index_base++);   // 8
-    int block_offsets_index = (index_base++);   // 9
-    int qkv_weights_index = (index_base++);     // 10
-    int linear_weights_index = (index_base++);  // 11
-    int qkv_biases_index = (index_base++);      // 12
+    int residual_index = (index_base++);        // 1
+    int rotary_embs_index = (index_base++);     // 2
+    int key_cache_index = (index_base++);       // 3
+    int value_cache_index = (index_base++);     // 4
+    int block_groups_index = (index_base++);    // 5
+    int block_list_index = (index_base++);      // 6
+    int block_mapping_index = (index_base++);   // 7
+    int block_bias_index = (index_base++);      // 8
+    int block_indices_index = (index_base++);   // 9
+    int block_offsets_index = (index_base++);   // 10
+    int ln_scales_index = (index_base++);       // 11
+    int qkv_weights_index = (index_base++);     // 12
+    int linear_weights_index = (index_base++);  // 13
+    int qkv_biases_index = (index_base++);      // 14
 
     std::vector<int64_t> src_dims = std::vector<int64_t>(ins[src_index].dims);
 
@@ -83,16 +85,49 @@ class FusedMHABlockAttention : public HpuFusedOperator {
     gemm_params_f_t.transpose_a = false;
     gemm_params_f_t.transpose_b = true;
 
+    synSectionHandle residual_section = createSection();
     auto src = createTensorFromCT(&ct, src_index);
+    auto residual =
+        createTensorFromCT(&ct, residual_index, true, residual_section);
+    auto residual_out = createTensorFromCT(&ct, 3, false, residual_section);
+
+    std::vector<synTensor> add_residual_in;
+    add_residual_in.push_back(src);
+    add_residual_in.push_back(residual);
+
+    std::vector<synTensor> add_residual_out;
+    add_residual_out.push_back(residual_out);
+
+    AddNodeAdd<T>(add_residual_in, add_residual_out, guid_ + "add_residual");
+
+    auto ln_scales = createTensorFromCT(&ct, ln_scales_index);
+
+    std::vector<synTensor> rmsnorm_inputs;
+    rmsnorm_inputs.push_back(residual_out);
+    rmsnorm_inputs.push_back(ln_scales);
+
+    auto tmp_dims = src_dims;
+    tmp_dims[2] = 1;
+    auto norm_out = createTensorNoPresist("norm_out", dtype_, src_dims);
+    auto norm_var = createTensorNoPresist("norm_var", dtype_, tmp_dims);
+
+    std::vector<synTensor> rmsnorm_outputs;
+    rmsnorm_outputs.push_back(norm_out);
+    rmsnorm_outputs.push_back(norm_var);
+
+    AddNodeRmsNorm<T>(rmsnorm_inputs,
+                      rmsnorm_outputs,
+                      params.rmsnorm_params,
+                      guid_ + "rmsnorm");
+
     auto qkv_weights = createTensorFromCT(&ct, qkv_weights_index);
     std::vector<synTensor> linear_inputs;
-    linear_inputs.push_back(src);
+    linear_inputs.push_back(norm_out);
     linear_inputs.push_back(qkv_weights);
     if (params.with_qkv_biases) {
       auto qkv_biases = createTensorFromCT(&ct, qkv_biases_index);
       linear_inputs.push_back(qkv_biases);
     }
-    auto tmp_dims = src_dims;
     auto wt_dims = ins[qkv_weights_index].dims;
     tmp_dims[2] = wt_dims[0];
 
@@ -730,29 +765,31 @@ class FusedMHABlockAttention : public HpuFusedOperator {
   synDataType dtype_;
 };
 
-class FusedGQABlockAttention : public HpuFusedOperator {
+class FusedRmsGQABlockAttention : public HpuFusedOperator {
  public:
-  explicit FusedGQABlockAttention(std::string guid_prefix, synDataType dtype)
+  explicit FusedRmsGQABlockAttention(std::string guid_prefix, synDataType dtype)
       : HpuFusedOperator(guid_prefix, false), dtype_(dtype) {}
   template <typename T>
-  void AddNode(ConvertTensors& ct, FusedBlockAttentionParams& params) {
+  void AddNode(ConvertTensors& ct, FusedRmsBlockAttentionParams& params) {
     auto ins = ct.GetTensors();
     auto outs = ct.GetTensors(false);
 
     int index_base = 0;
     int src_index = (index_base++);             // 0
-    int rotary_embs_index = (index_base++);     // 1
-    int key_cache_index = (index_base++);       // 2
-    int value_cache_index = (index_base++);     // 3
-    int block_groups_index = (index_base++);    // 4
-    int block_list_index = (index_base++);      // 5
-    int block_mapping_index = (index_base++);   // 6
-    int block_bias_index = (index_base++);      // 7
-    int block_indices_index = (index_base++);   // 8
-    int block_offsets_index = (index_base++);   // 9
-    int qkv_weights_index = (index_base++);     // 10
-    int linear_weights_index = (index_base++);  // 11
-    int qkv_biases_index = (index_base++);      // 12
+    int residual_index = (index_base++);        // 1
+    int rotary_embs_index = (index_base++);     // 2
+    int key_cache_index = (index_base++);       // 3
+    int value_cache_index = (index_base++);     // 4
+    int block_groups_index = (index_base++);    // 5
+    int block_list_index = (index_base++);      // 6
+    int block_mapping_index = (index_base++);   // 7
+    int block_bias_index = (index_base++);      // 8
+    int block_indices_index = (index_base++);   // 9
+    int block_offsets_index = (index_base++);   // 10
+    int ln_scales_index = (index_base++);       // 11
+    int qkv_weights_index = (index_base++);     // 12
+    int linear_weights_index = (index_base++);  // 13
+    int qkv_biases_index = (index_base++);      // 14
 
     std::vector<int64_t> src_dims = std::vector<int64_t>(ins[src_index].dims);
 
@@ -779,16 +816,49 @@ class FusedGQABlockAttention : public HpuFusedOperator {
     gemm_params_f_t.transpose_a = false;
     gemm_params_f_t.transpose_b = true;
 
+    synSectionHandle residual_section = createSection();
     auto src = createTensorFromCT(&ct, src_index);
+    auto residual =
+        createTensorFromCT(&ct, residual_index, true, residual_section);
+    auto residual_out = createTensorFromCT(&ct, 3, false, residual_section);
+
+    std::vector<synTensor> add_residual_in;
+    add_residual_in.push_back(src);
+    add_residual_in.push_back(residual);
+
+    std::vector<synTensor> add_residual_out;
+    add_residual_out.push_back(residual_out);
+
+    AddNodeAdd<T>(add_residual_in, add_residual_out, guid_ + "add_residual");
+
+    auto ln_scales = createTensorFromCT(&ct, ln_scales_index);
+
+    std::vector<synTensor> rmsnorm_inputs;
+    rmsnorm_inputs.push_back(residual_out);
+    rmsnorm_inputs.push_back(ln_scales);
+
+    auto tmp_dims = src_dims;
+    tmp_dims[2] = 1;
+    auto norm_out = createTensorNoPresist("norm_out", dtype_, src_dims);
+    auto norm_var = createTensorNoPresist("norm_var", dtype_, tmp_dims);
+
+    std::vector<synTensor> rmsnorm_outputs;
+    rmsnorm_outputs.push_back(norm_out);
+    rmsnorm_outputs.push_back(norm_var);
+
+    AddNodeRmsNorm<T>(rmsnorm_inputs,
+                      rmsnorm_outputs,
+                      params.rmsnorm_params,
+                      guid_ + "rmsnorm");
+
     auto qkv_weights = createTensorFromCT(&ct, qkv_weights_index);
     std::vector<synTensor> linear_inputs;
-    linear_inputs.push_back(src);
+    linear_inputs.push_back(norm_out);
     linear_inputs.push_back(qkv_weights);
     if (params.with_qkv_biases) {
       auto qkv_biases = createTensorFromCT(&ct, qkv_biases_index);
       linear_inputs.push_back(qkv_biases);
     }
-    auto tmp_dims = src_dims;
     auto wt_dims = ins[qkv_weights_index].dims;
     tmp_dims[2] = wt_dims[0];
 
@@ -1472,9 +1542,10 @@ class FusedGQABlockAttention : public HpuFusedOperator {
 };
 
 template <typename T, typename Context>
-void FusedBlockAttentionKernel(
+void FusedRmsBlockAttentionKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& src,
+    const phi::DenseTensor& residual,
     const phi::DenseTensor& rotary_embs,
     const phi::DenseTensor& key_cache,
     const phi::DenseTensor& value_cache,
@@ -1484,6 +1555,7 @@ void FusedBlockAttentionKernel(
     const phi::DenseTensor& block_bias,
     const phi::DenseTensor& block_indices,
     const phi::DenseTensor& block_offsets,
+    const phi::DenseTensor& ln_scales,
     const phi::DenseTensor& qkv_weights,
     const paddle::optional<phi::DenseTensor>& qkv_biases,
     const phi::DenseTensor& linear_weights,
@@ -1504,6 +1576,7 @@ void FusedBlockAttentionKernel(
 
   ConvertTensors ct;
   ct.Add(src);
+  ct.Add(residual);
   ct.Add(rotary_embs);
   ct.Add(key_cache);
   ct.Add(value_cache);
@@ -1514,11 +1587,13 @@ void FusedBlockAttentionKernel(
   ct.Add(block_bias);
   ct.Add(block_indices);
   ct.Add(block_offsets);
+  ct.Add(ln_scales);
   ct.Add(qkv_weights);
   ct.Add(linear_weights);
   ct.Add(out_linear, false);
   ct.Add(key_cache, false);
   ct.Add(value_cache, false);
+  ct.Add(residual, false);
 
   std::string guid_prefix = "fused_block_attention_";
   if (qkv_biases) {
@@ -1537,10 +1612,10 @@ void FusedBlockAttentionKernel(
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    FusedBlockAttentionParams params;
+    FusedRmsBlockAttentionParams params;
     memset(reinterpret_cast<void*>(&params),
            0x00,
-           sizeof(FusedBlockAttentionParams));
+           sizeof(FusedRmsBlockAttentionParams));
     params.rmsnorm_params.epsValid = true;
     params.rmsnorm_params.eps = epsilon.to<float>();
     params.const_params.constant.f = scaling_factor.to<float>();
@@ -1557,12 +1632,12 @@ void FusedBlockAttentionKernel(
     }
 
     if (num_head_ == num_kv_head) {
-      FusedMHABlockAttention op(guid_prefix, op_info.datatype_);
+      FusedRmsMHABlockAttention op(guid_prefix, op_info.datatype_);
       op.AddNode<T>(ct, params);
       op.Compile();
       op_info.setOp(op);
     } else {
-      FusedGQABlockAttention op(guid_prefix, op_info.datatype_);
+      FusedRmsGQABlockAttention op(guid_prefix, op_info.datatype_);
       op.AddNode<T>(ct, params);
       op.Compile();
       op_info.setOp(op);
@@ -1579,9 +1654,10 @@ void FusedBlockAttentionKernel(
 }  // namespace custom_kernel
 
 template <typename Context>
-void CallFusedBlockAttentionKernel(
+void CallFusedRmsBlockAttentionKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& src,
+    const phi::DenseTensor& residual,
     const phi::DenseTensor& rotary_embs,
     const phi::DenseTensor& key_cache,
     const phi::DenseTensor& value_cache,
@@ -1591,6 +1667,7 @@ void CallFusedBlockAttentionKernel(
     const phi::DenseTensor& block_bias,
     const phi::DenseTensor& block_indices,
     const phi::DenseTensor& block_offsets,
+    const phi::DenseTensor& ln_scales,
     const phi::DenseTensor& qkv_weights,
     const paddle::optional<phi::DenseTensor>& qkv_biases,
     const phi::DenseTensor& linear_weights,
@@ -1600,9 +1677,10 @@ void CallFusedBlockAttentionKernel(
     const phi::Scalar& num_head,
     const phi::Scalar& scaling_factor) {
   if (src.dtype() == phi::DataType::FLOAT16) {
-    custom_kernel::FusedBlockAttentionKernel<phi::dtype::float16>(
+    custom_kernel::FusedRmsBlockAttentionKernel<phi::dtype::float16>(
         dev_ctx,
         src,
+        residual,
         rotary_embs,
         key_cache,
         value_cache,
@@ -1612,6 +1690,7 @@ void CallFusedBlockAttentionKernel(
         block_bias,
         block_indices,
         block_offsets,
+        ln_scales,
         qkv_weights,
         qkv_biases,
         linear_weights,
@@ -1621,9 +1700,10 @@ void CallFusedBlockAttentionKernel(
         num_head,
         scaling_factor);
   } else if (src.dtype() == phi::DataType::BFLOAT16) {
-    custom_kernel::FusedBlockAttentionKernel<phi::dtype::bfloat16>(
+    custom_kernel::FusedRmsBlockAttentionKernel<phi::dtype::bfloat16>(
         dev_ctx,
         src,
+        residual,
         rotary_embs,
         key_cache,
         value_cache,
@@ -1633,6 +1713,7 @@ void CallFusedBlockAttentionKernel(
         block_bias,
         block_indices,
         block_offsets,
+        ln_scales,
         qkv_weights,
         qkv_biases,
         linear_weights,
@@ -1643,12 +1724,13 @@ void CallFusedBlockAttentionKernel(
         scaling_factor);
   } else {
     throw std::runtime_error(
-        "Unsupported data type for FusedBlockAttentionKernel");
+        "Unsupported data type for FusedRmsBlockAttentionKernel");
   }
 }
 
-std::vector<paddle::Tensor> FusedBlockAttentionForward(
+std::vector<paddle::Tensor> FusedRmsBlockAttentionForward(
     const paddle::Tensor& src,
+    const paddle::Tensor& residual,
     const paddle::Tensor& rotary_embs,
     const paddle::Tensor& key_cache,
     const paddle::Tensor& value_cache,
@@ -1658,6 +1740,7 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
     const paddle::Tensor& block_bias,
     const paddle::Tensor& block_indices,
     const paddle::Tensor& block_offsets,
+    const paddle::Tensor& ln_scales,
     const paddle::Tensor& qkv_weights,
     const paddle::optional<paddle::Tensor>& qkv_biases,
     const paddle::Tensor& linear_weights,
@@ -1668,6 +1751,8 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
   auto dev_ctx = static_cast<const phi::CustomContext*>(
       paddle::experimental::DeviceContextPool::Instance().Get(src.place()));
   auto src_tensor = static_cast<const phi::DenseTensor*>(src.impl().get());
+  auto residual_tensor =
+      static_cast<const phi::DenseTensor*>(residual.impl().get());
   auto rotary_embs_tensor =
       static_cast<const phi::DenseTensor*>(rotary_embs.impl().get());
   auto key_cache_tensor =
@@ -1686,6 +1771,8 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
       static_cast<const phi::DenseTensor*>(block_indices.impl().get());
   auto block_offsets_tensor =
       static_cast<const phi::DenseTensor*>(block_offsets.impl().get());
+  auto ln_scales_tensor =
+      static_cast<const phi::DenseTensor*>(ln_scales.impl().get());
   auto qkv_weights_tensor =
       static_cast<const phi::DenseTensor*>(qkv_weights.impl().get());
   auto linear_weights_tensor =
@@ -1707,30 +1794,33 @@ std::vector<paddle::Tensor> FusedBlockAttentionForward(
   out_linear->Resize(phi::make_ddim({batch_size, 1, out_features}));
   dev_ctx->Alloc(out_linear.get(), src_tensor->dtype());
 
-  CallFusedBlockAttentionKernel(*dev_ctx,
-                                *src_tensor,
-                                *rotary_embs_tensor,
-                                *key_cache_tensor,
-                                *value_cache_tensor,
-                                *block_groups_tensor,
-                                *block_list_tensor,
-                                *block_mapping_tensor,
-                                *block_bias_tensor,
-                                *block_indices_tensor,
-                                *block_offsets_tensor,
-                                *qkv_weights_tensor,
-                                qkv_biases_tensor,
-                                *linear_weights_tensor,
-                                out_linear.get(),
-                                phi::Scalar(epsilon),
-                                phi::Scalar(head_dim),
-                                phi::Scalar(num_head),
-                                phi::Scalar(scaling_factor));
+  CallFusedRmsBlockAttentionKernel(*dev_ctx,
+                                   *src_tensor,
+                                   *residual_tensor,
+                                   *rotary_embs_tensor,
+                                   *key_cache_tensor,
+                                   *value_cache_tensor,
+                                   *block_groups_tensor,
+                                   *block_list_tensor,
+                                   *block_mapping_tensor,
+                                   *block_bias_tensor,
+                                   *block_indices_tensor,
+                                   *block_offsets_tensor,
+                                   *ln_scales_tensor,
+                                   *qkv_weights_tensor,
+                                   qkv_biases_tensor,
+                                   *linear_weights_tensor,
+                                   out_linear.get(),
+                                   phi::Scalar(epsilon),
+                                   phi::Scalar(head_dim),
+                                   phi::Scalar(num_head),
+                                   phi::Scalar(scaling_factor));
   return {paddle::Tensor(out_linear)};
 }
 
-std::vector<std::vector<int64_t>> FusedBlockAttentionShape(
+std::vector<std::vector<int64_t>> FusedRmsBlockAttentionShape(
     const std::vector<int64_t>& src_shape,
+    const std::vector<int64_t>& residual_shape,
     const std::vector<int64_t>& rotary_embs_shape,
     const std::vector<int64_t>& key_cache_shape,
     const std::vector<int64_t>& value_cache_shape,
@@ -1740,6 +1830,7 @@ std::vector<std::vector<int64_t>> FusedBlockAttentionShape(
     const std::vector<int64_t>& block_bias_shape,
     const std::vector<int64_t>& block_indices_shape,
     const std::vector<int64_t>& block_offsets_shape,
+    const std::vector<int64_t>& ln_scales_shape,
     const std::vector<int64_t>& qkv_weights_shape,
     const paddle::optional<std::vector<int64_t>>& qkv_biases_shape,
     const std::vector<int64_t>& linear_weights_shape,
@@ -1752,8 +1843,9 @@ std::vector<std::vector<int64_t>> FusedBlockAttentionShape(
   return {{batch_size, 1, out_features}};
 }
 
-std::vector<paddle::DataType> FusedBlockAttentionDtype(
+std::vector<paddle::DataType> FusedRmsBlockAttentionDtype(
     const paddle::DataType& src_dtype,
+    const paddle::DataType& residual_dtype,
     const paddle::DataType& rotary_embs_dtype,
     const paddle::DataType& key_cache_dtype,
     const paddle::DataType& value_cache_dtype,
@@ -1763,14 +1855,16 @@ std::vector<paddle::DataType> FusedBlockAttentionDtype(
     const paddle::DataType& block_bias_dtype,
     const paddle::DataType& block_indices_dtype,
     const paddle::DataType& block_offsets_dtype,
+    const paddle::DataType& ln_scales_dtype,
     const paddle::DataType& qkv_weights_dtype,
     const paddle::optional<paddle::DataType>& qkv_biases_dtype,
     const paddle::DataType& linear_weights_dtype) {
   return {src_dtype};
 }
 
-PD_BUILD_OP(fused_block_attention)
+PD_BUILD_OP(fused_rms_block_attention)
     .Inputs({"src",
+             "residual",
              "rotary_embs",
              "key_cache",
              "value_cache",
@@ -1780,6 +1874,7 @@ PD_BUILD_OP(fused_block_attention)
              "block_bias",
              "block_indices",
              "block_offsets",
+             "ln_scales",
              "qkv_weights",
              paddle::Optional("qkv_biases"),
              "linear_weights"})
@@ -1788,6 +1883,6 @@ PD_BUILD_OP(fused_block_attention)
             "head_dim: int",
             "num_head: int",
             "scaling_factor: float"})
-    .SetKernelFn(PD_KERNEL(FusedBlockAttentionForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(FusedBlockAttentionShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(FusedBlockAttentionDtype));
+    .SetKernelFn(PD_KERNEL(FusedRmsBlockAttentionForward))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedRmsBlockAttentionShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedRmsBlockAttentionDtype));

--- a/backends/intel_hpu/kernels/rms_norm_kernel.cc
+++ b/backends/intel_hpu/kernels/rms_norm_kernel.cc
@@ -31,8 +31,43 @@ class RMS : public HpuOperator {
     std::vector<synTensor> inputs;
     std::vector<synTensor> outputs;
 
-    auto x = createTensor(ins[0].size(), dtype_, ins[0], true, "x");
-    inputs.push_back(x);
+    if (ins.size() > 2) {
+      std::vector<synTensor> add_inputs;
+      std::vector<synTensor> add_outputs;
+
+      auto x = createTensor(ins[2].size(), dtype_, ins[2], true, "x");
+      add_inputs.push_back(x);
+
+      auto residual =
+          createTensor(ins[2].size(), dtype_, ins[2], true, "residual");
+      add_inputs.push_back(residual);
+
+      auto residual_out =
+          createTensor(ins[2].size(), dtype_, ins[2], true, "residual_out");
+      add_outputs.push_back(residual_out);
+
+      std::string add_guid_ = "add_fwd_" + SynDataTypeToStr(dtype_);
+      synStatus status = synNodeCreate(graphHandle_,
+                                       add_inputs.data(),
+                                       add_outputs.data(),
+                                       add_inputs.size(),
+                                       add_outputs.size(),
+                                       nullptr,
+                                       0,
+                                       add_guid_.c_str(),
+                                       "Add",
+                                       nullptr,
+                                       nullptr);
+      PD_CHECK(status == synSuccess,
+               "[RUNTIME] synNodeCreate () failed = %d",
+               status);
+
+      inputs.push_back(residual_out);
+    } else {
+      auto x = createTensor(ins[0].size(), dtype_, ins[0], true, "x");
+      inputs.push_back(x);
+    }
+
     // syn_type_single
     auto w = createTensor(ins[1].size(), dtype_, ins[1], true, "w");
     inputs.push_back(w);
@@ -86,6 +121,12 @@ void RmsNormKernel(const Context& dev_ctx,
   std::vector<int64_t> outputs_dim = phi::vectorize<int64_t>(out->dims());
   std::vector<int64_t> inv_var_dim = phi::vectorize<int64_t>(inv_var->dims());
 
+  std::vector<int64_t> residual_dims;
+  if (residual) {
+    dev_ctx.template Alloc<T>(residual_out);
+    residual_dims = phi::vectorize<int64_t>(residual->dims());
+  }
+
   std::vector<int64_t> x_reshape_dims;
   for (int i = 0; i < begin_norm_axis; ++i) {
     x_reshape_dims.push_back(x_dims[i]);
@@ -110,13 +151,24 @@ void RmsNormKernel(const Context& dev_ctx,
   params.eps = epsilon;
 
   OpCacheOperator op_info;
-  op_info.prepareOpInfo<T, ns_LayerNormKernel::Params>(
-      "rms_norm_ex_fwd", {x_reshape_dims, w_dims}, &params);
+  if (residual) {
+    op_info.prepareOpInfo<T, ns_LayerNormKernel::Params>(
+        "rms_norm_ex_fwd", {x_reshape_dims, w_dims, residual_dims}, &params);
+  } else {
+    op_info.prepareOpInfo<T, ns_LayerNormKernel::Params>(
+        "rms_norm_ex_fwd", {x_reshape_dims, w_dims}, &params);
+  }
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
     RMS op(op_info.guid_, op_info.datatype_);
-    op.AddNode({x_reshape_dims, w_dims}, {outputs_dim, inv_var_dim}, params);
+    if (residual) {
+      op.AddNode({x_reshape_dims, w_dims, residual_dims},
+                 {outputs_dim, inv_var_dim},
+                 params);
+    } else {
+      op.AddNode({x_reshape_dims, w_dims}, {outputs_dim, inv_var_dim}, params);
+    }
     op.Compile();
     op_info.setOp(op);
 
@@ -126,6 +178,11 @@ void RmsNormKernel(const Context& dev_ctx,
   std::map<std::string, uint64_t> tensors;
   tensors["x"] = reinterpret_cast<uint64_t>(x.data<T>());
   tensors["w"] = reinterpret_cast<uint64_t>(norm_weight.data<T>());
+  if (residual) {
+    tensors["residual"] = reinterpret_cast<uint64_t>(residual->data<T>());
+    tensors["residual_out"] =
+        reinterpret_cast<uint64_t>(residual_out->data<T>());
+  }
   tensors["out"] = reinterpret_cast<uint64_t>(out->data<T>());
   tensors["inv_var"] = reinterpret_cast<uint64_t>(inv_var->data<T>());
 


### PR DESCRIPTION
- 为了与fastdeploy保持一致，将rmsNorm从各fused OP中分离出来。
- fused_rms_norm增加对residual的支持