### PR TITLE
[INTEL_HPU] Fix the synGraphCompile issue of fused_quant

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_quant.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_quant.cc
@@ -55,7 +55,7 @@ class FusedQuant : public HpuOperator {
                                 inputs[0].type,
                                 inputs[0].dims,
                                 false,
-                                inputs[0].name);
+                                "abs_out");
     std::vector<synTensor> abs_outputs;
     abs_outputs.push_back(abs_out);
     status = synNodeCreate(graphHandle_,
@@ -79,7 +79,7 @@ class FusedQuant : public HpuOperator {
                                 outputs[0].type,
                                 outputs[0].dims,
                                 false,
-                                outputs[0].name);
+                                "max_out");
 
     std::vector<synTensor> max_outputs;
     max_outputs.push_back(max_out);

--- a/backends/intel_hpu/tests/unittests/test_fused_quant.py
+++ b/backends/intel_hpu/tests/unittests/test_fused_quant.py
@@ -48,6 +48,18 @@ class TestFusedQuant(unittest.TestCase):
             mismatch_percentage <= 0.02
         ), f"Mismatched elements percentage: {mismatch_percentage:}% > {0.02}% threshold\n"
 
+        input = input.transpose([0, 1, 3, 2])
+        quant, scale = paddlenlp_ops.fused_quant(input)
+        quant = quant.to(dtype="float32")
+        dequant = paddle.multiply(quant, scale)
+
+        close_mask = np.isclose(dequant, input.to(dtype="float32"), rtol=1e-01)
+        mismatch_count = np.sum(~close_mask)
+        mismatch_percentage = mismatch_count / np.size(input) * 100.0
+        assert (
+            mismatch_percentage <= 0.02
+        ), f"Mismatched elements percentage: {mismatch_percentage:}% > {0.02}% threshold\n"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. When calling paddlenlp_ops.fused_quant the second time with different tensor shapes, graph compiling error will be triggered. It has been root caused to use the repeated name for creating different tensors.
2. Modified the associated test to cover the issue mentioned above.