### PR TITLE
【CUDA Kernel No.55】gelu_grad_kernel.h

### DIFF
--- a/backends/metax_gpu/kernels/cuda_kernels/gelu_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/gelu_grad_kernel_register.cu
@@ -16,7 +16,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/gelu_kernel.h"
 #include "paddle/phi/kernels/gpu/gelu_funcs.h"
-#include "paddle/phi/kernels/gpu/gelu_grad_kernel.cu" // NOLINT
+#include "paddle/phi/kernels/gelu_grad_kernel.h"
 // clang-format on
 PD_CUSTOM_KERNEL_REGISTER(gelu_grad,
                           metax_gpu,


### PR DESCRIPTION
Update gelu_grad_kernel.cu

### PR Category

Custom Device

### PR Types

Improvements

### Description

Include gelu_grad_kernel.h to replace .cu file include
ℹ️The .h file already exists in the Paddle repo. So there's no modifications to the Paddle repo.
ℹ️cmakelists already exists paddle/phi/kernels/gpu/gelu_grad_kernel.cu
<img width="1224" height="446" alt="7ed09b3b-1623-4708-a956-0353a952bf6e" src="https://github.com/user-attachments/assets/a50b7e56-7cad-464a-8c9e-4ddc1d4027e0" />
