### PR TITLE
【CUDA Kernel No.23】ap_trivial_fusion_end算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/ap_trivial_fusion_end_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/ap_trivial_fusion_end_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_trivial_fusion_end,
                           iluvatar_gpu,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -153,6 +153,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_variadic_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/barrier_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bincount_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/box_clip_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_concat_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/ap_trivial_fusion_end_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/ap_trivial_fusion_end_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(ap_trivial_fusion_end,
                           metax_gpu,


### PR DESCRIPTION
- 修改 `backends\metax_gpu\kernels\cuda_kernels\ap_trivial_fusion_end_kernel_register.cu` 和 `backends\iluvatar_gpu\kernels\cuda_kernels\ap_trivial_fusion_end_kernel_register.cu`
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中新增 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_trivial_fusion_end_kernel.cu` ，无需新增