### PR TITLE
【CUDA Kernel No.3-5】Include fused_bias_dropout_residual_layer_norm_grad_kernel fused_bias_dropout_residual_layer_norm_kernfused_embedding_eltwise_layernorm_kernelel

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/fused_embedding_eltwise_layernorm_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/fused_embedding_eltwise_layernorm_kernel_register.cu
@@ -15,7 +15,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/emb_eltwise_layer_norm_functor.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_embedding_eltwise_layernorm,
                           iluvatar_gpu,

--- a/backends/metax_gpu/kernels/fusion/fused_bias_dropout_residual_layer_norm_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_bias_dropout_residual_layer_norm_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/layer_norm_impl.cu.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_grad_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_grad_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_dropout_helper.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_bias_dropout_residual_layer_norm_grad,

--- a/backends/metax_gpu/kernels/fusion/fused_bias_dropout_residual_layer_norm_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_bias_dropout_residual_layer_norm_kernel_register.cu
@@ -17,7 +17,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/layer_norm_impl.cu.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_kernel.h"
 #include "paddle/phi/kernels/fusion/gpu/fused_dropout_helper.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_bias_dropout_residual_layer_norm,

--- a/backends/metax_gpu/kernels/fusion/fused_embedding_eltwise_layernorm_kernel_register.cu
+++ b/backends/metax_gpu/kernels/fusion/fused_embedding_eltwise_layernorm_kernel_register.cu
@@ -15,7 +15,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/emb_eltwise_layer_norm_functor.h"
-#include "paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fused_embedding_eltwise_layernorm,
                           metax_gpu,


### PR DESCRIPTION
## PR Category
Custom Device

## PR Types
Improvements

## Description
paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_grad_kernel.cu
paddle/phi/kernels/fusion/gpu/fused_bias_dropout_residual_layer_norm_kernel.cu |  
paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu |  
改为引用新增的头文件
