### PR TITLE
【CUDA Kernel No.36】c_softmax_with_cross_entropy_grad算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/c_softmax_with_cross_entropy_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/c_softmax_with_cross_entropy_grad_kernel_register.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/c_softmax_with_cross_entropy_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(c_softmax_with_cross_entropy_grad,
                           iluvatar_gpu,


### PR DESCRIPTION
- 修改 `backends\iluvatar_gpu\kernels\cuda_kernels\c_softmax_with_cross_entropy_grad_kernel_register.cc`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu` ，无需新增
- 沐曦没有对应的算子Kernel注册， `backends\metax_gpu\CMakeLists.txt` 列表中也没有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_softmax_with_cross_entropy_grad_kernel.cu`