### PR TITLE
【CUDA Kernel No.21】ap_facade 算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/CMakeLists.txt
+++ b/backends/iluvatar_gpu/CMakeLists.txt
@@ -135,6 +135,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/adamw_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/addmm_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/addmm_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/argsort_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/amp_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/arange_kernel.cu

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_facade_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/ap_facade_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_facade,
                           iluvatar_gpu,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -136,6 +136,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/all_reduce_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/all_to_all_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/apply_per_channel_scale_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/as_complex_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/as_real_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_facade_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/ap_facade_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_facade,
                           metax_gpu,


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
`backends/iluvatar_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu` 和`backends/metax_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu` 改为引用新增的头文件，在backends/metax_gpu/CMakeLists.txt中将 `paddle/phi/kernels/gpu/ap_facade_kernel.cu` 加入编译列表

前置PR：https://github.com/PaddlePaddle/Paddle/pull/75657