### PR TITLE
[ILUVATAR_GPU] Add several kernels for PaddleScience examples

### DIFF
--- a/backends/iluvatar_gpu/CMakeLists.txt
+++ b/backends/iluvatar_gpu/CMakeLists.txt
@@ -910,7 +910,6 @@ foreach(src ${CUDA_SRCS2})
   endif()
 endforeach()
 
-
 set(CUDA_SRCS ${CUDA_SRCS1} ${CUDA_SRCS2})
 list(REMOVE_DUPLICATES CUDA_SRCS)
 

--- a/backends/iluvatar_gpu/CMakeLists.txt
+++ b/backends/iluvatar_gpu/CMakeLists.txt
@@ -264,6 +264,12 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/fill_diagonal_tensor_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/gelu_grad_kernel.cu)
 
+foreach(src ${CUDA_SRCS1})
+  if(NOT EXISTS ${src})
+    message(FATAL_ERROR "Missing CUDA source file: ${src}")
+  endif()
+endforeach()
+
 file(
   GLOB
   CUDA_SRCS2
@@ -897,6 +903,13 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/kps/reduce_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/legacy/kps/reduce_max_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/array_kernel.cc)
+
+foreach(src ${CUDA_SRCS2})
+  if(NOT EXISTS ${src})
+    message(FATAL_ERROR "Missing CUDA source file: ${src}")
+  endif()
+endforeach()
+
 
 set(CUDA_SRCS ${CUDA_SRCS1} ${CUDA_SRCS2})
 list(REMOVE_DUPLICATES CUDA_SRCS)

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/activation_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/activation_grad_kernel_register.cc
@@ -325,6 +325,22 @@ PD_CUSTOM_KERNEL_REGISTER(sigmoid_grad,
                           phi::dtype::float16,
                           phi::dtype::bfloat16) {}
 
