### PR TITLE
【CUDA Kernel No.20】affine_channel算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/affine_channel_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(affine_channel,
                           iluvatar_gpu,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -603,6 +603,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fusion_group_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/skip_layernorm_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/affine_channel_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_layernorm_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/affine_channel_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/affine_channel_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(affine_channel,
                           metax_gpu,


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
backends/iluvatar_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu和backends/metax_gpu/kernels/cuda_kernels/affine_channel_kernel_register.cu改为引用新增的头文件，在backends/metax_gpu/CMakeLists.txt中将.cu加入编译列表