### PR TITLE
[INTEL_HPU] change fused_quant scale output format to bf16

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_quant.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_quant.cc
@@ -174,7 +174,7 @@ void fused_quant(const Context& dev_ctx,
     return;
   }
 
-  dev_ctx.template Alloc<float>(scale);
+  dev_ctx.template Alloc<phi::dtype::bfloat16>(scale);
   if (scale->numel() == 0) {
     return;
   }


### PR DESCRIPTION
Change scale output to bf16 to align with fused MoE kernel input requirement.