+PD_CUSTOM_KERNEL_REGISTER(sigmoid_double_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::SigmoidDoubleGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(sigmoid_triple_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::SigmoidTripleGradKernel,
+                          float,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
 PD_CUSTOM_KERNEL_REGISTER(logsigmoid_grad,
                           iluvatar_gpu,
                           ALL_LAYOUT,
@@ -433,6 +449,16 @@ PD_CUSTOM_KERNEL_REGISTER(pow_grad,
                           iluvatar_gpu,
                           ALL_LAYOUT,
                           phi::PowGradKernel,
+                          float,
+                          int,
+                          int64_t,
+                          phi::dtype::float16,
+                          phi::dtype::bfloat16) {}
+
+PD_CUSTOM_KERNEL_REGISTER(pow_double_grad,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::PowDoubleGradKernel,
                           float,
                           int,
                           int64_t,

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_grad_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_grad_kernel.cu
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/instance_norm_grad_kernel.h"
-#include "runtime/iluvatar_context.h"
-
 #include "glog/logging.h"
-
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -24,6 +20,8 @@
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/norm_utils.h"
 #include "paddle/phi/kernels/gpu/instance_norm_utils.h"
+#include "paddle/phi/kernels/instance_norm_grad_kernel.h"
+#include "runtime/iluvatar_context.h"
 
 namespace phi {
 template <typename T, int BlockDim>
@@ -637,43 +635,43 @@ void InstanceNormDoubleGradKernel(const Context &dev_ctx,
 #ifdef PADDLE_WITH_HIP
 // MIOPEN do not support double
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormGradKernel,
-                   float,
-                   phi::float16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormGradKernel,
+                          float,
+                          phi::float16) {}
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormDoubleGradKernel,
-                   float,
-                   phi::float16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormDoubleGradKernel,
+                          float,
+                          phi::float16) {}
 #elif CUDNN_VERSION_MIN(8, 1, 0)
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormGradKernel,
-                   float,
-                   phi::float16,
-                   phi::bfloat16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormGradKernel,
+                          float,
+                          phi::float16,
+                          phi::bfloat16) {}
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormDoubleGradKernel,
-                   float,
-                   phi::float16,
-                   phi::bfloat16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormDoubleGradKernel,
+                          float,
+                          phi::float16,
+                          phi::bfloat16) {}
 #else
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormGradKernel,
-                   float,
-                   phi::float16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormGradKernel,
+                          float,
+                          phi::float16) {}
 PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormDoubleGradKernel,
-                   float,
-                   phi::float16) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormDoubleGradKernel,
+                          float,
+                          phi::float16) {}
 #endif

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_grad_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_grad_kernel.cu
@@ -1,0 +1,679 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/instance_norm_grad_kernel.h"
+#include "runtime/iluvatar_context.h"
+
+#include "glog/logging.h"
+
+#include "paddle/common/layout.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/funcs/norm_utils.h"
+#include "paddle/phi/kernels/gpu/instance_norm_utils.h"
+
+namespace phi {
+template <typename T, int BlockDim>
+static __global__ void GradComputeDX(const T *dy,
+                                     const BatchNormParamType<T> *scale,
+                                     const BatchNormParamType<T> *mean,
+                                     const T *x,
+                                     const BatchNormParamType<T> *variance,
+                                     const int C,
+                                     const int64_t sample_size,
+                                     T *dx) {
+  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int ncid = blockIdx.x;
+  int c = ncid % C;
+  BatchNormParamType<T> mean_val = mean[ncid];
+  BatchNormParamType<T> inv_var_val = variance[ncid];
+  typedef cub::BlockReduce<BatchNormParamType<T>, BlockDim> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage dy_storage;
+  __shared__ typename BlockReduce::TempStorage dy_x_sub_mean_storage;
+  __shared__ BatchNormParamType<T> dy_sum_val;
+  __shared__ BatchNormParamType<T> dy_x_sub_mean_sum_val;
+  BatchNormParamType<T> dy_sum = static_cast<BatchNormParamType<T>>(0);
+  BatchNormParamType<T> dy_x_sub_mean_sum =
+      static_cast<BatchNormParamType<T>>(0);
+
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    BatchNormParamType<T> dy_i = static_cast<BatchNormParamType<T>>(dy[i]);
+    dy_sum += dy_i;
+    dy_x_sub_mean_sum +=
+        dy_i * (static_cast<BatchNormParamType<T>>(x[i]) - mean_val);
+  }
+  dy_sum = BlockReduce(dy_storage).Reduce(dy_sum, cub::Sum());
+  dy_x_sub_mean_sum =
+      BlockReduce(dy_x_sub_mean_storage).Reduce(dy_x_sub_mean_sum, cub::Sum());
+  if (threadIdx.x == 0) {
+    dy_sum_val = dy_sum;
+    dy_x_sub_mean_sum_val = dy_x_sub_mean_sum;
+  }
+  __syncthreads();
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    dx[i] = static_cast<T>(
+        (static_cast<BatchNormParamType<T>>(dy[i]) -
+         dy_sum_val / static_cast<BatchNormParamType<T>>(sample_size) -
+         (static_cast<BatchNormParamType<T>>(x[i]) - mean_val) *
+             dy_x_sub_mean_sum_val * inv_var_val * inv_var_val / sample_size) *
+        scale[c] * inv_var_val);
+  }
+}
+
+static __device__ __forceinline__ float real_sqrt(float x) {
+  return 1. / sqrtf(x);
+}
+static __device__ __forceinline__ double real_sqrt(double x) {
+  return 1. / sqrt(x);
+}
+
+template <typename T, typename AccT, int BlockDim>
+__global__ void DoubleGradComputeDX(const T *x,
+                                    const AccT *mean,
+                                    const AccT *variance,
+                                    const T *ddx,
+                                    const T *dy,
+                                    const AccT *scale,
+                                    const AccT *ddscale,
+                                    int C,
+                                    int64_t sample_size,
+                                    const double epsilon,
+                                    T *dx) {
+  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int ncid = blockIdx.x;
+  int c = ncid % C;
+
+  AccT mean_val = mean[ncid];
+  AccT var_val = variance[ncid];
+
+  typedef cub::BlockReduce<AccT, BlockDim> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage dy_storage;
+  __shared__ typename BlockReduce::TempStorage ddx_storage;
+  __shared__ typename BlockReduce::TempStorage dy_mul_ddx_storage;
+  __shared__ typename BlockReduce::TempStorage dy_mul_x_sub_mean_storage;
+  __shared__ typename BlockReduce::TempStorage ddx_mul_x_sub_mean_storage;
+  __shared__ AccT dy_sum_val;
+  __shared__ AccT ddx_sum_val;
+  __shared__ AccT dy_mul_ddx_sum_val;
+  __shared__ AccT dy_mul_x_sub_mean_sum_val;
+  __shared__ AccT ddx_mul_x_sub_mean_sum_val;
+
+  AccT dy_sum = 0;
+  AccT ddx_sum = 0;
+  AccT dy_mul_ddx_sum = 0;
+  AccT dy_mul_x_sub_mean_sum = 0;
+  AccT ddx_mul_x_sub_mean_sum = 0;
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    AccT ddx_i = static_cast<AccT>(ddx[i]);
+    AccT dy_i = static_cast<AccT>(dy[i]);
+    AccT tmp = static_cast<AccT>(x[i]) - mean_val;
+
+    dy_sum += dy_i;
+    ddx_sum += ddx_i;
+    dy_mul_ddx_sum += (ddx_i * dy_i);
+
+    dy_mul_x_sub_mean_sum += (dy_i * tmp);
+    ddx_mul_x_sub_mean_sum += (ddx_i * tmp);
+  }
+
+  dy_sum = BlockReduce(dy_storage).Reduce(dy_sum, cub::Sum());
+  ddx_sum = BlockReduce(ddx_storage).Reduce(ddx_sum, cub::Sum());
+  dy_mul_ddx_sum =
+      BlockReduce(dy_mul_ddx_storage).Reduce(dy_mul_ddx_sum, cub::Sum());
+  dy_mul_x_sub_mean_sum = BlockReduce(dy_mul_x_sub_mean_storage)
+                              .Reduce(dy_mul_x_sub_mean_sum, cub::Sum());
+  ddx_mul_x_sub_mean_sum = BlockReduce(ddx_mul_x_sub_mean_storage)
+                               .Reduce(ddx_mul_x_sub_mean_sum, cub::Sum());
+
+  if (threadIdx.x == 0) {
+    dy_sum_val = dy_sum;
+    ddx_sum_val = ddx_sum;
+    dy_mul_ddx_sum_val = dy_mul_ddx_sum;
+    dy_mul_x_sub_mean_sum_val = dy_mul_x_sub_mean_sum;
+    ddx_mul_x_sub_mean_sum_val = ddx_mul_x_sub_mean_sum;
+  }
+  __syncthreads();
+
+  if (ddx != nullptr) {
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      AccT tmp = static_cast<AccT>(dx[i]);
+      tmp +=
+          ((static_cast<AccT>(x[i]) - mean_val) * var_val * var_val * var_val /
+               sample_size *
+               (ddx_sum_val * dy_sum_val / sample_size - dy_mul_ddx_sum_val +
+                3. * dy_mul_x_sub_mean_sum_val * var_val *
+                    ddx_mul_x_sub_mean_sum_val * var_val / sample_size) +
+           ddx_mul_x_sub_mean_sum_val * var_val / sample_size * var_val *
+               var_val * (dy_sum_val / sample_size - static_cast<AccT>(dy[i])) +
+           dy_mul_x_sub_mean_sum_val * var_val / sample_size * var_val *
+               var_val *
+               (ddx_sum_val / sample_size - static_cast<AccT>(ddx[i]))) *
+          scale[c];
+      dx[i] = static_cast<T>(tmp);
+    }
+  }
+  __syncthreads();
+  if (ddscale != nullptr) {
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      AccT tmp = static_cast<AccT>(dx[i]);
+      tmp += (static_cast<AccT>(dy[i]) * var_val -
+              dy_sum_val / sample_size * var_val -
+              (static_cast<AccT>(x[i]) - mean_val) * var_val *
+                  dy_mul_x_sub_mean_sum_val * var_val / sample_size) *
+             ddscale[c];
+      dx[i] = static_cast<T>(tmp);
+    }
+  }
+}
+
+template <typename T, typename AccT, int BlockDim>
+__global__ void DoubleGradComputeDDY(const T *x,
+                                     const AccT *mean,
+                                     const AccT *variance,
+                                     const AccT *ddscale,
+                                     const AccT *ddbias,
+                                     const T *ddx,
+                                     const AccT *scale,
+                                     int C,
+                                     int64_t sample_size,
+                                     const double epsilon,
+                                     T *ddy) {
+  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int ncid = blockIdx.x;
+  int c = ncid % C;
+  AccT mean_val = mean[ncid];
+  AccT var_val = variance[ncid];
+  typedef cub::BlockReduce<AccT, BlockDim> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage ddx_storage;
+  __shared__ typename BlockReduce::TempStorage ddx_mul_x_sub_mean_storage;
+  __shared__ AccT ddx_sum_val;
+  __shared__ AccT ddx_mul_x_sub_mean_sum_val;
+
+  AccT ddx_sum = 0;
+  AccT ddx_mul_x_sub_mean_sum = 0;
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    AccT ddx_i = static_cast<AccT>(ddx[i]);
+    ddx_sum += ddx_i;
+    ddx_mul_x_sub_mean_sum += (ddx_i * (static_cast<AccT>(x[i]) - mean_val));
+  }
+  ddx_sum = BlockReduce(ddx_storage).Reduce(ddx_sum, cub::Sum());
+  ddx_mul_x_sub_mean_sum = BlockReduce(ddx_mul_x_sub_mean_storage)
+                               .Reduce(ddx_mul_x_sub_mean_sum, cub::Sum());
+  if (threadIdx.x == 0) {
+    ddx_sum_val = ddx_sum;
+    ddx_mul_x_sub_mean_sum_val = ddx_mul_x_sub_mean_sum;
+  }
+  __syncthreads();
+  if (ddx != nullptr) {
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      AccT tmp = static_cast<AccT>(ddy[i]);
+      tmp += scale[c] * var_val *
+             (static_cast<AccT>(ddx[i]) - ddx_sum_val / sample_size -
+              (static_cast<AccT>(x[i]) - mean_val) * var_val *
+                  ddx_mul_x_sub_mean_sum_val * var_val / sample_size);
+      ddy[i] = static_cast<T>(tmp);
+    }
+  }
+  __syncthreads();
+  if (ddscale != nullptr) {
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      AccT tmp = static_cast<AccT>(ddy[i]);
+      tmp += (static_cast<AccT>(x[i]) - mean_val) * var_val * ddscale[c];
+      ddy[i] = static_cast<T>(tmp);
+    }
+  }
+  __syncthreads();
+  if (ddbias != nullptr) {
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      ddy[i] = static_cast<T>(static_cast<AccT>(ddy[i]) + ddbias[c]);
+    }
+  }
+}
+
+template <typename T, typename AccT, int BlockDim>
+__global__ void DoubleGradComputeDScale(const T *x,
+                                        const AccT *mean,
+                                        const AccT *variance,
+                                        const T *ddx,
+                                        const T *dy,
+                                        int C,
+                                        int64_t sample_size,
+                                        const double epsilon,
+                                        AccT *dscale) {
+  int64_t beg_idx = blockIdx.x * sample_size + threadIdx.x;
+  int64_t end_idx = (blockIdx.x + 1) * sample_size;
+  int ncid = blockIdx.x;
+  int c = ncid % C;
+  AccT mean_val = mean[ncid];
+  AccT var_val = variance[ncid];
+  typedef cub::BlockReduce<AccT, BlockDim> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage dy_storage;
+  __shared__ typename BlockReduce::TempStorage dy_mul_x_sub_mean_storage;
+  __shared__ typename BlockReduce::TempStorage dscale_tmp_storage;
+  __shared__ AccT dy_sum_val;
+  __shared__ AccT dy_mul_x_sub_mean_sum_val;
+
+  AccT dy_sum = 0;
+  AccT dy_mul_x_sub_mean_sum = 0;
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    AccT dy_i = static_cast<AccT>(dy[i]);
+    dy_sum += dy_i;
+    dy_mul_x_sub_mean_sum += (dy_i * (static_cast<AccT>(x[i]) - mean_val));
+  }
+  dy_sum = BlockReduce(dy_storage).Reduce(dy_sum, cub::Sum());
+  dy_mul_x_sub_mean_sum = BlockReduce(dy_mul_x_sub_mean_storage)
+                              .Reduce(dy_mul_x_sub_mean_sum, cub::Sum());
+
+  if (threadIdx.x == 0) {
+    dy_sum_val = dy_sum;
+    dy_mul_x_sub_mean_sum_val = dy_mul_x_sub_mean_sum;
+  }
+  __syncthreads();
+  if (ddx != nullptr) {
+    AccT dscale_tmp = 0;
+    for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+      dscale_tmp +=
+          static_cast<AccT>(ddx[i]) * var_val *
+          (static_cast<AccT>(dy[i]) - dy_sum_val / sample_size -
+           dy_mul_x_sub_mean_sum_val * (static_cast<AccT>(x[i]) - mean_val) *
+               var_val * var_val / sample_size);
+    }
+    dscale_tmp = BlockReduce(dscale_tmp_storage).Reduce(dscale_tmp, cub::Sum());
+    if (threadIdx.x == 0) {
+      dscale[ncid] += dscale_tmp;
+    }
+    __syncthreads();
+  }
+}
+
+template <typename T, typename Context>
+void InstanceNormGradKernel(const Context &dev_ctx,
+                            const DenseTensor &x,
+                            const paddle::optional<DenseTensor> &scale,
+                            const paddle::optional<DenseTensor> &bias UNUSED,
+                            const DenseTensor &saved_mean,
+                            const DenseTensor &saved_variance,
+                            const DenseTensor &d_y,
+                            float epsilon_f,
+                            DenseTensor *d_x,
+                            DenseTensor *d_scale,
+                            DenseTensor *d_bias) {
+  using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
+  double epsilon = static_cast<double>(epsilon_f);
+  const auto *scale_ptr = scale.get_ptr();
+
+  const auto &x_dims = x.dims();
+
+  int N, C, H, W, D;
+  funcs::ExtractNCWHD(x_dims, DataLayout::kNCHW, &N, &C, &H, &W, &D);
+  int NxC = N * C;
+
+  DenseTensor x_tmp, d_y_tmp;
+  x_tmp.ShareDataWith(x).Resize({1, NxC, H, W, D});
+  d_y_tmp.ShareDataWith(d_y).Resize({1, NxC, H, W, D});
+
+  phi::funcs::SetConstant<GPUContext, AccT> set_constant;
+
+  dev_ctx.template Alloc<T>(d_x);
+  if (x.numel() == 0) {
+    if (d_scale) {
+      dev_ctx.template Alloc<AccT>(d_scale);
+      set_constant(dev_ctx, d_scale, static_cast<AccT>(0));
+    }
+    if (d_bias) {
+      dev_ctx.template Alloc<AccT>(d_bias);
+      set_constant(dev_ctx, d_bias, static_cast<AccT>(0));
+    }
+    return;
+  }
+  if (d_scale && d_bias) {
+    dev_ctx.template Alloc<AccT>(d_scale);
+    dev_ctx.template Alloc<AccT>(d_bias);
+  }
+
+  if (scale_ptr) {
+    PADDLE_ENFORCE_EQ(
+        scale_ptr->dims().size(),
+        1UL,
+        common::errors::InvalidArgument(
+            "The `shape` in InstanceNormOp is invalid: "
+            "the size of scale's dimensions must be equal to 1. But "
+            "received: the size of scale's dimensions "
+            "is [%d]",
+            scale_ptr->dims().size()));
+    PADDLE_ENFORCE_EQ(scale_ptr->dims()[0],
+                      C,
+                      common::errors::InvalidArgument(
+                          "The `shape` in InstanceNormOp is invalid: "
+                          "the first dimension of scale must be equal to "
+                          "Channels([%d]). But received: "
+                          "the first dimension of scale is [%d],"
+                          "the dimensions of scale is [%s], ",
+                          C,
+                          scale_ptr->dims()[0],
+                          scale_ptr->dims()));
+  }
+
+  const int64_t n = x.numel();
+  const int block = 512;
+  int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
+  const int max_blocks = std::max(max_threads / block, 1);
+  const int grid = std::min(NxC, max_blocks);
+  const int grid1 = (C + block - 1) / block;
+
+  DenseTensor scale_tmp;
+  scale_tmp.Resize({NxC});
+  dev_ctx.template Alloc<AccT>(&scale_tmp);
+
+  DenseTensor d_scale_tmp;
+  d_scale_tmp.Resize({NxC});
+  dev_ctx.template Alloc<AccT>(&d_scale_tmp);
+
+  DenseTensor d_bias_tmp;
+  d_bias_tmp.Resize({NxC});
+  dev_ctx.template Alloc<AccT>(&d_bias_tmp);
+  if (scale_ptr) {
+    repeat_param<AccT><<<grid, block, 0, dev_ctx.stream()>>>(
+        scale_ptr->data<AccT>(), scale_tmp.data<AccT>(), N, C);
+  } else {
+    set_constant(dev_ctx, &scale_tmp, static_cast<AccT>(1));
+  }
+  std::vector<int> dims;
+  std::vector<int> strides;
+  dims = {1, NxC, H, W, D};
+  strides = {NxC * H * W * D, H * W * D, W * D, D, 1};
+
+#ifdef PADDLE_WITH_HIP
+  miopenTensorDescriptor_t data_desc_;
+  miopenTensorDescriptor_t in_param_desc_;
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenCreateTensorDescriptor(&data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenCreateTensorDescriptor(&in_param_desc_));
+#else
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnTensorDescriptor_t in_param_desc_;
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnCreateTensorDescriptor(&data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnCreateTensorDescriptor(&in_param_desc_));
+#endif
+
+  if (epsilon <= CUDNN_BN_MIN_EPSILON - FLT_EPSILON) {
+    LOG(ERROR) << "Provided epsilon is smaller than "
+               << "CUDNN_BN_MIN_EPSILON. Setting it to "
+               << "CUDNN_BN_MIN_EPSILON instead.";
+  }
+  epsilon = std::max(epsilon, static_cast<double>(CUDNN_BN_MIN_EPSILON));
+
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::miopenSetTensorDescriptor(
+      data_desc_,
+      CudnnDataType<T>::type,
+      x_dims.size() > 3 ? x_dims.size() : 4,
+      const_cast<int *>(dims.data()),
+      const_cast<int *>(strides.data())));
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::miopenDeriveBNTensorDescriptor(
+      in_param_desc_, data_desc_, miopenBNSpatial));
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnSetTensorNdDescriptor(
+      data_desc_,
+      CudnnDataType<T>::type,
+      x_dims.size() > 3 ? x_dims.size() : 4,
+      dims.data(),
+      strides.data()));
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnDeriveBNTensorDescriptor(
+      in_param_desc_, data_desc_, CUDNN_BATCHNORM_SPATIAL));
+#endif
+  const auto *saved_mean_data =
+      saved_mean.template data<BatchNormParamType<T>>();
+  const auto *saved_var_data =
+      saved_variance.template data<BatchNormParamType<T>>();
+
+  if (d_scale && d_bias) {
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::miopenBatchNormalizationBackward(
+        GetDnnHandle(dev_ctx.stream(), dev_ctx.GetPlace()),
+        miopenBNSpatial,
+        CudnnDataType<T>::kOne(),
+        CudnnDataType<T>::kZero(),
+        CudnnDataType<T>::kOne(),
+        CudnnDataType<T>::kZero(),
+        data_desc_,
+        x_tmp.template data<T>(),
+        data_desc_,
+        d_y_tmp.template data<T>(),
+        data_desc_,
+        d_x->template data<T>(),
+        in_param_desc_,
+        scale_tmp.template data<BatchNormParamType<T>>(),
+        d_scale_tmp.template data<BatchNormParamType<T>>(),
+        d_bias_tmp.template data<BatchNormParamType<T>>(),
+        epsilon,
+        saved_mean_data,
+        saved_var_data));
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnBatchNormalizationBackward(
+        GetDnnHandle(dev_ctx.stream(), dev_ctx.GetPlace()),
+        CUDNN_BATCHNORM_SPATIAL,
+        CudnnDataType<T>::kOne(),
+        CudnnDataType<T>::kZero(),
+        CudnnDataType<T>::kOne(),
+        CudnnDataType<T>::kZero(),
+        data_desc_,
+        x_tmp.template data<T>(),
+        data_desc_,
+        d_y_tmp.template data<T>(),
+        data_desc_,
+        d_x->template data<T>(),
+        in_param_desc_,
+        scale_tmp.template data<BatchNormParamType<T>>(),
+        d_scale_tmp.template data<BatchNormParamType<T>>(),
+        d_bias_tmp.template data<BatchNormParamType<T>>(),
+        epsilon,
+        saved_mean_data,
+        saved_var_data));
+#endif
+  } else {
+    if (d_x) {
+      GradComputeDX<T, block><<<NxC, block, 0, dev_ctx.stream()>>>(
+          d_y.data<T>(),
+          scale_tmp.data<BatchNormParamType<T>>(),
+          saved_mean_data,
+          x.data<T>(),
+          saved_var_data,
+          C,
+          H * W * D,
+          d_x->data<T>());
+    }
+  }
+  if (d_scale && d_bias) {
+    add_param<AccT, block, false><<<grid1, block, 0, dev_ctx.stream()>>>(
+        d_scale_tmp.data<AccT>(), d_scale->data<AccT>(), N, C);
+    add_param<AccT, block, false><<<grid1, block, 0, dev_ctx.stream()>>>(
+        d_bias_tmp.data<AccT>(), d_bias->data<AccT>(), N, C);
+  }
+
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenDestroyTensorDescriptor(data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenDestroyTensorDescriptor(in_param_desc_));
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnDestroyTensorDescriptor(data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnDestroyTensorDescriptor(in_param_desc_));
+#endif
+}
+
+template <typename T, typename Context>
+void InstanceNormDoubleGradKernel(const Context &dev_ctx,
+                                  const DenseTensor &x,
+                                  const paddle::optional<DenseTensor> &scale,
+                                  const DenseTensor &saved_mean,
+                                  const DenseTensor &saved_variance,
+                                  const DenseTensor &dy,
+                                  const paddle::optional<DenseTensor> &ddx,
+                                  const paddle::optional<DenseTensor> &ddscale,
+                                  const paddle::optional<DenseTensor> &ddbias,
+                                  float epsilon_f,
+                                  DenseTensor *dx,
+                                  DenseTensor *dscale,
+                                  DenseTensor *ddy) {
+  using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
+  const auto *Scale = scale.get_ptr();
+  const auto *ddX = ddx.get_ptr();
+  const auto *ddScale = ddscale.get_ptr();
+  const auto *ddBias = ddbias.get_ptr();
+  const double epsilon = static_cast<double>(epsilon_f);
+  const T *x_data = x.data<T>();
+  const T *dy_data = dy.data<T>();
+  const T *ddx_data = (ddX == nullptr ? nullptr : ddX->data<T>());
+  const AccT *ddscale_data =
+      (ddScale == nullptr ? nullptr : ddScale->data<AccT>());
+  const AccT *ddbias_data =
+      (ddScale == nullptr ? nullptr : ddBias->data<AccT>());
+  const AccT *mean_data = saved_mean.data<AccT>();
+  const AccT *variance_data = saved_variance.data<AccT>();
+  phi::funcs::SetConstant<GPUContext, T> set_zero;
+  phi::funcs::SetConstant<GPUContext, AccT> set_zero_AccT;
+
+  auto &x_dims = x.dims();
+  int N, C, H, W, D;
+  funcs::ExtractNCWHD(x_dims, DataLayout::kNCHW, &N, &C, &H, &W, &D);
+  int NxC = N * C;
+  const int64_t n = x.numel();
+  int64_t sample_size = n / N / C;
+
+  DenseTensor scale_tmp;
+  if (!Scale) {
+    scale_tmp.Resize({C});
+    dev_ctx.template Alloc<AccT>(&scale_tmp);
+    set_zero_AccT(dev_ctx, &scale_tmp, static_cast<AccT>(1));
+  }
+  const AccT *scale_data = Scale ? Scale->data<AccT>() : scale_tmp.data<AccT>();
+  const int block = 512;
+  int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
+  const int max_blocks = std::max(max_threads / block, 1);
+  const int grid = NxC;
+  const int grid1 = (C + block - 1) / block;
+
+  if (dx) {
+    T *dx_data = dev_ctx.template Alloc<T>(dx);
+    set_zero(dev_ctx, dx, static_cast<T>(0));
+    DoubleGradComputeDX<T, AccT, block>
+        <<<grid, block, 0, dev_ctx.stream()>>>(x_data,
+                                               mean_data,
+                                               variance_data,
+                                               ddx_data,
+                                               dy_data,
+                                               scale_data,
+                                               ddscale_data,
+                                               C,
+                                               sample_size,
+                                               epsilon,
+                                               dx_data);
+  }
+  if (dscale) {
+    DenseTensor dscale_tmp;
+    dscale_tmp.Resize({NxC});
+    dev_ctx.template Alloc<AccT>(&dscale_tmp);
+    set_zero_AccT(dev_ctx, &dscale_tmp, static_cast<AccT>(0));
+    AccT *dscale_tmp_data = dscale_tmp.data<AccT>();
+
+    AccT *dscale_data = dev_ctx.template Alloc<AccT>(dscale);
+    set_zero_AccT(dev_ctx, dscale, static_cast<AccT>(0));
+    DoubleGradComputeDScale<T, AccT, block>
+        <<<grid, block, 0, dev_ctx.stream()>>>(x_data,
+                                               mean_data,
+                                               variance_data,
+                                               ddx_data,
+                                               dy_data,
+                                               C,
+                                               sample_size,
+                                               epsilon,
+                                               dscale_tmp_data);
+    add_param<AccT, block, false><<<grid1, block, 0, dev_ctx.stream()>>>(
+        dscale_tmp.data<AccT>(), dscale->data<AccT>(), N, C);
+  }
+  if (ddy) {
+    T *ddy_data = dev_ctx.template Alloc<T>(ddy);
+    set_zero(dev_ctx, ddy, static_cast<T>(0));
+    DoubleGradComputeDDY<T, AccT, block>
+        <<<grid, block, 0, dev_ctx.stream()>>>(x_data,
+                                               mean_data,
+                                               variance_data,
+                                               ddscale_data,
+                                               ddbias_data,
+                                               ddx_data,
+                                               scale_data,
+                                               C,
+                                               sample_size,
+                                               epsilon,
+                                               ddy_data);
+  }
+}
+}  // namespace phi
+
+#ifdef PADDLE_WITH_HIP
+// MIOPEN do not support double
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormGradKernel,
+                   float,
+                   phi::float16) {}
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormDoubleGradKernel,
+                   float,
+                   phi::float16) {}
+#elif CUDNN_VERSION_MIN(8, 1, 0)
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormDoubleGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
+#else
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormGradKernel,
+                   float,
+                   phi::float16) {}
+PD_REGISTER_PLUGIN_KERNEL(instance_norm_double_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormDoubleGradKernel,
+                   float,
+                   phi::float16) {}
+#endif

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_kernel.cu
@@ -1,0 +1,283 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/instance_norm_kernel.h"
+#include "runtime/iluvatar_context.h"
+
+#include "glog/logging.h"
+
+#include "paddle/common/layout.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/funcs/norm_utils.h"
+#include "paddle/phi/kernels/gpu/instance_norm_utils.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void InstanceNormKernel(const Context &dev_ctx,
+                        const DenseTensor &x,
+                        const paddle::optional<DenseTensor> &scale,
+                        const paddle::optional<DenseTensor> &bias,
+                        float epsilon_f,
+                        DenseTensor *y,
+                        DenseTensor *saved_mean,
+                        DenseTensor *saved_variance) {
+  using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
+  double epsilon = static_cast<double>(epsilon_f);
+  auto &x_dims = x.dims();
+  PADDLE_ENFORCE_GE(x_dims.size(),
+                    2,
+                    common::errors::InvalidArgument(
+                        "The `shape` in InstanceNormOp is invalid: "
+                        "the size of X's dimensions must greater than "
+                        "or equal to 2. But received: "
+                        "the size of X's dimensions is [%d]",
+                        x_dims.size()));
+  PADDLE_ENFORCE_LE(x_dims.size(),
+                    5,
+                    common::errors::InvalidArgument(
+                        "The `shape` in InstanceNormOp is invalid: "
+                        "the size of X's dimensions must smaller than "
+                        "or equal to 5. But received: "
+                        "the size of X's dimensions is [%d]",
+                        x_dims.size()));
+  int N, C, H, W, D;
+  funcs::ExtractNCWHD(x_dims, DataLayout::kNCHW, &N, &C, &H, &W, &D);
+  int NxC = N * C;
+  DenseTensor x_tmp;
+  x_tmp.ShareDataWith(x).Resize({1, NxC, H, W, D});
+  dev_ctx.template Alloc<T>(y);
+  phi::funcs::SetConstant<GPUContext, BatchNormParamType<T>> functor;
+  phi::funcs::SetConstant<GPUContext, T> functor_y;
+  if (x.numel() == 0) {
+    functor_y(dev_ctx, y, static_cast<T>(0));
+    if (saved_mean) {
+      dev_ctx.template Alloc<BatchNormParamType<T>>(saved_mean);
+      functor(dev_ctx, saved_mean, static_cast<BatchNormParamType<T>>(0));
+    }
+    if (saved_variance) {
+      dev_ctx.template Alloc<BatchNormParamType<T>>(saved_variance);
+      functor(dev_ctx, saved_variance, static_cast<BatchNormParamType<T>>(0));
+    }
+    return;
+  }
+
+#ifdef PADDLE_WITH_HIP
+  miopenTensorDescriptor_t data_desc_;
+  miopenTensorDescriptor_t in_param_desc_;
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenCreateTensorDescriptor(&data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenCreateTensorDescriptor(&in_param_desc_));
+#else
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnTensorDescriptor_t in_param_desc_;
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnCreateTensorDescriptor(&data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnCreateTensorDescriptor(&in_param_desc_));
+#endif
+  if (epsilon <= CUDNN_BN_MIN_EPSILON - FLT_EPSILON) {
+    LOG(ERROR) << "Provided epsilon is smaller than "
+               << "CUDNN_BN_MIN_EPSILON. Setting it to "
+               << "CUDNN_BN_MIN_EPSILON instead.";
+  }
+  epsilon = std::max(epsilon, static_cast<double>(CUDNN_BN_MIN_EPSILON));
+
+  VLOG(3) << "Setting descriptors.";
+  std::vector<int> dims;
+  std::vector<int> strides;
+  dims = {1, NxC, H, W, D};
+  strides = {NxC * H * W * D, H * W * D, W * D, D, 1};
+
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::miopenSetTensorDescriptor(
+      data_desc_,
+      CudnnDataType<T>::type,
+      x_dims.size() > 3 ? x_dims.size() : 4,
+      const_cast<int *>(dims.data()),
+      const_cast<int *>(strides.data())));
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::miopenDeriveBNTensorDescriptor(
+      in_param_desc_, data_desc_, miopenBNSpatial));
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnSetTensorNdDescriptor(
+      data_desc_,
+      CudnnDataType<T>::type,
+      x_dims.size() > 3 ? x_dims.size() : 4,
+      dims.data(),
+      strides.data()));
+  PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnDeriveBNTensorDescriptor(
+      in_param_desc_, data_desc_, CUDNN_BATCHNORM_SPATIAL));
+#endif
+
+  const auto scale_ptr = scale.get_ptr();
+  const auto bias_ptr = bias.get_ptr();
+
+  DenseTensor scale_tmp;
+  scale_tmp.Resize({NxC});
+  dev_ctx.template Alloc<AccT>(&scale_tmp);
+  DenseTensor bias_tmp;
+  bias_tmp.Resize({NxC});
+  dev_ctx.template Alloc<AccT>(&bias_tmp);
+
+  const int n = x.numel();
+  const int block = 512;
+  int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
+  const int max_blocks = std::max(max_threads / block, 1);
+  const int grid = std::min((NxC + block - 1) / block, max_blocks);
+
+  phi::funcs::SetConstant<GPUContext, AccT> set_constant;
+  if (scale_ptr) {
+    repeat_param<AccT><<<grid, block, 0, dev_ctx.stream()>>>(
+        scale_ptr->data<AccT>(), scale_tmp.data<AccT>(), N, C);
+  } else {
+    set_constant(dev_ctx, &scale_tmp, static_cast<AccT>(1));
+  }
+  if (bias_ptr) {
+    repeat_param<AccT><<<grid, block, 0, dev_ctx.stream()>>>(
+        bias_ptr->data<AccT>(), bias_tmp.data<AccT>(), N, C);
+  } else {
+    set_constant(dev_ctx, &bias_tmp, static_cast<AccT>(0));
+  }
+
+  auto handle = GetDnnHandle(dev_ctx.stream(), dev_ctx.GetPlace());
+
+  DenseTensor saved_mean_tmp, saved_variance_tmp;
+
+  if (saved_mean) {
+    dev_ctx.template Alloc<BatchNormParamType<T>>(saved_mean);
+    functor(dev_ctx, saved_mean, static_cast<BatchNormParamType<T>>(0));
+  } else {
+    saved_mean_tmp = phi::Full<BatchNormParamType<T>>(
+        dev_ctx, {NxC}, static_cast<BatchNormParamType<T>>(0));
+  }
+  if (saved_variance) {
+    dev_ctx.template Alloc<BatchNormParamType<T>>(saved_variance);
+    functor(dev_ctx, saved_variance, static_cast<BatchNormParamType<T>>(0));
+  } else {
+    saved_variance_tmp = phi::Full<BatchNormParamType<T>>(
+        dev_ctx, {NxC}, static_cast<BatchNormParamType<T>>(0));
+  }
+  auto *saved_mean_data = saved_mean
+                              ? saved_mean->data<BatchNormParamType<T>>()
+                              : saved_mean_tmp.data<BatchNormParamType<T>>();
+  auto *saved_variance_data =
+      saved_variance ? saved_variance->data<BatchNormParamType<T>>()
+                     : saved_variance_tmp.data<BatchNormParamType<T>>();
+
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenBatchNormalizationForwardTraining(
+          handle,
+          miopenBNSpatial,
+          const_cast<void *>(
+              static_cast<const void *>(CudnnDataType<T>::kOne())),
+          const_cast<void *>(
+              static_cast<const void *>(CudnnDataType<T>::kZero())),
+          data_desc_,
+          static_cast<const void *>(x_tmp.template data<T>()),
+          data_desc_,
+          static_cast<void *>(y->template data<T>()),
+          in_param_desc_,
+          const_cast<void *>(static_cast<const void *>(
+              scale_tmp.template data<BatchNormParamType<T>>())),
+          const_cast<void *>(static_cast<const void *>(
+              bias_tmp.template data<BatchNormParamType<T>>())),
+          0,
+          nullptr,
+          nullptr,
+          epsilon,
+          static_cast<void *>(saved_mean_data),
+          static_cast<void *>(saved_variance_data)));
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenDestroyTensorDescriptor(data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::miopenDestroyTensorDescriptor(in_param_desc_));
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnBatchNormalizationForwardTraining(
+          handle,
+          CUDNN_BATCHNORM_SPATIAL,
+          CudnnDataType<T>::kOne(),
+          CudnnDataType<T>::kZero(),
+          data_desc_,
+          x_tmp.template data<T>(),
+          data_desc_,
+          y->template data<T>(),
+          in_param_desc_,
+          scale_tmp.template data<BatchNormParamType<T>>(),
+          bias_tmp.template data<BatchNormParamType<T>>(),
+          0,
+          nullptr,
+          nullptr,
+          epsilon,
+          saved_mean_data,
+          saved_variance_data));
+
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnDestroyTensorDescriptor(data_desc_));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      phi::dynload::cudnnDestroyTensorDescriptor(in_param_desc_));
+#endif
+}
+
+}  // namespace phi
+
+#ifdef PADDLE_WITH_HIP
+// MIOPEN do not support double
+PD_REGISTER_PLUGIN_KERNEL(instance_norm,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormKernel,
+                   float,
+                   phi::float16) {
+  if (kernel_key.dtype() == phi::DataType::FLOAT16) {
+    kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);
+    kernel->InputAt(2).SetDataType(phi::DataType::FLOAT32);
+  }
+}
+#elif CUDNN_VERSION_MIN(8, 1, 0)
+PD_REGISTER_PLUGIN_KERNEL(instance_norm,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {
+  if (kernel_key.dtype() == phi::DataType::FLOAT16 ||
+      kernel_key.dtype() == phi::DataType::BFLOAT16) {
+    kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);
+    kernel->InputAt(2).SetDataType(phi::DataType::FLOAT32);
+  }
+}
+#else
+PD_REGISTER_PLUGIN_KERNEL(instance_norm,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::InstanceNormKernel,
+                   float,
+                   phi::float16) {
+  if (kernel_key.dtype() == phi::DataType::FLOAT16 ||
+      kernel_key.dtype() == phi::DataType::BFLOAT16) {
+    kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);
+    kernel->InputAt(2).SetDataType(phi::DataType::FLOAT32);
+  }
+}
+#endif

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/instance_norm_kernel.cu
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/instance_norm_kernel.h"
-#include "runtime/iluvatar_context.h"
-
 #include "glog/logging.h"
