### PR TITLE
【CUDA Kernel No.49】elementwise_grad_kernel.cu算子Kernel修复

### DIFF
--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -659,6 +659,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/rms_norm_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/lars_momentum_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/partial_sum_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/elementwise_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/backends/gpu/gpu_info.cc
   # ############################################################################
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/elementwise_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/elementwise_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/elementwise_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/elementwise_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(fmax_grad,
                           metax_gpu,


### PR DESCRIPTION
### PR Category

Custom Device

### PR Types

Improvements

### Description

Add elementwise_grad_kernel.cu to CMakeLists.txt for GPU backend integration in PaddleCustomDevice.
Since the corresponding header file already exists in the Paddle repository, the modification was made directly in the PaddleCustomDevice repository.