### PR TITLE
【CUDA Kernel No.10】fused_softmax_mask算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/fused_softmax_mask_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/fused_softmax_mask_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/fused_softmax_mask_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_utils.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_softmax_mask,

--- a/backends/metax_gpu/kernels/fusion/fused_softmax_mask_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_softmax_mask_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/fused_softmax_mask_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_softmax_mask_utils.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_softmax_mask,


### PR DESCRIPTION
- 修改 `backends\metax_gpu\kernels\fusion\fused_softmax_mask_kernel_register.cu` 和 `backends\iluvatar_gpu\kernels\cuda_kernels\fused_softmax_mask_kernel_register.cu`
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu` ，无需新增
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_kernel.cu` ，无需新增