### PR TITLE
[NPU] Add pandas minimal requirement for NPU

### DIFF
--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -120,7 +120,7 @@ def main():
         include_package_data=True,
         install_requires=[
             "pandas>=1.4.3"
-        ]
+        ],
         package_data = {
             '': ['*.so', '*.h', '*.py', '*.hpp'],
         },

--- a/backends/npu/setup.py.in
+++ b/backends/npu/setup.py.in
@@ -118,6 +118,9 @@ def main():
             'paddle_custom_device.npu.profile'
         ],
         include_package_data=True,
+        install_requires=[
+            "pandas>=1.4.3"
+        ]
         package_data = {
             '': ['*.so', '*.h', '*.py', '*.hpp'],
         },


### PR DESCRIPTION
为 NPU 包添加依赖约束 pandas >= 1.4.3。

低于 1.4.3 的 pandas 会导致 np.numeric.dtype 为 None https://stackoverflow.com/a/71879536 ，该 API 被昇腾使用，从而导致 TimesNetAd 在NPU 上推理报错：
```text
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py", line 670, in __init__
    self.dtype = numeric.dtype(int_type)
TypeError: 'NoneType' object is not callable
```