### PR TITLE
【CUDA Kernel No.61】Include index_add_grad_kernel.h

### DIFF
--- a/backends/iluvatar_gpu/CMakeLists.txt
+++ b/backends/iluvatar_gpu/CMakeLists.txt
@@ -745,7 +745,6 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/save_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/dropout_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/dropout_grad_kernel.cu
-  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bce_loss_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bce_loss_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/meshgrid_kernel.cu.cc

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/gpu/index_add_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/index_add_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(index_add_grad,
                           iluvatar_gpu,

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/index_add_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(index_add_grad,

--- a/backends/metax_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/gpu/index_add_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/index_add_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(index_add_grad,
                           metax_gpu,

--- a/backends/metax_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/index_add_grad_kernel_register.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/index_add_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(index_add_grad,


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description

- Include index_add_grad_kernel.h to replace .cu file include
- Fix missing kernel_registry includes
- Remove duplicate file in iluvatar_gpu's cmakelists

ℹ️The .h file already exists in the Paddle repo: paddle/phi/kernels/index_add_grad_kernel.h

ℹ️The index_add_grad_kernel.cu file has been included in iluvatar_gpu's cmakelists starting from line 269.
```cmake
file(
  GLOB
  CUDA_SRCS2
  ...
  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
  ...
)
set(CUDA_SRCS ${CUDA_SRCS1} ${CUDA_SRCS2})
list(REMOVE_DUPLICATES CUDA_SRCS1)
```

ℹ️The index_add_grad_kernel.cu file has been included in metax_gpu's cmakelists starting from line 107.
```cmake
file(
  GLOB
  CUDA_SRCS
  ...
  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/index_add_grad_kernel.cu
  ...
)
```