-
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -24,6 +20,8 @@
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/norm_utils.h"
 #include "paddle/phi/kernels/gpu/instance_norm_utils.h"
+#include "paddle/phi/kernels/instance_norm_kernel.h"
+#include "runtime/iluvatar_context.h"
 
 namespace phi {
 
@@ -243,11 +241,11 @@ void InstanceNormKernel(const Context &dev_ctx,
 #ifdef PADDLE_WITH_HIP
 // MIOPEN do not support double
 PD_REGISTER_PLUGIN_KERNEL(instance_norm,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormKernel,
-                   float,
-                   phi::float16) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormKernel,
+                          float,
+                          phi::float16) {
   if (kernel_key.dtype() == phi::DataType::FLOAT16) {
     kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);
     kernel->InputAt(2).SetDataType(phi::DataType::FLOAT32);
@@ -255,12 +253,12 @@ PD_REGISTER_PLUGIN_KERNEL(instance_norm,
 }
 #elif CUDNN_VERSION_MIN(8, 1, 0)
 PD_REGISTER_PLUGIN_KERNEL(instance_norm,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormKernel,
-                   float,
-                   phi::float16,
-                   phi::bfloat16) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormKernel,
+                          float,
+                          phi::float16,
+                          phi::bfloat16) {
   if (kernel_key.dtype() == phi::DataType::FLOAT16 ||
       kernel_key.dtype() == phi::DataType::BFLOAT16) {
     kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);
@@ -269,11 +267,11 @@ PD_REGISTER_PLUGIN_KERNEL(instance_norm,
 }
 #else
 PD_REGISTER_PLUGIN_KERNEL(instance_norm,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::InstanceNormKernel,
-                   float,
-                   phi::float16) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::InstanceNormKernel,
+                          float,
+                          phi::float16) {
   if (kernel_key.dtype() == phi::DataType::FLOAT16 ||
       kernel_key.dtype() == phi::DataType::BFLOAT16) {
     kernel->InputAt(1).SetDataType(phi::DataType::FLOAT32);

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sigmoid_cross_entropy_with_logits_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sigmoid_cross_entropy_with_logits_grad_kernel_register.cu
@@ -20,4 +20,5 @@ PD_CUSTOM_KERNEL_REGISTER(sigmoid_cross_entropy_with_logits_grad,
                           ALL_LAYOUT,
                           phi::SigmoidCrossEntropyWithLogitsGradKernel,
                           float,
+                          phi::dtype::float16,
                           double) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sigmoid_cross_entropy_with_logits_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sigmoid_cross_entropy_with_logits_kernel_register.cu
@@ -21,4 +21,5 @@ PD_CUSTOM_KERNEL_REGISTER(sigmoid_cross_entropy_with_logits,
                           ALL_LAYOUT,
                           phi::SigmoidCrossEntropyWithLogitsKernel,
                           float,
+                          phi::dtype::float16,
                           double) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_grad_kernel_register.cu
@@ -15,29 +15,28 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/sparse/unary_grad_kernel.h"
 
-
 PD_CUSTOM_KERNEL_REGISTER(transpose_coo_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::TransposeCooGradKernel,
-                   phi::float16,
-                   float,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::TransposeCooGradKernel,
+                          phi::float16,
+                          float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool) {}
 
 PD_CUSTOM_KERNEL_REGISTER(transpose_csr_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::TransposeCsrGradKernel,
-                   phi::float16,
-                   float,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::TransposeCsrGradKernel,
+                          phi::float16,
+                          float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_grad_kernel_register.cu
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/sparse/unary_grad_kernel.h"
+
+
+PD_CUSTOM_KERNEL_REGISTER(transpose_coo_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::TransposeCooGradKernel,
+                   phi::float16,
+                   float,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {}
+
+PD_CUSTOM_KERNEL_REGISTER(transpose_csr_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::TransposeCsrGradKernel,
+                   phi::float16,
+                   float,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_kernel_register.cu
@@ -13,31 +13,30 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/sparse/unary_kernel.h" //NOLINT
-
+#include "paddle/phi/kernels/sparse/unary_kernel.h"  //NOLINT
 
 PD_CUSTOM_KERNEL_REGISTER(transpose_coo,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::TransposeCooKernel,
-                   phi::float16,
-                   float,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::TransposeCooKernel,
+                          phi::float16,
+                          float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool) {}
 
 PD_CUSTOM_KERNEL_REGISTER(transpose_csr,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::TransposeCsrKernel,
-                   phi::float16,
-                   float,
-                   int8_t,
-                   uint8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool) {}
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::TransposeCsrKernel,
+                          phi::float16,
+                          float,
+                          int8_t,
+                          uint8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_transpose_kernel_register.cu
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/sparse/unary_kernel.h" //NOLINT
+
+
+PD_CUSTOM_KERNEL_REGISTER(transpose_coo,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::TransposeCooKernel,
+                   phi::float16,
+                   float,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {}
+
+PD_CUSTOM_KERNEL_REGISTER(transpose_csr,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::TransposeCsrKernel,
+                   phi::float16,
+                   float,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_grad_kernel_register.cc
@@ -20,12 +20,26 @@ PD_CUSTOM_KERNEL_REGISTER(sparse_coo_tensor_grad,
                           ALL_LAYOUT,
                           phi::sparse::SparseCooTensorGradKernel,
                           float,
-                          double,
                           uint8_t,
                           int16_t,
                           int,
                           int64_t,
-                          phi::dtype::complex<float>,
-                          phi::dtype::complex<double>) {
+                          phi::dtype::complex<float>) {
   kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}
+
+PD_CUSTOM_KERNEL_REGISTER(values_coo_grad,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::ValuesCooGradKernel,
+                   float,
+                   phi::float16,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool,
+                   phi::dtype::complex<float>) {
+  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_grad_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_grad_kernel_register.cc
@@ -29,17 +29,17 @@ PD_CUSTOM_KERNEL_REGISTER(sparse_coo_tensor_grad,
 }
 
 PD_CUSTOM_KERNEL_REGISTER(values_coo_grad,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::ValuesCooGradKernel,
-                   float,
-                   phi::float16,
-                   uint8_t,
-                   int8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool,
-                   phi::dtype::complex<float>) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::ValuesCooGradKernel,
+                          float,
+                          phi::float16,
+                          uint8_t,
+                          int8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool,
+                          phi::dtype::complex<float>) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_kernel_register.cu
@@ -15,16 +15,31 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/sparse/sparse_utils_kernel.h"
 
+
 PD_CUSTOM_KERNEL_REGISTER(sparse_coo_tensor,
                           iluvatar_gpu,
                           ALL_LAYOUT,
                           phi::sparse::SparseCooTensorKernel,
                           float,
-                          double,
                           phi::dtype::float16,
                           uint8_t,
                           int16_t,
                           int,
                           int64_t,
-                          phi::dtype::complex<float>,
-                          phi::dtype::complex<double>) {}
+                          phi::dtype::complex<float>) {}
+
+PD_CUSTOM_KERNEL_REGISTER(values_coo,
+                   iluvatar_gpu,
+                   ALL_LAYOUT,
+                   phi::sparse::ValuesCooKernel,
+                   float,
+                   phi::float16,
+                   uint8_t,
+                   int8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool,
+                   phi::dtype::complex<float>) {
+  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/sparse_utils_kernel_register.cu
@@ -15,7 +15,6 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/sparse/sparse_utils_kernel.h"
 
-
 PD_CUSTOM_KERNEL_REGISTER(sparse_coo_tensor,
                           iluvatar_gpu,
                           ALL_LAYOUT,
@@ -29,17 +28,17 @@ PD_CUSTOM_KERNEL_REGISTER(sparse_coo_tensor,
                           phi::dtype::complex<float>) {}
 
 PD_CUSTOM_KERNEL_REGISTER(values_coo,
-                   iluvatar_gpu,
-                   ALL_LAYOUT,
-                   phi::sparse::ValuesCooKernel,
-                   float,
-                   phi::float16,
-                   uint8_t,
-                   int8_t,
-                   int16_t,
-                   int,
-                   int64_t,
-                   bool,
-                   phi::dtype::complex<float>) {
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::sparse::ValuesCooKernel,
+                          float,
+                          phi::float16,
+                          uint8_t,
+                          int8_t,
+                          int16_t,
+                          int,
+                          int64_t,
+                          bool,
+                          phi::dtype::complex<float>) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }

--- a/backends/iluvatar_gpu/kernels/funcs/instance_norm_utils.h
+++ b/backends/iluvatar_gpu/kernels/funcs/instance_norm_utils.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cfloat>
+#include <string>
+#include <vector>
+#ifdef __NVCC__
+#include "cub/cub.cuh"
+#endif
+#ifdef __HIPCC__
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#endif
+
+#include "paddle/phi/backends/gpu/gpu_dnn.h"
+#include "paddle/phi/common/amp_type_traits.h"
+
+namespace phi {
+
+template <typename T>
+using CudnnDataType = phi::backends::gpu::CudnnDataType<T>;
+template <typename T>
+using BatchNormParamType = typename CudnnDataType<T>::BatchNormParamType;
+
+template <typename T>
+static __global__ void repeat_param(const T *input,
+                                    T *output,
+                                    const int repeat_num,
+                                    const int C) {
+  CUDA_KERNEL_LOOP(i, repeat_num * C) {
+    int index = i % C;
+    output[i] = input[index];
+  }
+}
+
+template <typename T, int BlockDim, bool AVG>
+static __global__ void add_param(const T *input,
+                                 T *output,
+                                 const int repeat_num,
+                                 const int C) {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  typedef cub::BlockReduce<MPType, BlockDim> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage ou_storage;
+  for (int i = blockIdx.x; i < C; i += gridDim.x) {
+    MPType ou = static_cast<MPType>(0);
+    for (int j = threadIdx.x; j < repeat_num; j += blockDim.x) {
+      const int index = j * C + i;
+      ou = ou + static_cast<MPType>(input[index]);
+    }
+    ou = BlockReduce(ou_storage).Reduce(ou, cub::Sum());
+    if (threadIdx.x == 0) {
+      output[i] = static_cast<T>(ou);
+    }
+    __syncthreads();
+
+    if (AVG) {
+      output[i] = static_cast<T>(static_cast<MPType>(output[i]) / repeat_num);
+    }
+  }
+}
+}  // namespace phi


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the Iluvatar GPU backend, focusing on kernel registration, improved error handling in CMake, and expanded support for sparse and normalization operations. The most significant changes are the addition of new CUDA kernel registrations (including double and triple gradient support), new kernel implementations for instance normalization and sparse transpose operations, and improved CMake checks for missing source files.

**Kernel Registration and Support Expansion:**

* Added registration for new gradient kernels: `sigmoid_double_grad`, `sigmoid_triple_grad`, and `pow_double_grad`, enabling higher-order derivative computations for these activation functions (`activation_grad_kernel_register.cc`). [[1]](diffhunk://#diff-b282ba2674962776f02ea1fc61b5180651ea78aaa7052c9ff745e3b81c247cc3R328-R343) [[2]](diffhunk://#diff-b282ba2674962776f02ea1fc61b5180651ea78aaa7052c9ff745e3b81c247cc3R457-R466)
* Added support for `phi::dtype::float16` in `sigmoid_cross_entropy_with_logits` and its gradient kernel registrations, improving mixed-precision training compatibility (`sigmoid_cross_entropy_with_logits_kernel_register.cu`, `sigmoid_cross_entropy_with_logits_grad_kernel_register.cu`). [[1]](diffhunk://#diff-44424dff6c0e312020083001d03bcb80ee243a8dd398b97b9c505e492aa14854R24) [[2]](diffhunk://#diff-7c3d10fe7c7f1f3e8b24b321b01719fa084a11e2fde2a50ef73d2b4a42a7e267R23)

**Sparse Tensor Operations:**

* Introduced kernel registrations for sparse COO/CSR transpose and their gradients, supporting a wide range of data types including `float16`, `float`, `int`, and `bool` (`sparse_transpose_kernel_register.cu`, `sparse_transpose_grad_kernel_register.cu`). [[1]](diffhunk://#diff-cac075e64f3a18aa5a25f7134b28e23ab4584017ee24b9746fc165a8cb0c09efR1-R43) [[2]](diffhunk://#diff-45db0ead3f92c45c891d4248b52beab7ef2c49847cdca09ad11b4d1963052fafR1-R43)
* Added `values_coo` and `values_coo_grad` kernel registrations for COO sparse tensor value manipulation, and removed unsupported types from `sparse_coo_tensor` and its gradient registration (`sparse_utils_kernel_register.cu`, `sparse_utils_grad_kernel_register.cc`). [[1]](diffhunk://#diff-2b291961e83b0644cf8ff23ceb1f9d4e9fc98cf26a437af46c74e25b1b1d6b25R18-R45) [[2]](diffhunk://#diff-146548b2e6c94a6c391c5bf9e502c32067b19f4f9327b2ba2d922b3731282e94L23-R45)

**Instance Normalization:**

* Implemented a new CUDA kernel for `instance_norm` with full kernel registration, including support for `float`, `float16`, and `bfloat16`, and added utility functions for parameter broadcasting and reduction (`instance_norm_kernel.cu`, `instance_norm_utils.h`). [[1]](diffhunk://#diff-f68595c6cdcb8ca252e56d5d301781f330c0fb682dc6839c20fc2a08e08a17fdR1-R283) [[2]](diffhunk://#diff-221185691b5d9305645f4f1e08d5348de86cedec0db75e2ecce270cc5371995aR1-R75)

**Build System Improvements:**

* Enhanced CMake scripts to check for the existence of all CUDA source files (`CUDA_SRCS1` and `CUDA_SRCS2`), causing a build failure if any file is missing, which improves build reliability (`CMakeLists.txt`). [[1]](diffhunk://#diff-3b1f2093490bd018261f3ef4feff4ab63ee1b3a49378ba70e73268eae268ce17R267-R272) [[2]](diffhunk://#diff-3b1f2093490bd018261f3ef4feff4ab63ee1b3a49378ba70e73268eae268ce17R907-R913)

These changes collectively improve the robustness, feature set, and data type support of the Iluvatar GPU backend, especially for advanced deep learning operations and sparse tensor workflows.