### PR TITLE
【CUDA Kernel No.24】ap_variadic算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/ap_variadic_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/ap_variadic_kernel_register.cu
@@ -14,7 +14,7 @@
 
 #include "paddle/ap/include/kernel_dispatch/ap_variadic_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_variadic_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_variadic_kernel.h"
 
 #ifdef PADDLE_WITH_HIP
 PD_CUSTOM_KERNEL_REGISTER(ap_variadic,

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -146,6 +146,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/angle_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/adamax_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_variadic_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bincount_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_grad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/ap_variadic_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/ap_variadic_kernel_register.cu
@@ -14,7 +14,7 @@
 
 #include "paddle/ap/include/kernel_dispatch/ap_variadic_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/ap_variadic_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/ap_variadic_kernel.h"
 
 #ifdef PADDLE_WITH_HIP
 PD_CUSTOM_KERNEL_REGISTER(ap_variadic,


### PR DESCRIPTION
- 修改 `backends\metax_gpu\kernels\cuda_kernels\ap_variadic_kernel_register.cu` 和 `backends\iluvatar_gpu\kernels\cuda_kernels\ap_variadic_kernel_register.cu`
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中新增 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_variadic_kernel.cu`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_variadic_kernel.cu` ，无需新增