### PR TITLE
【CUDA Kernel No.40】comm_init_all算子Kernel修复

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/comm_init_all_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/comm_init_all_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/comm_init_all_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/comm_init_all_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(
     comm_init_all, iluvatar_gpu, ALL_LAYOUT, phi::CommInitAllKernel, float) {}

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -282,6 +282,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/clip_by_norm_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/check_numerics_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/comm_init_all_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/c_split_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/broadcast_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/decayed_adagrad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/comm_init_all_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/comm_init_all_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/comm_init_all_kernel.cu"  //NOLINT
+#include "paddle/phi/kernels/comm_init_all_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(
     comm_init_all, metax_gpu, ALL_LAYOUT, phi::CommInitAllKernel, float) {}


### PR DESCRIPTION
- 修改了 `backends\iluvatar_gpu\kernels\cuda_kernels\comm_init_all_kernel_register.cu` 和 `backends\metax_gpu\kernels\cuda_kernels\comm_init_all_kernel_register.cu`
- 对应的 `backends\iluvatar_gpu\CMakeLists.txt` 列表中已有 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/comm_init_all_kernel.cu` ，无需新增
- 对应的 `backends\metax_gpu\CMakeLists.txt` 列表中新增 `${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/comm_init_all_kernel.cu`