### PR TITLE
[ILUVATAR GPU] register more double/triple grad kernel

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/abs_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/abs_grad_kernel_register.cc
@@ -30,3 +30,16 @@ PD_CUSTOM_KERNEL_REGISTER(abs_grad,
                           complex<float>) {
   kernel->InputAt(1).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
 }
+
+PD_CUSTOM_KERNEL_REGISTER(abs_double_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::AbsDoubleGradKernel,
+                   float,
+                   int,
+                   int64_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16,
+                   complex<float>) {
+  kernel->InputAt(1).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
+}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/abs_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/abs_grad_kernel_register.cc
@@ -32,14 +32,14 @@ PD_CUSTOM_KERNEL_REGISTER(abs_grad,
 }
 
 PD_CUSTOM_KERNEL_REGISTER(abs_double_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::AbsDoubleGradKernel,
-                   float,
-                   int,
-                   int64_t,
-                   phi::dtype::float16,
-                   phi::dtype::bfloat16,
-                   complex<float>) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::AbsDoubleGradKernel,
+                          float,
+                          int,
+                          int64_t,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16,
+                          complex<float>) {
   kernel->InputAt(1).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
 }

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/activation_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/activation_grad_kernel_register.cc
@@ -31,10 +31,42 @@ PD_CUSTOM_KERNEL_REGISTER(sin_grad,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {}
 
+PD_CUSTOM_KERNEL_REGISTER(sin_double_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::SinDoubleGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(sin_triple_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::SinTripleGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
 PD_CUSTOM_KERNEL_REGISTER(cos_grad,
                           iluvatar_gpu,
                           ALL_LAYOUT,
                           phi::CosGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(cos_double_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::CosDoubleGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(cos_triple_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::CosTripleGradKernel,
                           float,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {}
@@ -115,6 +147,14 @@ PD_CUSTOM_KERNEL_REGISTER(tanh_grad,
                           iluvatar_gpu,
                           ALL_LAYOUT,
                           phi::TanhGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(tanh_double_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::TanhDoubleGradKernel,
                           float,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {}


### PR DESCRIPTION
This pull request adds support for higher-order gradient (double and triple gradient) kernel registrations for several activation functions in the Iluvatar GPU backend. These changes enhance the framework's ability to compute second and third derivatives for activation functions, which is important for advanced optimization and certain deep learning techniques.

### Activation Function Kernel Registrations

**Sin and Cos Activation Functions:**
* Added registrations for `sin_double_grad` and `sin_triple_grad` kernels, enabling computation of second and third derivatives for the sine activation function.
* Added registrations for `cos_double_grad` and `cos_triple_grad` kernels, enabling computation of second and third derivatives for the cosine activation function.

**Tanh Activation Function:**
* Added registration for the `tanh_double_grad` kernel, allowing computation of the second derivative for the tanh activation function.

**Abs Activation Function:**
* Added registration for the `abs_double_grad` kernel, enabling computation of the second derivative for the absolute value activation function.
