### PR TITLE
【CUDA Kernel No.93】psroi_pool_grad_kernel算子修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/psroi_pool_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(psroi_pool_grad,
                           iluvatar_gpu,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -380,6 +380,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/maxout_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/p_send_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/momentum_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/pixel_shuffle_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/lu_unpack_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/nll_loss_grad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/psroi_pool_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(psroi_pool_grad,
                           metax_gpu,


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description
1. Updated include directives in the following kernel registration files to reference the newly added header file `#include "paddle/phi/kernels/psroi_pool_grad_kernel.h"`:
   - `backends/iluvatar_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu`
   - `backends/metax_gpu/kernels/cuda_kernels/psroi_pool_grad_kernel_register.cu`

2. Added `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/psroi_pool_grad_kernel.cu` to line 383 in `backends/metax_gpu/CMakeLists.txt`

Note: Confirmed that `backends/iluvatar_gpu/CMakeLists.txt` requires no modifications.