### PR TITLE
[ILUVATAR] add `determinant/determinant_grad` kernel

### DIFF
--- a/backends/iluvatar_gpu/CMakeLists.txt
+++ b/backends/iluvatar_gpu/CMakeLists.txt
@@ -708,6 +708,8 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/shuffle_batch_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/slogdeterminant_grad_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/determinant_grad_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/determinant_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/sparse_momentum_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/straight_through_estimator_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/svd_grad_kernel.cu

--- a/backends/iluvatar_gpu/kernels/cuda_kernels/determinant_kernel.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/determinant_kernel.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/gpu/determinant_kernel.cu"  // NOLINT
+
+PD_CUSTOM_KERNEL_REGISTER(determinant,
+                          iluvatar_gpu,
+                          ALL_LAYOUT,
+                          phi::DeterminantKernel,
+                          float,
+                          phi::float16,
+                          phi::complex64) {}


### PR DESCRIPTION
This pull request introduces support for the determinant operation on the Iluvatar GPU backend in PaddlePaddle. The main changes include registering the determinant and its gradient CUDA kernels in the build system and implementing the custom kernel registration for the backend.

**Kernel registration and build system updates:**

* Added `determinant_kernel.cu` and `determinant_grad_kernel.cu` to the list of CUDA source files in `backends/iluvatar_gpu/CMakeLists.txt`, ensuring they are compiled for the Iluvatar GPU backend.

**Custom kernel implementation:**

* Created `backends/iluvatar_gpu/kernels/cuda_kernels/determinant_kernel.cu` to register the determinant kernel for the Iluvatar GPU backend, supporting `float`, `float16`, and `complex64` data types.