### PR TITLE
[CI] update custom_cpu image and npu image to ubuntu24.04

### DIFF
--- a/backends/custom_cpu/tools/dockerfile/Dockerfile.ubuntu24.x86_64.gcc133
+++ b/backends/custom_cpu/tools/dockerfile/Dockerfile.ubuntu24.x86_64.gcc133
@@ -1,6 +1,6 @@
 # Docker Image for PaddlePaddle ubuntu develop base environment
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 LABEL maintainer="PaddlePaddle Authors <paddle-dev@baidu.com>"
 
 RUN apt-get update && apt-get install -y apt-utils
@@ -8,7 +8,7 @@ RUN ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
 RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update && apt-get install -y curl wget vim git unzip unrar tar ntp xz-utils libssl-dev bzip2 gzip make automake \
-    coreutils language-pack-zh-hans libsm6 libxext6 libxrender-dev libgl1-mesa-glx libsqlite3-dev libopenblas-dev liblapack3 \
+    coreutils language-pack-zh-hans libsm6 libxext6 libxrender-dev libglx-mesa0 libsqlite3-dev libopenblas-dev liblapack3 \
     bison libjpeg-dev zlib1g zlib1g-dev swig locales net-tools libtool numactl libnuma-dev liblzma-dev libbz2-dev libblas-dev \
     openssl openssh-server libffi-dev pciutils libblas3 liblapack-dev libzstd-dev default-jre libgcc-s1 gcc g++ gfortran gdb
 
@@ -18,11 +18,8 @@ COPY root/ /root/
 # workdir
 WORKDIR /opt
 
-# GCC 8.4
-RUN apt-get install -y gcc-8 g++-8 gfortran-8
-RUN update-alternatives --install /usr/bin/g++  g++  /usr/bin/g++-8  90 && \
-    update-alternatives --install /usr/bin/gcc  gcc  /usr/bin/gcc-8  90 && \
-    update-alternatives --install /usr/bin/gfortran  gfortran  /usr/bin/gfortran-8  90
+# GCC
+RUN apt-get install -y gcc g++ gfortran
 
 # cmake 3.27.7
 RUN wget -q https://cmake.org/files/v3.27/cmake-3.27.7-linux-x86_64.sh && \
@@ -33,7 +30,7 @@ ENV PATH=/opt/cmake-3.27.7/bin:${PATH}
 
 # default python version
 ARG PY_VERSION=3.10
-RUN apt-get install -y python3-distutils python${PY_VERSION} python${PY_VERSION}-dev
+RUN apt-get install -y python${PY_VERSION}-distutils python${PY_VERSION} python${PY_VERSION}-dev
 
 # install pip
 RUN curl -s -q https://bootstrap.pypa.io/get-pip.py | /usr/bin/python${PY_VERSION}
@@ -49,13 +46,13 @@ RUN pip install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format=
 
 # add more libs
 RUN apt-get update && apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev lsof libgeos-dev \
-    pkg-config libhdf5-103 libhdf5-dev lrzsz libsndfile1 tree ninja-build -y
+    pkg-config libhdf5-103-1t64 libhdf5-dev lrzsz libsndfile1 tree ninja-build -y
 
 # install Paddle requirement
 RUN wget --no-check-certificate https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O requirements.txt && \
-    pip install -r requirements.txt -i https://pip.baidu-int.com/simple --trusted-host pip.baidu-int.com && rm -rf requirements.txt
+    pip install -r requirements.txt && rm -rf requirements.txt
 RUN wget --no-check-certificate https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/unittest_py/requirements.txt -O requirements.txt && \
-    pip install -r requirements.txt -i https://pip.baidu-int.com/simple --trusted-host pip.baidu-int.com && rm -rf requirements.txt
+    pip install --break-system-packages --ignore-installed -r requirements.txt && rm -rf requirements.txt
 
 # git credential to skip password typing
 RUN git config --global credential.helper store

--- a/backends/custom_cpu/tools/dockerfile/build-image.sh
+++ b/backends/custom_cpu/tools/dockerfile/build-image.sh
@@ -16,7 +16,7 @@
 
 # BOTH for x86_64 and aarch64
 
