### PR TITLE
[NPU] Remove old ir tests for compare ops

### DIFF
--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -23,9 +23,6 @@ from paddle.base import Program, program_guard
 from tests.op_test import OpTest, convert_float_to_uint16
 from npu_utils import get_cann_version
 
-with paddle.pir_utils.OldIrGuard():
-    from paddle.base import program_guard as old_program_guard, Program as OldProgram
-
 
 CANN_VERSION_CODE = get_cann_version()
 
@@ -79,49 +76,20 @@ def create_test_class(op_type, typename, callback):
             paddle.enable_static()
             op = eval("paddle." + self.op_type)
 
-            # TODO(LittleHeroZZZX): Remove after CI switched to PIR
-            if not paddle.get_flags(["FLAGS_enable_pir_api"])["FLAGS_enable_pir_api"]:
-                cases = [
-                    {"x": "a", "y": "b", "args": {"axis": True}},
-                    {"x": "a", "y": "b", "args": {"force_cpu": 1}},
-                    {"x": "a", "y": "b", "args": {"cond": 1}},
-                    {"x": "a", "y": "c", "args": {}},
-                    {"x": "c", "y": "a", "args": {}},
-                    {"x": "a", "y": "d", "args": {}},
-                    {"x": "d", "y": "a", "args": {}},
-                    {"x": "c", "y": "d", "args": {}},
-                ]
+            with program_guard(Program(), Program()):
+                a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
+                b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
+                c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
+                d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
 
-                def build_op(case):
-                    with old_program_guard(OldProgram(), OldProgram()):
-                        a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
-                        b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
-                        c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
-                        d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
-                        inputs = {"a": a, "b": b, "c": c, "d": d}
-
-                        op(x=inputs[case["x"]], y=inputs[case["y"]], **case["args"])
-                        exe = paddle.static.Executor(self.place)
-
-                        exe.run(paddle.static.default_main_program())
-
-                for case in cases:
-                    self.assertRaises(TypeError, build_op, case)
-            else:
-                with program_guard(Program(), Program()):
-                    a = paddle.static.data(name="a", shape=[-1, 2], dtype="float32")
-                    b = paddle.static.data(name="b", shape=[-1, 2], dtype="float32")
-                    c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
-                    d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
-
-                    self.assertRaises(TypeError, op, x=a, y=b, axis=True)
-                    self.assertRaises(TypeError, op, x=a, y=b, force_cpu=1)
-                    self.assertRaises(TypeError, op, x=a, y=b, cond=1)
-                    self.assertRaises(TypeError, op, x=a, y=c)
-                    self.assertRaises(TypeError, op, x=c, y=a)
-                    self.assertRaises(TypeError, op, x=a, y=d)
-                    self.assertRaises(TypeError, op, x=d, y=a)
-                    self.assertRaises(TypeError, op, x=c, y=d)
+                self.assertRaises(TypeError, op, x=a, y=b, axis=True)
+                self.assertRaises(TypeError, op, x=a, y=b, force_cpu=1)
+                self.assertRaises(TypeError, op, x=a, y=b, cond=1)
+                self.assertRaises(TypeError, op, x=a, y=c)
+                self.assertRaises(TypeError, op, x=c, y=a)
+                self.assertRaises(TypeError, op, x=a, y=d)
+                self.assertRaises(TypeError, op, x=d, y=a)
+                self.assertRaises(TypeError, op, x=c, y=d)
             paddle.disable_static()
 
         def test_dynamic_api(self):
@@ -236,16 +204,6 @@ def create_test_class(op_type, typename, callback):
                     )
                 real_result = callback(input_x, input_y)
             self.assertEqual((res == real_result).all(), True)
-
-        def test_attr_name(self):
-            paddle.enable_static()
-            with paddle.pir_utils.OldIrGuard():
-                with old_program_guard(OldProgram(), OldProgram()):
-                    x = paddle.static.data(name="x", shape=[-1, 4], dtype=typename)
-                    y = paddle.static.data(name="y", shape=[-1, 4], dtype=typename)
-                    op = eval("paddle.%s" % (self.op_type))
-                    out = op(x=x, y=y, name="name_%s" % (self.op_type))
-                    self.assertEqual("name_%s" % (self.op_type) in out.name, True)
 
     cls_name = "{0}_{1}".format(op_type, typename)
     Cls.__name__ = cls_name


### PR DESCRIPTION
在 https://github.com/PaddlePaddle/Paddle/pull/74870 中，greater_than下沉至 C++，不支持旧静态图组网。本 PR 移除 compare ops 单测中旧 IR 下的测试。