### PR TITLE
[Iluvatar] Temporarily force imp_mode to be assigned by IXATTNBKD_FAT…

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/flash_attn_grad_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/flash_attn_grad_kernel.cu
@@ -339,8 +339,13 @@ void FlashAttnUnpaddedGradBaseKernel(
     ixAttnbkdInfo.return_softmax_lse = false;
     ixAttnbkdInfo.philox_args =
         *(reinterpret_cast<ixAttnBkdPhiloxState*>(&philox_state));
-    ixAttnbkdInfo.imp_mode =
-        FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    
+    // NOTE: The reason for bellow comment is that when using pip to
+    // install the pre-compiled whl file to run FD, the value assigned
+    // here is IXATTNBKD_FATTN_PERF_MODE instead of IXATTNBKD_FATTN_PERF_MODE.
+    // ixAttnbkdInfo.imp_mode =
+    //     FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    ixAttnbkdInfo.imp_mode = IXATTNBKD_FATTN_MEM_MODE;
     ixAttnbkdInfo.is_unpad = true;
     ixAttnbkdInfo.batch = batch_size;
     ixAttnbkdInfo.max_seq_len_src = max_seqlen_q;
@@ -952,8 +957,12 @@ void FlashAttnGradBaseKernel(
     ixAttnbkdInfo.return_softmax_lse = false;
     ixAttnbkdInfo.philox_args =
         *(reinterpret_cast<ixAttnBkdPhiloxState*>(&philox_state));
-    ixAttnbkdInfo.imp_mode =
-        FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    // NOTE: The reason for bellow comment is that when using pip to
+    // install the pre-compiled whl file to run FD, the value assigned
+    // here is IXATTNBKD_FATTN_PERF_MODE instead of IXATTNBKD_FATTN_PERF_MODE.
+    // ixAttnbkdInfo.imp_mode =
+    //     FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    ixAttnbkdInfo.imp_mode = IXATTNBKD_FATTN_MEM_MODE;
     ixAttnbkdInfo.is_unpad = false;
     ixAttnbkdInfo.batch = batch_size;
     ixAttnbkdInfo.max_seq_len_src = seqlen_q;

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/flash_attn_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/flash_attn_kernel.cu
@@ -220,8 +220,12 @@ void FlashAttnUnpaddedBaseKernel(
     ixAttnbkdInfo.batch = batch_size;
     ixAttnbkdInfo.max_seq_len_src = max_seqlen_q;
     ixAttnbkdInfo.max_seq_len_trg = max_seqlen_k;
-    ixAttnbkdInfo.imp_mode =
-        FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    // NOTE: The reason for bellow comment is that when using pip to
+    // install the pre-compiled whl file to run FD, the value assigned
+    // here is IXATTNBKD_FATTN_PERF_MODE instead of IXATTNBKD_FATTN_PERF_MODE.
+    // ixAttnbkdInfo.imp_mode =
+    //     FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    ixAttnbkdInfo.imp_mode = IXATTNBKD_FATTN_MEM_MODE;
     ixAttnbkdInfo.accuracy_first = accuracy_first;
 
     ixAttnBkdDataType_t dataType;
@@ -743,8 +747,12 @@ void FlashAttnBaseKernel(
     ixAttnbkdInfo.batch = batch_size;
     ixAttnbkdInfo.max_seq_len_src = seqlen_q;
     ixAttnbkdInfo.max_seq_len_trg = seqlen_k;
-    ixAttnbkdInfo.imp_mode =
-        FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    // NOTE: The reason for bellow comment is that when using pip to
+    // install the pre-compiled whl file to run FD, the value assigned
+    // here is IXATTNBKD_FATTN_PERF_MODE instead of IXATTNBKD_FATTN_PERF_MODE.
+    // ixAttnbkdInfo.imp_mode =
+    //     FLAGS_imp_mode ? IXATTNBKD_FATTN_MEM_MODE : IXATTNBKD_FATTN_PERF_MODE;
+    ixAttnbkdInfo.imp_mode = IXATTNBKD_FATTN_MEM_MODE;
     ixAttnbkdInfo.accuracy_first = accuracy_first;
 
     ixAttnBkdDataType_t dataType;


### PR DESCRIPTION
安装daily whl测试Fastdeploy时，虽然imp_mode=1，但是这里赋值成IXATTNBKD_FATTN_PERF_MODE，为了不block Fastdeploy测试，暂时将ixAttnbkdInfo.imp_mode强制修改成IXATTNBKD_FATTN_MEM_MODE