### PR TITLE
【CUDA Kernel No.39】collect_fpn_proposals算子Kernel修复

### DIFF
--- a/backends/metax_gpu/kernels/cuda_kernels/collect_fpn_proposals_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/collect_fpn_proposals_kernel_register.cu
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(collect_fpn_proposals,
                           metax_gpu,


### PR DESCRIPTION
- 修改了 `backends\metax_gpu\kernels\cuda_kernels\collect_fpn_proposals_kernel_register.cu`
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu` ，无需新增
- 天数没有对应的算子Kernel注册，但是 `backends\iluvatar_gpu\CMakeLists.txt` 列表中有多处 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu`