### PR TITLE
【CUDA Kernel No.26】barrier算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/barrier_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/barrier_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/barrier_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/barrier_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(
     barrier, iluvatar_gpu, ALL_LAYOUT, phi::BarrierKernel, int) {}

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -146,6 +146,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/angle_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/adamax_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/ap_facade_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/barrier_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/bincount_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_embedding_grad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/barrier_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/barrier_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/barrier_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/barrier_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(
     barrier, metax_gpu, ALL_LAYOUT, phi::BarrierKernel, int) {}


### PR DESCRIPTION
- 修改 `backends\metax_gpu\kernels\cuda_kernels\barrier_kernel_register.cu` 和 `backends\iluvatar_gpu\kernels\cuda_kernels\barrier_kernel_register.cu`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/barrier_kernel.cu` ，无需新增
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中新增 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/barrier_kernel.cu`