### PR TITLE
[NPU] Update test error for compare ops

### DIFF
--- a/backends/npu/tests/unittests/test_compare_op_npu.py
+++ b/backends/npu/tests/unittests/test_compare_op_npu.py
@@ -82,14 +82,14 @@ def create_test_class(op_type, typename, callback):
                 c = paddle.static.data(name="c", shape=[-1, 2], dtype="int16")
                 d = base.create_lod_tensor(np.array([[-1]]), [[1]], self.place)
 
-                self.assertRaises(TypeError, op, x=a, y=b, axis=True)
-                self.assertRaises(TypeError, op, x=a, y=b, force_cpu=1)
-                self.assertRaises(TypeError, op, x=a, y=b, cond=1)
-                self.assertRaises(TypeError, op, x=a, y=c)
-                self.assertRaises(TypeError, op, x=c, y=a)
-                self.assertRaises(TypeError, op, x=a, y=d)
-                self.assertRaises(TypeError, op, x=d, y=a)
-                self.assertRaises(TypeError, op, x=c, y=d)
+                self.assertRaises((TypeError, ValueError), op, x=a, y=b, axis=True)
+                self.assertRaises((TypeError, ValueError), op, x=a, y=b, force_cpu=1)
+                self.assertRaises((TypeError, ValueError), op, x=a, y=b, cond=1)
+                self.assertRaises((TypeError, ValueError), op, x=a, y=c)
+                self.assertRaises((TypeError, ValueError), op, x=c, y=a)
+                self.assertRaises((TypeError, ValueError), op, x=a, y=d)
+                self.assertRaises((TypeError, ValueError), op, x=d, y=a)
+                self.assertRaises((TypeError, ValueError), op, x=c, y=d)
             paddle.disable_static()
 
         def test_dynamic_api(self):


### PR DESCRIPTION
在 https://github.com/PaddlePaddle/Paddle/pull/74870 中，greater_than下沉至 C++ 后对于不支持的参数将抛出 ValueError。本 PR 更正 compare ops 单测中对于不支持参数异常类型。
<img width="1574" height="507" alt="image" src="https://github.com/user-attachments/assets/a20c865f-ae5f-4ed1-8ba7-32e4186b3703" />
