### PR TITLE
【CUDA Kernel No.7】fused_seqpool_cvm_grad算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/fused_bias_residual_layernorm_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/fused_bias_residual_layernorm_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_layernorm_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fused_layernorm_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_bias_residual_layernorm,
                           iluvatar_gpu,

--- a/backends/metax_gpu/kernels/fusion/fused_layernorm_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_layernorm_kernel_register.cu
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/fused_layernorm_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/attention_layer.norm.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_dropout_helper.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_layernorm_kernel.cu"  //NOLINT
 
 #ifndef PADDLE_WITH_HIP
 #if CUDNN_VERSION_MIN(8, 1, 0)


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
backends/metax_gpu/kernels/fusion/fused_layernorm_kernel_register.cu和backends/iluvatar_gpu/kernels/cuda_kernels/fused_bias_residual_layernorm_kernel_register.cu改为引用新增的头文件，两个算子的Kernel 源文件已加入编译列表，无需修改