### PR TITLE
【CUDA Kernel No.21】ap_facade算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_facade_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_facade_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_facade,
                           iluvatar_gpu,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -145,6 +145,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/angle_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/angle_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/adamax_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bincount_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_grad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/ap_facade_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_facade_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_facade_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_facade,
                           metax_gpu,


### PR DESCRIPTION
修改backends\iluvatar_gpu\kernels\cuda_kernels\ap_facade_kernel_register.cu和backends\metax_gpu\kernels\cuda_kernels\ap_facade_kernel_register.cu

对应的backends\iluvatar_gpu\CMakeLists.txt列表中已有ap_facade_kernel.cu，无需新增

对应的backends\metax_gpu\CMakeLists.txt列表中新增${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu