### PR TITLE
【CUDA Kernel No.100】roi_align算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/roi_align_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/roi_align_kernel_register.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/roi_align_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/roi_align_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(
     roi_align, iluvatar_gpu, ALL_LAYOUT, phi::RoiAlignKernel, float) {}


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
本算子Paddle中已包含头文件，且#include没有问题
将backends/iluvatar_gpu/kernels/cuda_kernels/roi_align_kernel_register.cc的#include 改为引用对应的头文件
backends/metax_gpu/kernels/cuda_kernels/roi_align_grad_kernel_register.cu、backends/iluvatar_gpu/CMakeLists.txt、backends/metax_gpu/CMakeLists.txt无需修改
