### PR TITLE
【CUDA Kernel No.12】fused_stack_transpose_quant算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/fused_stack_transpose_quant_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/fused_stack_transpose_quant_kernel_register.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/quant_utils.h"
 #include "paddle/phi/kernels/primitive/datamover_primitives.h"
 

--- a/backends/metax_gpu/kernels/fusion/fused_stack_transpose_quant_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_stack_transpose_quant_kernel_register.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/quant_utils.h"
 #include "paddle/phi/kernels/primitive/datamover_primitives.h"
 


### PR DESCRIPTION
- 修改 `backends\iluvatar_gpu\kernels\cuda_kernels\fused_stack_transpose_quant_kernel_register.cu` 和 `backends\iluvatar_gpu\kernels\cuda_kernels\fused_stack_transpose_quant_kernel_register.cu`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已经有两个 `fused_stack_transpose_quant_kernel.cu` ，貌似有很多文件都是这样，是否需要删除重复的文件列表
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中已有 `fused_stack_transpose_quant_kernel.cu` ，无需新增