-# ubuntu24.gcc84-py39
+# ubuntu24.gcc133-py39
 docker build --network=host -f Dockerfile.ubuntu24.$(uname -m).gcc133 \
   --build-arg PY_VERSION=3.9 \
   --build-arg http_proxy=${proxy} \
@@ -26,7 +26,7 @@ docker build --network=host -f Dockerfile.ubuntu24.$(uname -m).gcc133 \
   -t registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py39 .
 docker push registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py39
 
-# ubuntu24.gcc84-py310
+# ubuntu24.gcc133-py310
 docker build --network=host -f Dockerfile.ubuntu24.$(uname -m).gcc133 \
   --build-arg PY_VERSION=3.10 \
   --build-arg http_proxy=${proxy} \

--- a/backends/custom_cpu/tools/dockerfile/build-image.sh
+++ b/backends/custom_cpu/tools/dockerfile/build-image.sh
@@ -16,32 +16,22 @@
 
 # BOTH for x86_64 and aarch64
 
-# ubuntu20.gcc84-py38
-docker build --network=host -f Dockerfile.ubuntu20.$(uname -m).gcc84 \
-  --build-arg PY_VERSION=3.8 \
-  --build-arg http_proxy=${proxy} \
-  --build-arg https_proxy=${proxy} \
-  --build-arg ftp_proxy=${proxy} \
-  --build-arg no_proxy=bcebos.com,baidu-int.com \
-  -t registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py38 .
-docker push registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py38
-
-# ubuntu20.gcc84-py39
-docker build --network=host -f Dockerfile.ubuntu20.$(uname -m).gcc84 \
+# ubuntu24.gcc84-py39
+docker build --network=host -f Dockerfile.ubuntu24.$(uname -m).gcc133 \
   --build-arg PY_VERSION=3.9 \
   --build-arg http_proxy=${proxy} \
   --build-arg https_proxy=${proxy} \
   --build-arg ftp_proxy=${proxy} \
   --build-arg no_proxy=bcebos.com,baidu-int.com \
-  -t registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py39 .
-docker push registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py39
+  -t registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py39 .
+docker push registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py39
 
-# ubuntu20.gcc84-py310
-docker build --network=host -f Dockerfile.ubuntu20.$(uname -m).gcc84 \
+# ubuntu24.gcc84-py310
+docker build --network=host -f Dockerfile.ubuntu24.$(uname -m).gcc133 \
   --build-arg PY_VERSION=3.10 \
   --build-arg http_proxy=${proxy} \
   --build-arg https_proxy=${proxy} \
   --build-arg ftp_proxy=${proxy} \
   --build-arg no_proxy=bcebos.com,baidu-int.com \
-  -t registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py310 .
-docker push registry.baidubce.com/device/paddle-cpu:ubuntu20-$(uname -m)-gcc84-py310
+  -t registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py310 .
+docker push registry.baidubce.com/device/paddle-cpu:ubuntu24-$(uname -m)-gcc133-py310

--- a/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu24.gcc133
+++ b/backends/npu/tools/dockerfile/Dockerfile.npu.ubuntu24.gcc133
@@ -3,10 +3,10 @@
 FROM <baseimg>
 LABEL maintainer="PaddlePaddle Authors <paddle-dev@baidu.com>"
 
-
-
-# HwHiAiUser
-RUN groupadd -g 1000 HwHiAiUser && \
+# del default user and add HwHiAiUser
+RUN (groupdel $(getent group 1000 | cut -d: -f1) 2>/dev/null || true) && \
+    (userdel $(getent passwd 1000 | cut -d: -f1) 2>/dev/null || true) && \
+    groupadd -g 1000 HwHiAiUser && \
     useradd -u 1000 -g 1000 -m -d /home/HwHiAiUser HwHiAiUser
 
 RUN mkdir -p /usr/local/Ascend/driver
