### PR TITLE
[INTEL_HPU] disable recipe runner async mode temporary

### DIFF
--- a/backends/intel_hpu/kernels/hpu_operator.cc
+++ b/backends/intel_hpu/kernels/hpu_operator.cc
@@ -147,7 +147,7 @@ void RecipeRunner::ExecuteRecipe(C_Stream stream,
                                  synRecipeHandle recipeHandle_) {
 #else
 void RecipeRunner::Run(C_Stream stream,
-                       std::map<std::string, uint64_t>& tensors) {
+                       const std::map<std::string, uint64_t>& tensors) {
 #endif
   uint64_t request_workspace_size = 0;
   synStatus status =

--- a/backends/intel_hpu/kernels/hpu_operator.h
+++ b/backends/intel_hpu/kernels/hpu_operator.h
@@ -33,7 +33,7 @@
 #include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/extension.h"
 
-#define ENABLE_ASYNC_RUN
+// #define ENABLE_ASYNC_RUN
 
 class HpuOperator {
  public:


### PR DESCRIPTION
disable temporary, will re-enable when multi-card issue is fixed.