### PR TITLE
[INTEL_HPU] move test_fused_rms_qkv_rope.py out of PR testing cases

### DIFF
--- a/backends/intel_hpu/tests/config.py
+++ b/backends/intel_hpu/tests/config.py
@@ -19,5 +19,6 @@ skip_case_lst = {}
 # when filter passwdown 'stable' will load this list
 # this list for the unstable test case to skip
 skip_case_lst = [
+    "test_fused_rms_qkv_rope.py",
     "test_cast_8k_4k.py",
 ]


### PR DESCRIPTION
currently this case is not stable, so tmp move test_fused_rms_qkv_rope.py out of PR testing cases