@@ -20,17 +20,11 @@ ARG NPU_VERSION
 RUN apt-get update -y && apt-get install -y zlib1g zlib1g-dev libsqlite3-dev openssl libssl-dev libffi-dev libbz2-dev \
     libxslt1-dev unzip pciutils net-tools libblas-dev gfortran libblas3 liblapack-dev liblapack3 libopenblas-dev zstd
 
-RUN pip3.8 install --upgrade pip setuptools wheel && \
-    pip3.9 install --upgrade pip setuptools wheel && \
-    pip3.10 install --upgrade pip setuptools wheel
+RUN pip3.9 install --upgrade pip setuptools wheel
 
-RUN pip3.8 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
-    pip3.9 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
-    pip3.10 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0'
+RUN pip3.9 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0'
 
-RUN pip3.8 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
-    pip3.9 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
-    pip3.10 install attrs pyyaml pathlib2 scipy requests psutil absl-py
+RUN pip3.9 install attrs pyyaml pathlib2 scipy requests psutil absl-py
 
 # update envs for driver
 ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:$LD_LIBRARY_PATH

--- a/backends/npu/tools/dockerfile/build-image.sh
+++ b/backends/npu/tools/dockerfile/build-image.sh
@@ -32,9 +32,9 @@ if [ ! -f Ascend-cann-toolkit_${CANN_VERSION}_linux-$(uname -m).run ]; then
   exit 1
 fi
 
-sed "s#<baseimg>#registry.baidubce.com/device/paddle-cpu:ubuntu20-npu-base-$(uname -m)-gcc84#g" Dockerfile.npu.ubuntu20.gcc84 > Dockerfile.npu.ubuntu20.gcc84.test
-#docker pull registry.baidubce.com/device/paddle-cpu:ubuntu20-npu-base-$(uname -m)-gcc84
-docker build --network=host -f Dockerfile.npu.ubuntu20.gcc84.test \
+sed "s#<baseimg>#registry.baidubce.com/device/paddle-cpu:ubuntu24-npu-base-$(uname -m)-gcc133#g" Dockerfile.npu.ubuntu24.gcc133 > Dockerfile.npu.ubuntu24.gcc133.test
+#docker pull registry.baidubce.com/device/paddle-cpu:ubuntu24-npu-base-$(uname -m)-gcc133
+docker build --network=host -f Dockerfile.npu.ubuntu24.gcc133.test \
   --build-arg CANN_VERSION=${CANN_VERSION} \
   --build-arg SYSTEM=${SYSTEM} \
   --build-arg NPU_VERSION=${NPU_VERSION} \
@@ -42,6 +42,6 @@ docker build --network=host -f Dockerfile.npu.ubuntu20.gcc84.test \
   --build-arg https_proxy=${proxy} \
   --build-arg ftp_proxy=${proxy} \
   --build-arg no_proxy=bcebos.com \
-  -t ccr-2vdh3abv-pub.cnc.bj.baidubce.com/device/paddle-npu:cann${DOCKER_VERSION}-ubuntu20-npu-${NPU_VERSION}-base-$(uname -m)-gcc84 .
-docker push ccr-2vdh3abv-pub.cnc.bj.baidubce.com/device/paddle-npu:cann${DOCKER_VERSION}-ubuntu20-npu-${NPU_VERSION}-base-$(uname -m)-gcc84
-rm -rf Dockerfile.npu.ubuntu20.gcc84.test
+  -t ccr-2vdh3abv-pub.cnc.bj.baidubce.com/device/paddle-npu:cann${DOCKER_VERSION}-ubuntu24-npu-${NPU_VERSION}-base-$(uname -m)-gcc133 .
+docker push ccr-2vdh3abv-pub.cnc.bj.baidubce.com/device/paddle-npu:cann${DOCKER_VERSION}-ubuntu24-npu-${NPU_VERSION}-base-$(uname -m)-gcc133
+rm -rf Dockerfile.npu.ubuntu24.gcc133.test


### PR DESCRIPTION
## feat
* 更新 custom_cpu 的基础镜像到 ubuntu:24.04
* 删除 custom_cpu 中 python 3.8 相关内容
* npu 改为只安装 python3.9 相关依赖

cc: @tianshuo78520a 