### PR TITLE
[INTEL_HPU] update ut fused_fp8_sdpa_proj_t interface

### DIFF
--- a/backends/intel_hpu/tests/unittests/test_fused_fp8_sdpa_proj_t.py
+++ b/backends/intel_hpu/tests/unittests/test_fused_fp8_sdpa_proj_t.py
@@ -87,7 +87,7 @@ def ref_result(
         scaling_factor,
         False,
     )
-    attn_output = attn_output.reshape([bsz, q_len, head_dim * num_heads])
+    attn_output = attn_output.reshape([bsz * q_len, head_dim * num_heads])
 
     out_linear_out = paddle.matmul(attn_output, linear_weights)
 


### PR DESCRIPTION
this will fix issue as below:
AssertionError:
Not equal to tolerance rtol=0.01, atol=0

(shapes (16, 16, 256), (256, 256) mismatch)
 x: array([[[17032, 17035, 17027, ..., 17021, 17028, 17027],
        [17027, 17028, 17026, ..., 17018, 17026, 17025],
        [17029, 17029, 17026, ..., 17019, 17025, 17025],...
 y: array([[16889, 16896, 16881, ..., 16873, 16883, 16882],
       [16993, 16996, 16992, ..., 16983, 16992, 16989],
       [17027, 17027, 17024, ..., 17016, 17023, 17022],...

----------------------------------------------------------------------
Ran 3 tests in 2.808s
