### PR TITLE
[INTEL_HPU] enable tensor_wise_fp8 kernels - Mlp GateMoe

### DIFF
--- a/backends/intel_hpu/custom_ops/llama_infer/fused_gate_moe.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_gate_moe.cc
@@ -41,12 +41,14 @@ struct FusedGateMoeParams {
   bool fused_gemm;
   bool measurement_mode;
   bool dynamic_scale;
+
+  bool hidden_states_static_quant;
 };
 
 enum TENSOR_IDS_IN {
   HIDDEN_STATES = 0,
-  GATE_OUT = 1,
-  BIAS_OR_WEIGHTS,  // 2 + bias_offset
+  GATE_WEIGHT = 1,
+  BIAS_OR_WEIGHTS,  // 2 + bias_offset + hs_quant_offset
   EOS_TOKEN
 };
 
@@ -95,24 +97,43 @@ class FusedGateMoe : public HpuFusedOperator {
   template <typename T, typename TMoe>
   void AddNode(ConvertTensors& ct, FusedGateMoeParams params) {
     auto ins = ct.GetTensors();
-    auto gate_data_type = ins[GATE_OUT].type;
+    auto gate_data_type = ins[GATE_WEIGHT].type;
 
     /* ---------------- MoE Gate ---------------- */
+    // gate_out = paddle.matmul(x.cast("float32"), gate.weight)
+    auto hidden_states = createTensorFromCT(&ct, HIDDEN_STATES);
+    auto hidden_states_fp32 = createTensorNoPresist(
+        "hidden_states_fp32", gate_data_type, ins[HIDDEN_STATES].dims);
+    std::vector<synTensor> cast_fp32_in = {hidden_states};
+    std::vector<synTensor> cast_fp32_out = {hidden_states_fp32};
+    AddNodeCast(
+        cast_fp32_in, cast_fp32_out, "cast_bf16_to_f32", "cast_bf16_to_f32");
+
+    std::vector<synTensor> gate_in;
+    auto gate_weights = createTensorFromCT(&ct, GATE_WEIGHT);
+    gate_in.push_back(hidden_states_fp32);
+    gate_in.push_back(gate_weights);
+
+    std::vector<int64_t> gate_out_dims = {ins[HIDDEN_STATES].dims[0],
+                                          ins[GATE_WEIGHT].dims[1]};
+    auto gate_out_tensor =
+        createTensorNoPresist("gate_out_tensor", gate_data_type, gate_out_dims);
+    std::vector<synTensor> gate_out = {gate_out_tensor};
+
+    synGEMMParams gemm_params_f_f;
+    gemm_params_f_f.transpose_a = false;
+    gemm_params_f_f.transpose_b = false;
+    AddNodeGemm(gate_in, gate_out, gemm_params_f_f, guid_ + "gemm_gate");
 
     // weights = paddle.nn.functional.softmax(gate_out, axis=-1)
-    auto gate_out = createTensorFromCT(&ct, GATE_OUT);
-    std::vector<synTensor> softmax_in;
-    softmax_in.push_back(gate_out);
-
     auto weights =
-        createTensorNoPresist("weights", gate_data_type, ins[GATE_OUT].dims);
-    std::vector<synTensor> softmax_out;
-    softmax_out.push_back(weights);
+        createTensorNoPresist("weights", gate_data_type, gate_out_dims);
+    std::vector<synTensor> softmax_out = {weights};
 
     ns_Softmax::Params softmax_params;
     softmax_params.dim = 0;
     AddNodeSoftmax<float>(
-        softmax_in, softmax_out, softmax_params, guid_ + "softmax");
+        gate_out, softmax_out, softmax_params, guid_ + "softmax");
 
     ns_TopkNodeV2::ParamsV4 topk_params{};
     topk_params.bsw = params.topk;
@@ -121,14 +142,14 @@ class FusedGateMoe : public HpuFusedOperator {
     topk_params.isVcData = false;
     topk_params.isStable = false;
 
-    std::vector<int64_t> topk_dims = std::vector<int64_t>(ins[GATE_OUT].dims);
-    topk_dims[1] = params.topk;
+    std::vector<int64_t> topk_dims = {ins[HIDDEN_STATES].dims[0], params.topk};
     auto routing_weights_fp32 = createTensorNoPresist(
         "routing_weights_fp32", gate_data_type, topk_dims);
     auto selected_experts =
         createTensorNoPresist("selected_experts", syn_type_int32, topk_dims);
 
     int bias_offset = 0;
+    int hs_quant_offset = 0;
     // if layer.moe_use_gate_correction_bias:
     if (params.moe_use_gate_correction_bias) {
       // scores = weights + layer.gate_correction_bias
@@ -136,7 +157,7 @@ class FusedGateMoe : public HpuFusedOperator {
       int bias_base = BIAS_OR_WEIGHTS;
       auto gate_correction_bias = createTensorFromCT(&ct, bias_base);
       auto gate_correction_out = createTensorNoPresist(
-          "gate_correction_out", gate_data_type, ins[GATE_OUT].dims);
+          "gate_correction_out", gate_data_type, gate_out_dims);
       std::vector<synTensor> gate_correction_in;
       gate_correction_in.push_back(weights);
       gate_correction_in.push_back(gate_correction_bias);
@@ -147,7 +168,7 @@ class FusedGateMoe : public HpuFusedOperator {
 
       // _, selected_experts = paddle.topk(scores, layer.top_k, axis=-1)
       auto drop_data =
-          createTensorNoPresist("drop_data", syn_type_int32, topk_dims);
+          createTensorNoPresist("drop_data", gate_data_type, topk_dims);
 
       std::vector<synTensor> topk_outs;
       topk_outs.push_back(drop_data);
@@ -185,7 +206,7 @@ class FusedGateMoe : public HpuFusedOperator {
       reduceSum_in.push_back(routing_weights_fp32);
 
       auto reduceSum = createTensorNoPresist(
-          "reduceSum", gate_data_type, {ins[GATE_OUT].dims[0], 1});
+          "reduceSum", gate_data_type, {ins[HIDDEN_STATES].dims[0], 1});
       std::vector<synTensor> reduceSum_out;
       reduceSum_out.push_back(reduceSum);
 
@@ -218,77 +239,123 @@ class FusedGateMoe : public HpuFusedOperator {
     AddNodeCast(cast_in, cast_out, "cast_f32_to_bf16", guid_ + "cast");
 
     std::vector<synTensor> inputs;
-    synTensor hidden_states = createTensorFromCT(&ct, HIDDEN_STATES);
-    synTensor fp8_scale = nullptr;
+    synTensor fp8_d_scale = nullptr;
 
-    /* ---------------- quant_fn for fp8 MoE  ---------------- */
-    // x, x_scale = self.quant_fn(x)
+    /* ----------------  hidden_states to fp8  ---------------- */
     if (dtype_ == syn_type_fp8_143) {
-      ns_ConstantKernel::Params const_params;
-      synTensor q_min =
-          createTensorNoPresist("q_min", ins[HIDDEN_STATES].type, {1});
-      const_params.constant.f = MIN_FP8_VALUES;
-      std::vector<synTensor> min_tensor = {q_min};
-      AddNodeFull<T>(min_tensor, const_params, guid_ + "full_min");
+      // w/a Tensor fp8_d_scale was already mapped
+      unsigned int seed = static_cast<unsigned int>(
+          std::chrono::system_clock::now().time_since_epoch().count());
+      if (params.hidden_states_static_quant == false) {
+        /* ----  dynamic quant for hidden_states ---- */
+        // x, x_scale = self.quant_fn(x)
+        ns_ConstantKernel::Params const_params;
+        synTensor q_min =
+            createTensorNoPresist("q_min", ins[HIDDEN_STATES].type, {1});
+        const_params.constant.f = MIN_FP8_VALUES;
+        std::vector<synTensor> min_tensor = {q_min};
+        AddNodeFull<T>(min_tensor, const_params, guid_ + "full_min");
 
-      synTensor q_max =
-          createTensorNoPresist("q_max", ins[HIDDEN_STATES].type, {1});
-      const_params.constant.f = MAX_FP8_VALUES;
-      std::vector<synTensor> max_tensor = {q_max};
-      AddNodeFull<T>(max_tensor, const_params, guid_ + "full_max");
+        synTensor q_max =
+            createTensorNoPresist("q_max", ins[HIDDEN_STATES].type, {1});
+        const_params.constant.f = MAX_FP8_VALUES;
+        std::vector<synTensor> max_tensor = {q_max};
+        AddNodeFull<T>(max_tensor, const_params, guid_ + "full_max");
 
-      synTensor zeropoint =
-          createTensorNoPresist("zeropoint", ins[HIDDEN_STATES].type, {1});
-      const_params.constant.f = 0;
-      std::vector<synTensor> zeropoint_tensor = {zeropoint};
-      AddNodeFull<T>(zeropoint_tensor, const_params, guid_ + "full_zero");
+        synTensor zeropoint =
+            createTensorNoPresist("zeropoint", ins[HIDDEN_STATES].type, {1});
+        const_params.constant.f = 0;
+        std::vector<synTensor> zeropoint_tensor = {zeropoint};
+        AddNodeFull<T>(zeropoint_tensor, const_params, guid_ + "full_zero");
 
-      std::vector<synTensor> abs_in;
-      abs_in.push_back(hidden_states);
-      auto hidden_states_abs = createTensorNoPresist("hidden_states_abs",
-                                                     ins[HIDDEN_STATES].type,
-                                                     ins[HIDDEN_STATES].dims);
-      std::vector<synTensor> abs_out;
-      abs_out.push_back(hidden_states_abs);
-      AddNodeAbs<T>(abs_in, abs_out, guid_ + "abs");
+        std::vector<synTensor> abs_in;
+        abs_in.push_back(hidden_states);
+        auto hidden_states_abs = createTensorNoPresist("hidden_states_abs",
+                                                       ins[HIDDEN_STATES].type,
+                                                       ins[HIDDEN_STATES].dims);
+        std::vector<synTensor> abs_out;
+        abs_out.push_back(hidden_states_abs);
+        AddNodeAbs<T>(abs_in, abs_out, guid_ + "abs");
 
-      auto max_out =
-          createTensorNoPresist("max_out", ins[HIDDEN_STATES].type, {1});
-      std::vector<synTensor> max_outputs;
-      max_outputs.push_back(max_out);
+        auto max_out =
+            createTensorNoPresist("max_out", ins[HIDDEN_STATES].type, {1});
+        std::vector<synTensor> max_outputs;
+        max_outputs.push_back(max_out);
 
-      ns_Reduction::ParamsV2 reduce_max_params{};
-      AddNodeMaximumMultidimensional<T>(
-          abs_out, max_outputs, reduce_max_params, guid_ + "reduceMax");
+        ns_Reduction::ParamsV2 reduce_max_params{};
+        AddNodeMaximumMultidimensional<T>(
+            abs_out, max_outputs, reduce_max_params, guid_ + "reduceMax");
 
-      std::vector<synTensor> div_inputs;
-      div_inputs.push_back(max_out);
-      div_inputs.push_back(q_max);
-      std::vector<synTensor> div_outputs;
-      // w/a Tensor fp8_scale was already mapped
-      unsigned int seed = time(NULL);
-      std::string fp8_scale_name = "fp8_scale_" + std::to_string(rand_r(&seed));
+        std::vector<synTensor> div_inputs;
+        div_inputs.push_back(max_out);
+        div_inputs.push_back(q_max);
 
-      fp8_scale =
-          createTensorNoPresist(fp8_scale_name, ins[HIDDEN_STATES].type, {1});
-      div_outputs.push_back(fp8_scale);
-      AddNodeDivide<T>(div_inputs, div_outputs, guid_ + "div");
+        std::vector<synTensor> div_outputs;
+        std::string fp8_scale_name =
+            "fp8_scale_" + std::to_string(rand_r(&seed));
+        fp8_d_scale =
+            createTensorNoPresist(fp8_scale_name, ins[HIDDEN_STATES].type, {1});
+        div_outputs.push_back(fp8_d_scale);
+        AddNodeDivide<T>(div_inputs, div_outputs, guid_ + "div");
 
-      std::vector<synTensor> quant_inputs;
-      quant_inputs.push_back(hidden_states);
-      quant_inputs.push_back(fp8_scale);
-      quant_inputs.push_back(zeropoint);
-      quant_inputs.push_back(q_min);
-      quant_inputs.push_back(q_max);
+        std::vector<synTensor> quant_inputs;
+        quant_inputs.push_back(hidden_states);
+        quant_inputs.push_back(fp8_d_scale);
+        quant_inputs.push_back(zeropoint);
+        quant_inputs.push_back(q_min);
+        quant_inputs.push_back(q_max);
 
-      std::vector<synTensor> quant_outputs;
-      synTensor scaled_hidden_states = createTensorNoPresist(
-          "scaled_hidden_states", dtype_, ins[HIDDEN_STATES].dims);
-      quant_outputs.push_back(scaled_hidden_states);
-      AddNodeQuantizePerTensor<T>(quant_inputs, quant_outputs, guid_ + "quant");
+        std::vector<synTensor> quant_outputs;
+        synTensor scaled_hidden_states = createTensorNoPresist(
+            "scaled_hidden_states", dtype_, ins[HIDDEN_STATES].dims);
+        quant_outputs.push_back(scaled_hidden_states);
+        AddNodeQuantizePerTensor<T>(
+            quant_inputs, quant_outputs, guid_ + "quant");
 
-      // fp8
-      inputs.push_back(scaled_hidden_states);
+        // fp8
+        inputs.push_back(scaled_hidden_states);
+      } else {
+        /* ----  static quant for hidden_states ---- */
+        hs_quant_offset = 1;
+        int hs_quant_base = BIAS_OR_WEIGHTS + bias_offset;
+        auto fp8_scale = createTensorFromCT(&ct, hs_quant_base);
+
+        std::vector<synTensor> quant_inputs;
+        quant_inputs.push_back(hidden_states);
+        quant_inputs.push_back(fp8_scale);
+
+        std::vector<synTensor> quant_outputs;
+        synTensor scaled_hidden_states = createTensorNoPresist(
+            "scaled_hidden_states", dtype_, ins[HIDDEN_STATES].dims);
+        quant_outputs.push_back(scaled_hidden_states);
+
+        ns_CastKernel::Params cast_to_fp8_params;
+        cast_to_fp8_params.round_mode = CAST_ROUND_HALF_NE;
+        AddNodeConvertToFP8<T>(
+            quant_inputs, quant_outputs, cast_to_fp8_params, guid_ + "quant");
+        // fp8
+        inputs.push_back(scaled_hidden_states);
+
+        synTensor one =
+            createTensorNoPresist("one", ins[HIDDEN_STATES].type, {1});
+        ns_ConstantKernel::Params const_params;
+        const_params.constant.f = 1.0f;
+        std::vector<synTensor> one_tensor = {one};
+        AddNodeFull<T>(one_tensor, const_params, guid_ + "full_one");
+
+        std::vector<synTensor> div_inputs;
+        div_inputs.push_back(one);
+        div_inputs.push_back(fp8_scale);
+
+        std::vector<synTensor> div_outputs;
+        // w/a Tensor fp8_scale was already mapped
+        std::string fp8_scale_name =
+            "fp8_scale_" + std::to_string(rand_r(&seed));
+        fp8_d_scale =
+            createTensorNoPresist(fp8_scale_name, ins[HIDDEN_STATES].type, {1});
+        div_outputs.push_back(fp8_d_scale);
+        AddNodeDivide<T>(div_inputs, div_outputs, guid_ + "reciprocal");
+      }
     } else {
       // bf16 / blockwise fp8
       inputs.push_back(hidden_states);
@@ -302,7 +369,7 @@ class FusedGateMoe : public HpuFusedOperator {
 
     // Add gate_up_weights and down_weights
     int64_t input_count = params.num_experts * weights_per_expert;
-    int weight_base = BIAS_OR_WEIGHTS + bias_offset;
+    int weight_base = BIAS_OR_WEIGHTS + bias_offset + hs_quant_offset;
     for (int64_t i = weight_base; i < weight_base + input_count; i++) {
       inputs.push_back(createTensorFromCT(&ct, i));
     }
@@ -311,7 +378,7 @@ class FusedGateMoe : public HpuFusedOperator {
     if (dtype_ == syn_type_fp8_143) {
       // fp8
       // hidden_states_scales
-      inputs.push_back(fp8_scale);
+      inputs.push_back(fp8_d_scale);
       auto scales_per_expert = params.fused_gemm ? 2 : 3;
       if (!params.dynamic_scale) scales_per_expert += 1;
       input_count = params.num_experts * scales_per_expert;
@@ -344,14 +411,14 @@ template <typename T, typename TMoe, typename Context>
 void FusedGateMoeKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& hidden_states,
-    const phi::DenseTensor& gate_out,
+    const phi::DenseTensor& gate_weights,
     const paddle::optional<phi::DenseTensor>& gate_correction_bias,
     const std::vector<phi::DenseTensor>& gate_up_weights,
     const std::vector<phi::DenseTensor>& down_weights,
+    const paddle::optional<phi::DenseTensor>& hidden_states_scales,
     const paddle::optional<std::vector<phi::DenseTensor>>& scales,
     phi::DenseTensor* final_hidden_states,
     const int top_k,
-    const bool moe_use_gate_correction_bias,
     const bool norm_topk_prob,
     const bool permuted_weights,
     const std::string& activation,
@@ -364,13 +431,13 @@ void FusedGateMoeKernel(
   FusedGateMoeParams params;
   memset(reinterpret_cast<void*>(&params), 0x00, sizeof(FusedGateMoeParams));
   params.topk = top_k;
-  params.moe_use_gate_correction_bias = moe_use_gate_correction_bias;
   params.norm_topk_prob = norm_topk_prob;
   params.permuted_weights = permuted_weights;
   params.fused_gemm = (gate_up_weights.size() == down_weights.size());
   params.num_experts = down_weights.size();
   params.experts_min = experts_min;
   params.experts_max = experts_max;
+  params.hidden_states_static_quant = false;
   params.dynamic_scale = dynamic_scale;
   params.block_size = block_size;
   strncpy(params.activation_mode,
@@ -380,9 +447,14 @@ void FusedGateMoeKernel(
 
   ConvertTensors ct;
   ct.Add(hidden_states);
-  ct.Add(gate_out);
-  if (moe_use_gate_correction_bias) {
+  ct.Add(gate_weights);
+  if (gate_correction_bias) {
     ct.Add(gate_correction_bias.get());
+    params.moe_use_gate_correction_bias = true;
+  }
+  if (hidden_states_scales) {
+    ct.Add(hidden_states_scales.get());
+    params.hidden_states_static_quant = true;
   }
   for (const auto& t : gate_up_weights) {
     ct.Add(t);
@@ -426,14 +498,14 @@ template <typename Context>
 void CallFusedGateMoeKernel(
     const Context& dev_ctx,
     const phi::DenseTensor& hidden_states,
-    const phi::DenseTensor& gate_out,
+    const phi::DenseTensor& gate_weights,
     const paddle::optional<phi::DenseTensor>& gate_correction_bias,
     const std::vector<phi::DenseTensor>& gate_up_weights,
     const std::vector<phi::DenseTensor>& down_weights,
+    const paddle::optional<phi::DenseTensor>& hidden_states_scales,
     const paddle::optional<std::vector<phi::DenseTensor>>& scales,
     phi::DenseTensor* final_hidden_states,
     const int top_k,
-    const bool moe_use_gate_correction_bias,
     const bool norm_topk_prob,
     const bool permuted_weights,
     const std::string& activation,
@@ -451,14 +523,14 @@ void CallFusedGateMoeKernel(
                                         phi::dtype::bfloat16>(
           dev_ctx,
           hidden_states,
-          gate_out,
+          gate_weights,
           gate_correction_bias,
           gate_up_weights,
           down_weights,
+          hidden_states_scales,
           scales,
           final_hidden_states,
           top_k,
-          moe_use_gate_correction_bias,
           norm_topk_prob,
           permuted_weights,
           activation,
@@ -473,14 +545,14 @@ void CallFusedGateMoeKernel(
                                         phi::dtype::float8_e4m3fn>(
           dev_ctx,
           hidden_states,
-          gate_out,
+          gate_weights,
           gate_correction_bias,
           gate_up_weights,
           down_weights,
+          hidden_states_scales,
           scales,
           final_hidden_states,
           top_k,
-          moe_use_gate_correction_bias,
           norm_topk_prob,
           permuted_weights,
           activation,
@@ -498,12 +570,11 @@ void CallFusedGateMoeKernel(
 
 std::vector<paddle::Tensor> FusedGateMoeForward(
     const paddle::Tensor& hidden_states,
-    const paddle::Tensor& gate_out,
+    const paddle::Tensor& gate_weights,
     const paddle::optional<paddle::Tensor>& gate_correction_bias,
     const std::vector<paddle::Tensor>& gate_up_weights,
     const std::vector<paddle::Tensor>& down_weights,
     const int top_k,
-    const bool moe_use_gate_correction_bias,
     const bool norm_topk_prob,
     const bool permuted_weights,
     const std::string& activation,
@@ -516,8 +587,8 @@ std::vector<paddle::Tensor> FusedGateMoeForward(
 
   auto hidden_states_tensor =
       static_cast<const phi::DenseTensor*>(hidden_states.impl().get());
-  auto gate_out_tensor =
-      static_cast<const phi::DenseTensor*>(gate_out.impl().get());
+  auto gate_weights_tensor =
+      static_cast<const phi::DenseTensor*>(gate_weights.impl().get());
 
   auto gate_correction_tensor = paddle::optional<phi::DenseTensor>();
   if (gate_correction_bias) {
@@ -546,20 +617,20 @@ std::vector<paddle::Tensor> FusedGateMoeForward(
   CallFusedGateMoeKernel(
       *dev_ctx,
       *hidden_states_tensor,
-      *gate_out_tensor,
+      *gate_weights_tensor,
       gate_correction_tensor,
       gate_up_weights_vec,
       down_weights_vec,
+      paddle::optional<phi::DenseTensor>(), /* hidden_states_scale */
       paddle::optional<std::vector<phi::DenseTensor>>(), /* scales */
       final_hidden_states.get(),
       top_k,
-      moe_use_gate_correction_bias,
       norm_topk_prob,
       permuted_weights,
       activation,
       experts_min,
       experts_max,
-      true,  /* moe input = bf16 */
+      true,  /* is_bf16_moe_input, moe input = bf16 */
       false, /* measurement_mode, so far not need */
       false, /* dynamic_scale */
       -1 /* block_size */,
@@ -570,16 +641,16 @@ std::vector<paddle::Tensor> FusedGateMoeForward(
 
 std::vector<paddle::Tensor> FusedGateMoeFP8Forward(
     const paddle::Tensor& hidden_states,
-    const paddle::Tensor& gate_out,
+    const paddle::Tensor& gate_weights,
     const paddle::optional<paddle::Tensor>& gate_correction_bias,
     const std::vector<paddle::Tensor>& gate_up_weights,
     const std::vector<paddle::Tensor>& down_weights,
+    const paddle::optional<paddle::Tensor>& hidden_states_scales,
     const paddle::optional<std::vector<paddle::Tensor>>&
         intermediate_hidden_states_scales,
     const std::vector<paddle::Tensor>& gate_up_weights_scales,
     const std::vector<paddle::Tensor>& down_weights_scales,
     const int top_k,
-    const bool moe_use_gate_correction_bias,
     const bool norm_topk_prob,
     const bool permuted_weights,
     const std::string& activation,
@@ -592,8 +663,8 @@ std::vector<paddle::Tensor> FusedGateMoeFP8Forward(
 
   auto hidden_states_tensor =
       static_cast<const phi::DenseTensor*>(hidden_states.impl().get());
-  auto gate_out_tensor =
-      static_cast<const phi::DenseTensor*>(gate_out.impl().get());
+  auto gate_weights_tensor =
+      static_cast<const phi::DenseTensor*>(gate_weights.impl().get());
 
   auto gate_correction_tensor = paddle::optional<phi::DenseTensor>();
   if (gate_correction_bias) {
@@ -612,6 +683,14 @@ std::vector<paddle::Tensor> FusedGateMoeFP8Forward(
   for (const auto& t : down_weights) {
     down_weights_vec.push_back(
         *static_cast<const phi::DenseTensor*>(t.impl().get()));
+  }
+
+  auto hidden_states_scales_tensor = paddle::optional<phi::DenseTensor>();
+  if (hidden_states_scales) {
+    auto hidden_states_scales_dt =
+        static_cast<phi::DenseTensor*>(hidden_states_scales->impl().get());
+    hidden_states_scales_tensor =
+        paddle::optional<phi::DenseTensor>(*hidden_states_scales_dt);
   }
 
   bool dynamic_scale = true;
@@ -638,20 +717,20 @@ std::vector<paddle::Tensor> FusedGateMoeFP8Forward(
   CallFusedGateMoeKernel(
       *dev_ctx,
       *hidden_states_tensor,
-      *gate_out_tensor,
+      *gate_weights_tensor,
       gate_correction_tensor,
       gate_up_weights_vec,
       down_weights_vec,
+      hidden_states_scales_tensor,
       scales_vec,
       final_hidden_states.get(),
       top_k,
-      moe_use_gate_correction_bias,
       norm_topk_prob,
       permuted_weights,
       activation,
       experts_min,
       experts_max,
-      false, /* moe input = fp8*/
+      false, /* is_bf16_moe_input, moe input = fp8*/
       false, /* measurement_mode, so far not supported on FP8 */
       dynamic_scale,
       -1 /* block_size */,
@@ -661,14 +740,13 @@ std::vector<paddle::Tensor> FusedGateMoeFP8Forward(
 
 std::vector<paddle::Tensor> FusedGateMoeBlockWiseFP8Forward(
     const paddle::Tensor& hidden_states,
-    const paddle::Tensor& gate_out,
+    const paddle::Tensor& gate_weights,
     const paddle::optional<paddle::Tensor>& gate_correction_bias,
     const std::vector<paddle::Tensor>& gate_up_weights,
     const std::vector<paddle::Tensor>& down_weights,
     const std::vector<paddle::Tensor>& gate_up_weights_scales,
     const std::vector<paddle::Tensor>& down_weights_scales,
     const int top_k,
-    const bool moe_use_gate_correction_bias,
     const bool norm_topk_prob,
     const bool permuted_weights,
     const std::string& activation,
@@ -682,8 +760,8 @@ std::vector<paddle::Tensor> FusedGateMoeBlockWiseFP8Forward(
 
   auto hidden_states_tensor =
       static_cast<const phi::DenseTensor*>(hidden_states.impl().get());
-  auto gate_out_tensor =
-      static_cast<const phi::DenseTensor*>(gate_out.impl().get());
+  auto gate_weights_tensor =
+      static_cast<const phi::DenseTensor*>(gate_weights.impl().get());
 
   auto gate_correction_tensor = paddle::optional<phi::DenseTensor>();
   if (gate_correction_bias) {
@@ -720,20 +798,20 @@ std::vector<paddle::Tensor> FusedGateMoeBlockWiseFP8Forward(
   CallFusedGateMoeKernel(
       *dev_ctx,
       *hidden_states_tensor,
-      *gate_out_tensor,
+      *gate_weights_tensor,
       gate_correction_tensor,
       gate_up_weights_vec,
       down_weights_vec,
+      paddle::optional<phi::DenseTensor>(), /* hidden_states_scale */
       scales_vec,
       final_hidden_states.get(),
       top_k,
-      moe_use_gate_correction_bias,
       norm_topk_prob,
       permuted_weights,
       activation,
       experts_min,
       experts_max,
-      true,  /* moe input = bf16 */
+      true,  /* is_bf16_moe_input, moe input = bf16 */
       false, /* measurement_mode, so far not supported on FP8 */
       false, /*dynamic_scale*/
       block_size,
@@ -743,7 +821,7 @@ std::vector<paddle::Tensor> FusedGateMoeBlockWiseFP8Forward(
 
 std::vector<std::vector<int64_t>> FusedGateMoeInferShape(
     const std::vector<int64_t>& hidden_states_shape,
-    const std::vector<int64_t>& gate_out_shape,
+    const std::vector<int64_t>& gate_weights_shape,
     const paddle::optional<std::vector<int64_t>>& gate_correction_bias_shape,
     const std::vector<int64_t>& gate_up_weights_shape,
     const std::vector<int64_t>& down_weights_shape) {
@@ -752,7 +830,7 @@ std::vector<std::vector<int64_t>> FusedGateMoeInferShape(
 
 std::vector<paddle::DataType> FusedGateMoeInferDtype(
     const paddle::DataType& hidden_states_dtype,
-    const paddle::DataType& gate_out_dtype,
+    const paddle::DataType& gate_weights_dtype,
     const paddle::optional<paddle::DataType>& gate_correction_bias_dtype,
     const paddle::DataType& gate_up_weights_dtype,
     const paddle::DataType& down_weights_dtype) {
@@ -760,19 +838,17 @@ std::vector<paddle::DataType> FusedGateMoeInferDtype(
 }
 
 // hidden_states        : bf16
-// gate_out             : fp32
-// gate_correction_bias : fp32 [BT, 1] <optional>
+// gate_weights         : fp32
+// gate_correction_bias : fp32 [1, num_experts] <optional>
 // final_hidden_states  : bf16
-// moe_use_gate_correction_bias -> gate_correction_bias (False->None)
 PD_BUILD_OP(fused_gate_moe)
     .Inputs({"hidden_states",
-             "gate_out",
+             "gate_weights",
              paddle::Optional("gate_correction_bias"),
              paddle::Vec("gate_up_weights"),
              paddle::Vec("down_weights")})
     .Outputs({"final_hidden_states"})
     .Attrs({"top_k: int",
-            "moe_use_gate_correction_bias: bool",
             "norm_topk_prob: bool",
             "permuted_weights: bool",
             "activation: std::string",
@@ -783,25 +859,24 @@ PD_BUILD_OP(fused_gate_moe)
     .SetInferShapeFn(PD_INFER_SHAPE(FusedGateMoeInferShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedGateMoeInferDtype));
 
-// hidden_states        : bf16 --> quant --> fp8 --> moe
-// gate_out             : fp32
-// gate_correction_bias : fp32 [BT, 1] <optional>
+// hidden_states        : bf16 --> quant/cast --> fp8 --> moe
+// gate_weights         : fp32
+// gate_correction_bias : fp32 [1, num_experts] <optional>
 // gate_up/down_weights : fp8
 // final_hidden_states  : internel fp8 --> bf16
-// moe_use_gate_correction_bias -> gate_correction_bias (False->None)
 // dynamic_scale <-> intermediate_hidden_states_scales (Ture->None)
 PD_BUILD_OP(fused_gate_moe_fp8)
     .Inputs({"hidden_states",
-             "gate_out",
+             "gate_weights",
              paddle::Optional("gate_correction_bias"),
              paddle::Vec("gate_up_weights"),
              paddle::Vec("down_weights"),
+             paddle::Optional("hidden_states_scales"),
              paddle::Optional(paddle::Vec("intermediate_hidden_states_scales")),
              paddle::Vec("gate_up_weights_scales"),
              paddle::Vec("down_weights_scales")})
     .Outputs({"final_hidden_states"})
     .Attrs({"top_k: int",
-            "moe_use_gate_correction_bias: bool",
             "norm_topk_prob: bool",
             "permuted_weights: bool",
             "activation: std::string",
@@ -813,14 +888,13 @@ PD_BUILD_OP(fused_gate_moe_fp8)
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedGateMoeInferDtype));
 
 // hidden_states        : bf16 --> moe(internel fp8)
-// gate_out             : fp32
-// gate_correction_bias : fp32 [BT, 1] <optional>
+// gate_weights         : fp32
+// gate_correction_bias : fp32 [1, num_experts] <optional>
 // gate_up/down_weights : fp8
 // final_hidden_states  : internel fp8 --> bf16
-// moe_use_gate_correction_bias -> gate_correction_bias (False->None)
 PD_BUILD_OP(fused_gate_moe_blockwise_fp8)
     .Inputs({"hidden_states",
-             "gate_out",
+             "gate_weights",
              paddle::Optional("gate_correction_bias"),
              paddle::Vec("gate_up_weights"),
              paddle::Vec("down_weights"),
@@ -828,7 +902,6 @@ PD_BUILD_OP(fused_gate_moe_blockwise_fp8)
              paddle::Vec("down_weights_scales")})
     .Outputs({"final_hidden_states"})
     .Attrs({"top_k: int",
-            "moe_use_gate_correction_bias: bool",
             "norm_topk_prob: bool",
             "permuted_weights: bool",
             "activation: std::string",

--- a/backends/intel_hpu/custom_ops/llama_infer/fused_mlp.cc
+++ b/backends/intel_hpu/custom_ops/llama_infer/fused_mlp.cc
@@ -16,15 +16,16 @@
 #include "habanalabs/synapse_api.h"
 #include "habanalabs/synapse_common_types.h"
 #include "kernels/funcs.h"
+#include "kernels/hpu_funcs.h"
 #include "kernels/hpu_operator.h"
 #include "paddle/extension.h"
 #include "utils/utils.h"
 
 namespace custom_kernel {
 
-class FusedMlp : public HpuOperator {
+class FusedSplitMlp : public HpuOperator {
  public:
-  explicit FusedMlp(synDataType dtype)
+  explicit FusedSplitMlp(synDataType dtype)
       : HpuOperator("fused_mlp_fwd", false), dtype_(dtype) {}
 
   void AddNode(ConvertTensors& ct) {
@@ -340,13 +341,255 @@ class FusedGateUpMlp : public HpuOperator {
   synDataType dtype_;
 };
 
+struct FusedMlpParams {
+  synSplitParams split_params;
+  synGEMMParams gemm_params;
+
+  bool fused_gate_up;
+  bool use_fp8;
+};
+
+enum TENSOR_IDS_IN {
+  HIDDEN_STATES = 0,
+  PROJ_WEIGHT,
+  DOWN_WEIGHT,
+  PROJ_SCALE,
+  DOWN_SCALE,
+  HID_STE_SCALE,
+  INTM_HID_STE_SCALE,
+  UP_SCALE = -2,
+  UP_WEIGHT = -1
+};
+
+class FusedMlp : public HpuFusedOperator {
+ public:
+  explicit FusedMlp(synDataType dtype)
+      : HpuFusedOperator("fused_mlp_", false), dtype_(dtype) {}
+  template <typename T>
+  void AddNode(ConvertTensors& ct, FusedMlpParams params) {
+    auto inputs = ct.GetTensors();
+    auto outputs = ct.GetTensors(false);
+
+    synTensor hidden_states = createTensorFromCT(&ct, HIDDEN_STATES);
+    synTensor proj_weight = createTensorFromCT(&ct, PROJ_WEIGHT);
+
+    std::vector<int64_t> proj_dims = inputs[HIDDEN_STATES].dims;
+    if (params.gemm_params.transpose_b == true) {
+      proj_dims[inputs[HIDDEN_STATES].dims.size() - 1] =
+          inputs[PROJ_WEIGHT].dims[0];
+    } else {
+      proj_dims[inputs[HIDDEN_STATES].dims.size() - 1] =
+          inputs[PROJ_WEIGHT].dims[1];
+    }
+    synTensor proj_out = createTensorNoPresist("proj_out", dtype_, proj_dims);
+    std::vector<synTensor> ffn_ins;
+    std::vector<synTensor> ffn_outs = {proj_out};
+
+    synTensor scaled_hidden_states;
+    synTensor hidden_states_de_scale;
+    if (params.use_fp8) {
+      // static quant hidden_states to fp8 with hidden_states_scale
+      // move out from AddNodeFusedFP8Gemm because scaled_hidden_states maybe
+      // use twice
+      std::vector<synTensor> quant_inputs;
+      synTensor hidden_states_scale = createTensorFromCT(&ct, HID_STE_SCALE);
+      quant_inputs.push_back(hidden_states);
+      quant_inputs.push_back(hidden_states_scale);
+      std::vector<synTensor> quant_outputs;
+      scaled_hidden_states = createTensorNoPresist(
+          "scaled_hidden_states", syn_type_fp8_143, inputs[HIDDEN_STATES].dims);
+      quant_outputs.push_back(scaled_hidden_states);
+      ns_CastKernel::Params cast_to_fp8_params;
+      cast_to_fp8_params.round_mode = CAST_ROUND_HALF_NE;
+      AddNodeConvertToFP8<T>(
+          quant_inputs, quant_outputs, cast_to_fp8_params, guid_ + "cast");
+      ffn_ins.push_back(scaled_hidden_states);
+      ffn_ins.push_back(proj_weight);
+
+      // 1/hidden_states_scale for gemm d_scale
+      hidden_states_de_scale = createTensorNoPresist(
+          "hidden_states_de_scale", inputs[HIDDEN_STATES].type, {1});
+      synTensor one =
+          createTensorNoPresist("one", inputs[HIDDEN_STATES].type, {1});
+      ns_ConstantKernel::Params const_params;
+      const_params.constant.f = 1.0f;
+      std::vector<synTensor> one_tensor = {one};
+      AddNodeFull<T>(one_tensor, const_params, guid_ + "full_one");
+      std::vector<synTensor> div_inputs;
+      div_inputs.push_back(one);
+      div_inputs.push_back(hidden_states_scale);
+      std::vector<synTensor> div_outputs = {hidden_states_de_scale};
+      AddNodeDivide<T>(div_inputs, div_outputs, guid_ + "reciprocal");
+
+      ffn_ins.push_back(hidden_states_de_scale);
+      auto proj_de_scale = createTensorFromCT(&ct, PROJ_SCALE);
+      ffn_ins.push_back(proj_de_scale);
+
+      AddNodeFusedFP8Gemm<T>(
+          ffn_ins, ffn_outs, params.gemm_params, guid_ + "proj_gemm");
+    } else {
+      ffn_ins.push_back(hidden_states);
+      ffn_ins.push_back(proj_weight);
+      AddNodeGemm(ffn_ins, ffn_outs, params.gemm_params, guid_ + "proj_gemm");
+    }
+
+    std::vector<int64_t> swiglu_dims = proj_dims;
+    std::vector<synTensor> silu_ins;
+    synTensor up_out;
+
+    // Second Gemm or split First Gemm
+    if (params.fused_gate_up) {
+      // fused weights, split node. bf16 must, fp8 optional
+      swiglu_dims[proj_dims.size() - 1] = proj_dims[proj_dims.size() - 1] / 2;
+      synTensor gate_out =
+          createTensorNoPresist("gate_out", dtype_, swiglu_dims);
+      up_out = createTensorNoPresist("up_out", dtype_, swiglu_dims);
+      std::vector<synTensor> split_outs = {gate_out, up_out};
+      AddNodeSplit(ffn_outs, split_outs, params.split_params, guid_ + "split");
+      silu_ins = {gate_out};
+    } else if (params.use_fp8) {
+      // splitted weights, fp8_gemm node. fp8 branch
+      auto up_weight = createTensorFromCT(&ct, inputs.size() + UP_WEIGHT);
+      auto up_scale = createTensorFromCT(&ct, inputs.size() + UP_SCALE);
+      up_out = createTensorNoPresist("up_out", dtype_, swiglu_dims);
+      ffn_ins.clear();
+      ffn_ins.push_back(scaled_hidden_states);
+      ffn_ins.push_back(up_weight);
+      ffn_ins.push_back(hidden_states_de_scale);
+      ffn_ins.push_back(up_scale);
+      ffn_outs.clear();
+      ffn_outs.push_back(up_out);
+      AddNodeFusedFP8Gemm<T>(
+          ffn_ins, ffn_outs, params.gemm_params, guid_ + "up_gemm");
+      silu_ins = {proj_out};
+    } else {
+      // splitted weights, gemm node. bf16 branch
+      auto up_weight = createTensorFromCT(&ct, inputs.size() + UP_WEIGHT);
+      up_out = createTensorNoPresist("up_out", dtype_, swiglu_dims);
+      ffn_ins.clear();
+      ffn_ins.push_back(hidden_states);
+      ffn_ins.push_back(up_weight);
+      ffn_outs.clear();
+      ffn_outs.push_back(up_out);
+      AddNodeGemm(ffn_ins, ffn_outs, params.gemm_params, guid_ + "up_gemm");
+      silu_ins = {proj_out};
+    }
+
+    // silu node
+    auto silu_out = createTensorNoPresist("silu_out", dtype_, swiglu_dims);
+    std::vector<synTensor> silu_outs = {silu_out};
+    AddNodeSilu<T>(silu_ins, silu_outs, guid_ + "silu");
+
+    // multi node
+    auto multi_out = createTensorNoPresist("multi_out", dtype_, swiglu_dims);
+    std::vector<synTensor> multi_ins = {silu_out, up_out};
+    std::vector<synTensor> multi_outs = {multi_out};
+    AddNodeMultiply<T>(multi_ins, multi_outs, guid_ + "multi");
+
+    auto down_weight = createTensorFromCT(&ct, DOWN_WEIGHT);
+    auto mlp_out = createTensorFromCT(&ct, 0, false);
+    std::vector<synTensor> ffn_down_ins = {multi_out, down_weight};
+    std::vector<synTensor> ffn_down_outs = {mlp_out};
+
+    // ffn_down gemm node
+    if (params.use_fp8) {
+      auto intermediate_hidden_states_scale =
+          createTensorFromCT(&ct, INTM_HID_STE_SCALE);
+      auto down_scale = createTensorFromCT(&ct, DOWN_SCALE);
+      ffn_down_ins.push_back(intermediate_hidden_states_scale);
+      ffn_down_ins.push_back(down_scale);
+      AddNodeFusedFP8Gemm<T>(
+          ffn_down_ins, ffn_down_outs, params.gemm_params, guid_ + "down_gemm");
+    } else {
+      AddNodeGemm(
+          ffn_down_ins, ffn_down_outs, params.gemm_params, guid_ + "down_gemm");
+    }
+  }
+
+ protected:
+  synDataType dtype_;
+};
+
 template <typename T, typename Context>
-void FusedMlpKernel(const Context& dev_ctx,
-                    const phi::DenseTensor& x,
-                    const phi::DenseTensor& gate_weight,
-                    const phi::DenseTensor& up_weight,
-                    const phi::DenseTensor& down_weight,
-                    phi::DenseTensor* out) {
+void FusedMlpKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& hidden_states,
+    const phi::DenseTensor& proj_weight,
+    const paddle::optional<phi::DenseTensor>& up_weight,
+    const phi::DenseTensor& down_weight,
+    const paddle::optional<phi::DenseTensor>& hidden_states_scale,
+    const paddle::optional<phi::DenseTensor>& proj_scale,
+    const paddle::optional<phi::DenseTensor>& up_scale,
+    const paddle::optional<phi::DenseTensor>& intermediate_hidden_states_scale,
+    const paddle::optional<phi::DenseTensor>& down_scale,
+    const bool permuted_weights,
+    phi::DenseTensor* out) {
+  // allocate memory on device.
+  dev_ctx.template Alloc<T>(out);
+  if (out->numel() == 0) {
+    return;
+  }
+
+  FusedMlpParams params;
+  memset(reinterpret_cast<void*>(&params), 0x00, sizeof(FusedMlpParams));
+
+  params.gemm_params.transpose_a = false;
+  params.gemm_params.transpose_b = permuted_weights;
+
+  params.fused_gate_up = true;
+
+  params.use_fp8 = (proj_weight.dtype() == phi::DataType::FLOAT8_E4M3FN);
+
+  ConvertTensors ct;
+  ct.Add(hidden_states);
+  ct.Add(proj_weight);
+  ct.Add(down_weight);
+
+  if (params.use_fp8) {
+    ct.Add(proj_scale.get());
+    ct.Add(down_scale.get());
+    ct.Add(hidden_states_scale.get());
+    ct.Add(intermediate_hidden_states_scale.get());
+    if (up_scale) {
+      ct.Add(up_scale.get());
+    }
+  }
+  if (up_weight) {
+    ct.Add(up_weight.get());
+    params.fused_gate_up = false;
+  }
+
+  ct.Add(*out, false);
+
+  std::vector<DIMS> inputs_dims = ct.GetDims();
+
+  OpCacheOperator op_info;
+  std::string recipe_name =
+      params.use_fp8 ? "FusedFP8MlpKernel" : "FusedMlpKernel";
+  op_info.prepareOpInfo<T, FusedMlpParams>(recipe_name, inputs_dims, &params);
+  auto recipe = op_info.GetRecipe();
+
+  if (recipe == nullptr) {
+    FusedMlp op(op_info.datatype_);
+    op.AddNode<T>(ct, params);
+    op.Compile();
+    op_info.setOp(op);
+
+    recipe = op_info.GetRecipe();
+  }
+
+  std::map<std::string, uint64_t> tensors = ct.GetDeviceAddr();
+  RecipeRunner runner(recipe);
+  runner.Run(reinterpret_cast<C_Stream>(dev_ctx.stream()), tensors);
+}
+
+template <typename T, typename Context>
+void FusedSplitMlpKernel(const Context& dev_ctx,
+                         const phi::DenseTensor& x,
+                         const phi::DenseTensor& gate_weight,
+                         const phi::DenseTensor& up_weight,
+                         const phi::DenseTensor& down_weight,
+                         phi::DenseTensor* out) {
   // allocate memory on device.
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) {
@@ -366,7 +609,7 @@ void FusedMlpKernel(const Context& dev_ctx,
   auto recipe = op_info.GetRecipe();
 
   if (recipe == nullptr) {
-    FusedMlp op(op_info.datatype_);
+    FusedSplitMlp op(op_info.datatype_);
     op.AddNode(ct);
     op.Compile();
     op_info.setOp(op);
@@ -428,14 +671,14 @@ void FusedGateUpMlpKernel(const Context& dev_ctx,
 }  // namespace custom_kernel
 
 template <typename Context>
-void CallFusedMlpKernel(const Context& dev_ctx,
-                        const phi::DenseTensor& x,
-                        const phi::DenseTensor& gate_weight,
-                        const phi::DenseTensor& up_weight,
-                        const phi::DenseTensor& down_weight,
-                        phi::DenseTensor* out) {
+void CallFusedSplitMlpKernel(const Context& dev_ctx,
+                             const phi::DenseTensor& x,
+                             const phi::DenseTensor& gate_weight,
+                             const phi::DenseTensor& up_weight,
+                             const phi::DenseTensor& down_weight,
+                             phi::DenseTensor* out) {
   if (x.dtype() == phi::DataType::BFLOAT16) {
-    custom_kernel::FusedMlpKernel<phi::dtype::bfloat16>(
+    custom_kernel::FusedSplitMlpKernel<phi::dtype::bfloat16>(
         dev_ctx, x, gate_weight, up_weight, down_weight, out);
   } else {
     throw std::runtime_error("Unsupported data type for FusedMlpKernel");
@@ -456,7 +699,163 @@ void CallFusedGateUpMlpKernel(const Context& dev_ctx,
   }
 }
 
+template <typename Context>
+void CallFusedMlpKernel(
+    const Context& dev_ctx,
+    const phi::DenseTensor& hidden_states,
+    const phi::DenseTensor& proj_weight,
+    const paddle::optional<phi::DenseTensor>& up_weight,
+    const phi::DenseTensor& down_weight,
+    const paddle::optional<phi::DenseTensor>& hidden_states_scale,
+    const paddle::optional<phi::DenseTensor>& proj_scale,
+    const paddle::optional<phi::DenseTensor>& up_scale,
+    const paddle::optional<phi::DenseTensor>& intermediate_hidden_states_scale,
+    const paddle::optional<phi::DenseTensor>& down_scale,
+    const bool permuted_weights,
+    phi::DenseTensor* out) {
+  if (hidden_states.dtype() == phi::DataType::BFLOAT16) {
+    custom_kernel::FusedMlpKernel<phi::dtype::bfloat16>(
+        dev_ctx,
+        hidden_states,
+        proj_weight,
+        up_weight,
+        down_weight,
+        hidden_states_scale,
+        proj_scale,
+        up_scale,
+        intermediate_hidden_states_scale,
+        down_scale,
+        permuted_weights,
+        out);
+  } else {
+    throw std::runtime_error("Unsupported data type for FusedRmsMlpKernel");
+  }
+}
+
 std::vector<paddle::Tensor> FusedMlpForward(
+    const paddle::Tensor& hidden_states,
+    const paddle::Tensor& proj_weight,
+    const paddle::optional<paddle::Tensor>& up_weight,
+    const paddle::Tensor& down_weight) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(
+          hidden_states.place()));
+
+  auto hidden_states_tensor =
+      static_cast<const phi::DenseTensor*>(hidden_states.impl().get());
+  auto proj_weight_tensor =
+      static_cast<const phi::DenseTensor*>(proj_weight.impl().get());
+  auto up_weight_tensor = paddle::optional<phi::DenseTensor>();
+  if (up_weight) {
+    auto up_weight_dt = static_cast<phi::DenseTensor*>(up_weight->impl().get());
+    up_weight_tensor = paddle::optional<phi::DenseTensor>(*up_weight_dt);
+  }
+  auto down_weight_tensor =
+      static_cast<const phi::DenseTensor*>(down_weight.impl().get());
+  auto out_tensor = std::make_shared<phi::DenseTensor>();
+
+  out_tensor->Resize(hidden_states_tensor->dims());
+
+  CallFusedMlpKernel(*dev_ctx,
+                     *hidden_states_tensor,
+                     *proj_weight_tensor,
+                     up_weight_tensor,
+                     *down_weight_tensor,
+                     paddle::optional<phi::DenseTensor>(),
+                     paddle::optional<phi::DenseTensor>(),
+                     paddle::optional<phi::DenseTensor>(),
+                     paddle::optional<phi::DenseTensor>(),
+                     paddle::optional<phi::DenseTensor>(),
+                     false,  // permuted_weights,
+                     out_tensor.get());
+
+  paddle::Tensor out(out_tensor);
+
+  return {out};
+}
+
+std::vector<paddle::Tensor> FusedFP8MlpForward(
+    const paddle::Tensor& hidden_states,
+    const paddle::Tensor& proj_weight,
+    const paddle::optional<paddle::Tensor>& up_weight,
+    const paddle::Tensor& down_weight,
+    const paddle::optional<paddle::Tensor>& hidden_states_scale,
+    const paddle::optional<paddle::Tensor>& proj_scale,
+    const paddle::optional<paddle::Tensor>& up_scale,
+    const paddle::optional<paddle::Tensor>& intermediate_hidden_states_scale,
+    const paddle::optional<paddle::Tensor>& down_scale,
+    const bool permuted_weights) {
+  auto dev_ctx = static_cast<const phi::CustomContext*>(
+      paddle::experimental::DeviceContextPool::Instance().Get(
+          hidden_states.place()));
+
+  auto hidden_states_tensor =
+      static_cast<const phi::DenseTensor*>(hidden_states.impl().get());
+  auto proj_weight_tensor =
+      static_cast<const phi::DenseTensor*>(proj_weight.impl().get());
+  auto up_weight_tensor = paddle::optional<phi::DenseTensor>();
+  if (up_weight) {
+    auto up_weight_dt = static_cast<phi::DenseTensor*>(up_weight->impl().get());
+    up_weight_tensor = paddle::optional<phi::DenseTensor>(*up_weight_dt);
+  }
+  auto down_weight_tensor =
+      static_cast<const phi::DenseTensor*>(down_weight.impl().get());
+
+  auto hidden_states_scale_tensor = paddle::optional<phi::DenseTensor>();
+  if (hidden_states_scale) {
+    auto hidden_states_scale_dt =
+        static_cast<phi::DenseTensor*>(hidden_states_scale->impl().get());
+    hidden_states_scale_tensor =
+        paddle::optional<phi::DenseTensor>(*hidden_states_scale_dt);
+  }
+  auto proj_scale_tensor = paddle::optional<phi::DenseTensor>();
+  if (proj_scale) {
+    auto proj_scale_dt =
+        static_cast<phi::DenseTensor*>(proj_scale->impl().get());
+    proj_scale_tensor = paddle::optional<phi::DenseTensor>(*proj_scale_dt);
+  }
+  auto up_scale_tensor = paddle::optional<phi::DenseTensor>();
+  if (up_scale) {
+    auto up_scale_dt = static_cast<phi::DenseTensor*>(up_scale->impl().get());
+    up_scale_tensor = paddle::optional<phi::DenseTensor>(*up_scale_dt);
+  }
+  auto intermediate_hidden_states_scale_tensor =
+      paddle::optional<phi::DenseTensor>();
+  if (intermediate_hidden_states_scale) {
+    auto intermediate_hidden_states_scale_dt = static_cast<phi::DenseTensor*>(
+        intermediate_hidden_states_scale->impl().get());
+    intermediate_hidden_states_scale_tensor =
+        paddle::optional<phi::DenseTensor>(
+            *intermediate_hidden_states_scale_dt);
+  }
+  auto down_scale_tensor = paddle::optional<phi::DenseTensor>();
+  if (down_scale) {
+    auto down_scale_dt =
+        static_cast<phi::DenseTensor*>(down_scale->impl().get());
+    down_scale_tensor = paddle::optional<phi::DenseTensor>(*down_scale_dt);
+  }
+  auto out_tensor = std::make_shared<phi::DenseTensor>();
+  out_tensor->Resize(hidden_states_tensor->dims());
+
+  CallFusedMlpKernel(*dev_ctx,
+                     *hidden_states_tensor,
+                     *proj_weight_tensor,
+                     up_weight_tensor,
+                     *down_weight_tensor,
+                     hidden_states_scale_tensor,
+                     proj_scale_tensor,
+                     up_scale_tensor,
+                     intermediate_hidden_states_scale_tensor,
+                     down_scale_tensor,
+                     permuted_weights,
+                     out_tensor.get());
+
+  paddle::Tensor out(out_tensor);
+
+  return {out};
+}
+
+std::vector<paddle::Tensor> FusedSplitMlpForward(
     const paddle::Tensor& x,
     const paddle::Tensor& proj_weight,
     const paddle::optional<paddle::Tensor>& up_weight,
@@ -477,12 +876,12 @@ std::vector<paddle::Tensor> FusedMlpForward(
     auto up_tensor =
         static_cast<const phi::DenseTensor*>(up_weight->impl().get());
 
-    CallFusedMlpKernel(*dev_ctx,
-                       *x_tensor,
-                       *gate_tensor,
-                       *up_tensor,
-                       *down_tensor,
-                       out_tensor.get());
+    CallFusedSplitMlpKernel(*dev_ctx,
+                            *x_tensor,
+                            *gate_tensor,
+                            *up_tensor,
+                            *down_tensor,
+                            out_tensor.get());
   } else {
     auto proj_tensor =
         static_cast<const phi::DenseTensor*>(proj_weight.impl().get());
@@ -512,9 +911,28 @@ std::vector<paddle::DataType> FusedMlpInferDtype(
   return {x_dtype};
 }
 
-PD_BUILD_OP(fused_mlp)
-    .Inputs({"x", "proj_weight", paddle::Optional("up_weight"), "down_weight"})
+PD_BUILD_OP(fused_mlp_bf16)
+    .Inputs({"hidden_states",
+             "proj_weight",
+             paddle::Optional("up_weight"),
+             "down_weight"})
     .Outputs({"out"})
     .SetKernelFn(PD_KERNEL(FusedMlpForward))
+    .SetInferShapeFn(PD_INFER_SHAPE(FusedMlpInferShape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(FusedMlpInferDtype));
+
+PD_BUILD_OP(fused_mlp)
+    .Inputs({"hidden_states",
+             "proj_weight",
+             paddle::Optional("up_weight"),
+             "down_weight",
+             paddle::Optional("hidden_states_scale"),
+             paddle::Optional("proj_scale"),
+             paddle::Optional("up_scale"),
+             paddle::Optional("intermediate_hidden_states_scales"),
+             paddle::Optional("down_scale")})
+    .Outputs({"out"})
+    .Attrs({"permuted_weights: bool"})
+    .SetKernelFn(PD_KERNEL(FusedFP8MlpForward))
     .SetInferShapeFn(PD_INFER_SHAPE(FusedMlpInferShape))
     .SetInferDtypeFn(PD_INFER_DTYPE(FusedMlpInferDtype));

--- a/backends/intel_hpu/custom_ops/tests/test_fused_mlp.py
+++ b/backends/intel_hpu/custom_ops/tests/test_fused_mlp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import numpy as np
 
 import paddle
 import paddlenlp_ops
@@ -23,144 +24,932 @@ paddle.device.set_device("intel_hpu")
 paddle.seed(20241214)
 
 
+def check_using_cosine_similarity(test_result, ref_result, required_similarity, logger):
+    vec1 = test_result.to("float32").cpu().numpy().reshape(-1)
+    vec2 = ref_result.to("float32").cpu().numpy().reshape(-1)
+
+    norm1 = np.linalg.norm(vec1)
+    norm2 = np.linalg.norm(vec2)
+
+    if norm1 == 0 or norm2 == 0:
+        cos_sim = 1.0 if np.array_equal(vec1, vec2) else 0.0
+    else:
+        cos_sim = np.dot(vec1, vec2) / (norm1 * norm2)
+
+    print(f"Cosine similarity: {cos_sim}")
+    return cos_sim >= required_similarity
+
+
+def tensorwise_quant_to_fp8(tensor):
+    return paddlenlp_ops.fused_quant(tensor)
+    """
+    x_abs = paddle.abs(tensor).astype(paddle.float32)
+    x_amax = paddle.amax(x_abs)
+    x_amax = paddle.clip(x_amax, min=1e-4)
+    scale = paddle.to_tensor(x_amax / 240.0, dtype=paddle.bfloat16)
+    x_scaled = (tensor / scale).astype(paddle.float8_e4m3fn)
+    return x_scaled, scale
+    """
+
+
 def init_data(
     batch_size=8,
-    seqence_len=128,
-    hidden_size=256,
-    intermediate_size=512,
+    seqence_len=1,
+    hidden_size=2560,
+    intermediate_size=3072,
     dtype="bfloat16",
+    is_3D_hidden_states=False,
+    fused_ffn1=True,
+    permute_weights=False,
 ):
     with paddle.no_grad():
-        x = paddle.rand([batch_size, seqence_len, hidden_size], dtype=dtype)
+        if is_3D_hidden_states:
+            hidden_states = (
+                paddle.rand([batch_size * seqence_len, hidden_size], dtype="bfloat16")
+                * 10
+            ) - 5
+        else:
+            hidden_states = (
+                paddle.rand([batch_size, seqence_len, hidden_size], dtype="bfloat16")
+                * 10
+            ) - 5
 
-        gate_weight = paddle.normal(
-            mean=0.0, std=0.02, shape=[hidden_size, intermediate_size]
-        ).astype(dtype)
-        up_weight = paddle.normal(
-            mean=1.0, std=0.05, shape=[hidden_size, intermediate_size]
-        ).astype(dtype)
-        down_weight = paddle.normal(
-            mean=0.5, std=0.12, shape=[intermediate_size, hidden_size]
-        ).astype(dtype)
-        proj_weight = paddle.concat([gate_weight, up_weight], axis=1)
+        gate_weight = (
+            paddle.rand([hidden_size, intermediate_size], dtype="bfloat16")
+        ) * 2.0 - 1.0
+        up_weight = (
+            paddle.rand([hidden_size, intermediate_size], dtype="bfloat16")
+        ) * 2.0 - 1.0
+        down_weight = (
+            paddle.rand([intermediate_size, hidden_size], dtype="bfloat16")
+        ) * 2.0 - 1.0
+        if permute_weights:
+            gate_weight = gate_weight.transpose([1, 0])
+            up_weight = up_weight.transpose([1, 0])
+            down_weight = down_weight.transpose([1, 0])
+            up_gate_weight = paddle.concat([gate_weight, up_weight], axis=0)
+        else:
+            up_gate_weight = paddle.concat([gate_weight, up_weight], axis=1)
 
-    return x, gate_weight, up_weight, down_weight, proj_weight
+    if dtype == "bfloat16":
+        if fused_ffn1:
+            return hidden_states, up_gate_weight, None, down_weight
+        else:
+            return hidden_states, gate_weight, up_weight, down_weight
+    elif dtype == "fp8":
+        hidden_states_scaled, d_hidden_states_scales = tensorwise_quant_to_fp8(
+            hidden_states
+        )
+        hidden_states_scale = 1.0 / d_hidden_states_scales
+        d_intermediate_hidden_states_scales = paddle.to_tensor(
+            [976], dtype=paddle.bfloat16
+        )
+        intermediate_hidden_states_scales = paddle.to_tensor(
+            [1.0 / 976], dtype=paddle.bfloat16
+        )
+        gate_weight, d_gate_scale = tensorwise_quant_to_fp8(gate_weight)
+        up_weight, d_up_scale = tensorwise_quant_to_fp8(up_weight)
+        down_weight, d_down_scale = tensorwise_quant_to_fp8(down_weight)
+        up_gate_weight, d_up_gate_scale = tensorwise_quant_to_fp8(up_gate_weight)
+        if fused_ffn1:
+            return (
+                hidden_states,
+                up_gate_weight,
+                None,
+                down_weight,
+                hidden_states_scale,
+                d_hidden_states_scales,
+                d_up_gate_scale,
+                None,
+                intermediate_hidden_states_scales,
+                d_intermediate_hidden_states_scales,
+                d_down_scale,
+            )
+        else:
+            return (
+                hidden_states,
+                gate_weight,
+                up_weight,
+                down_weight,
+                hidden_states_scale,
+                d_hidden_states_scales,
+                d_gate_scale,
+                d_up_scale,
+                intermediate_hidden_states_scales,
+                d_intermediate_hidden_states_scales,
+                d_down_scale,
+            )
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
 
 
 def ref_mlp(
-    x,
-    gate_weight,
+    hidden_states,
+    proj_weight,
     up_weight,
     down_weight,
+    permuted_weights,
 ):
-    def swiglu_naive(x, up=None):
+    def swiglu_naive(hidden_states, up=None):
         if up is not None:
-            gate = x
+            gate = hidden_states
         else:
-            gate, up = paddle.chunk(x, chunks=2, axis=-1)
+            gate, up = paddle.chunk(hidden_states, chunks=2, axis=-1)
         silu = gate / (paddle.exp(-gate) + 1)
         return silu * up
 
-    gate = paddle.matmul(x, gate_weight)
-    up = paddle.matmul(x, up_weight)
-    swiglu = swiglu_naive(x=gate, up=up)
-    res = paddle.matmul(swiglu, down_weight)
+    gate = paddle.matmul(hidden_states, proj_weight, transpose_y=permuted_weights)
+    up = (
+        paddle.matmul(hidden_states, up_weight, transpose_y=permuted_weights)
+        if up_weight is not None
+        else None
+    )
+    swiglu = swiglu_naive(hidden_states=gate, up=up)
+    # _, d_scales_swiglu = tensorwise_quant_to_fp8(swiglu)
+    # print(f"Reference intermediate_hidden_states_scales: {d_scales_swiglu.item()}")
+    res = paddle.matmul(swiglu, down_weight, transpose_y=permuted_weights)
 
-    return res.numpy()
+    return res
 
 
 class refMlpOP(paddle.nn.Layer):
-    def __init__(self, x, gate_weight=None, up_weight=None, down_weight=None):
+    def __init__(
+        self,
+        hidden_states,
+        up_gate_weight,
+        up_weight=None,
+        down_weight=None,
+        up_gate_scale=None,
+        d_up_scale=None,
+        d_down_scale=None,
+        permuted_weights=False,
+    ):
         super().__init__()
-        self.x = x
-        self.gate_weight = gate_weight
-        self.up_weight = up_weight
-        self.down_weight = down_weight
+        self.hidden_states = hidden_states
+        self.permuted_weights = permuted_weights
+        if up_gate_weight.dtype != paddle.bfloat16:
+            self.up_gate_weight = up_gate_weight.cast("bfloat16") * up_gate_scale
+            self.up_weight = (
+                (up_weight.cast("bfloat16") * d_up_scale)
+                if up_weight is not None
+                else None
+            )
+            self.down_weight = down_weight.cast("bfloat16") * d_down_scale
+        else:
+            self.up_gate_weight = up_gate_weight
+            self.up_weight = up_weight
+            self.down_weight = down_weight
 
     def forward(self):
         mlp_out_ref = ref_mlp(
-            self.x,
-            self.gate_weight,
+            self.hidden_states,
+            self.up_gate_weight,
             self.up_weight,
             self.down_weight,
+            self.permuted_weights,
         )
         return mlp_out_ref
 
 
 class fusedMlpOP(paddle.nn.Layer):
-    def __init__(self, x, gate_weight=None, up_weight=None, down_weight=None):
+    def __init__(
+        self, hidden_states, proj_weight=None, up_weight=None, down_weight=None
+    ):
         super().__init__()
-        self.x = x
-        self.gate_weight = gate_weight
+        self.hidden_states = hidden_states
+        self.proj_weight = proj_weight
         self.up_weight = up_weight
         self.down_weight = down_weight
 
     def forward(self):
-        fused_mlp_out = paddlenlp_ops.fused_mlp(
-            self.x,
-            self.gate_weight,
+        """
+        fused_mlp_out = paddlenlp_ops.fused_mlp_new(
+            self.hidden_states,
+            self.proj_weight,
             self.up_weight,
             self.down_weight,
         )
+        """
+        """
+        fused_mlp_out = paddlenlp_ops.fused_mlp_bf16(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+        )
+        """
+        fused_mlp_out = paddlenlp_ops.fused_mlp(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+        )
+        return fused_mlp_out
+
+    def forward_profile(self):
+        fused_mlp_out = paddlenlp_ops.fused_mlp(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+        )
+        for _ in range(9):
+            fused_mlp_out = paddlenlp_ops.fused_mlp(
+                fused_mlp_out,
+                self.proj_weight,
+                self.up_weight,
+                self.down_weight,
+                None,
+                None,
+                None,
+                None,
+                None,
+                False,
+            )
         return fused_mlp_out
 
 
-class fusedGateUpMlpOP(paddle.nn.Layer):
-    def __init__(self, x, proj_weight=None, down_weight=None):
+class fusedFp8MlpOP(paddle.nn.Layer):
+    def __init__(
+        self,
+        hidden_states,
+        proj_weight,
+        up_weight=None,
+        down_weight=None,
+        hidden_states_scale=None,
+        d_hidden_states_scale=None,
+        d_proj_scale=None,
+        d_up_scale=None,
+        intermediate_hidden_states_scales=None,
+        d_intermediaete_hidden_states_scales=None,
+        d_down_scale=None,
+        permuted_weights=False,
+    ):
         super().__init__()
-        self.x = x
+        self.hidden_states = hidden_states
         self.proj_weight = proj_weight
+        self.up_weight = up_weight
         self.down_weight = down_weight
+        self.hidden_states_scale = hidden_states_scale
+        self.d_proj_scale = d_proj_scale
+        self.d_up_scale = d_up_scale
+        self.intermediate_hidden_states_scales = intermediate_hidden_states_scales
+        self.d_down_scale = d_down_scale
+        self.permuted_weights = permuted_weights
+        self.d_hidden_states_scale = d_hidden_states_scale
+        self.d_intermediaete_hidden_states_scales = d_intermediaete_hidden_states_scales
 
     def forward(self):
-        fused_gateup_mlp_out = paddlenlp_ops.fused_mlp(
-            self.x,
+        fused_fp8_mlp_out = paddlenlp_ops.fused_mlp(
+            self.hidden_states,
             self.proj_weight,
-            None,
+            self.up_weight,
             self.down_weight,
+            self.hidden_states_scale,  # 240/max
+            self.d_proj_scale,
+            self.d_up_scale,
+            self.intermediate_hidden_states_scales,  # 240/max
+            self.d_down_scale,
+            self.permuted_weights,
         )
-        return fused_gateup_mlp_out
+        """
+        fused_fp8_mlp_out = paddlenlp_ops.fused_fp8_mlp_new(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+            self.d_hidden_states_scale,  # max/240
+            self.d_proj_scale,
+            self.d_up_scale,
+            self.d_intermediaete_hidden_states_scales,  # max/240
+            self.d_down_scale,
+            self.permuted_weights,
+        )
+        """
+        return fused_fp8_mlp_out
+
+    def forward_profile(self):
+        fused_fp8_mlp_out = paddlenlp_ops.fused_mlp(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+            self.hidden_states_scale,
+            self.d_proj_scale,
+            self.d_up_scale,
+            self.intermediate_hidden_states_scales,
+            self.d_down_scale,
+            self.permuted_weights,
+        )
+        for _ in range(9):
+            fused_fp8_mlp_out = paddlenlp_ops.fused_mlp(
+                fused_fp8_mlp_out,
+                self.proj_weight,
+                self.up_weight,
+                self.down_weight,
+                self.hidden_states_scale,
+                self.d_proj_scale,
+                self.d_up_scale,
+                self.intermediate_hidden_states_scales,
+                self.d_down_scale,
+                self.permuted_weights,
+            )
+        return fused_fp8_mlp_out
+
+    def forward_profile_new(self):
+        fused_fp8_mlp_out = paddlenlp_ops.fused_fp8_mlp_new(
+            self.hidden_states,
+            self.proj_weight,
+            self.up_weight,
+            self.down_weight,
+            self.d_hidden_states_scale,
+            self.d_proj_scale,
+            self.d_up_scale,
+            self.d_intermediaete_hidden_states_scales,
+            self.d_down_scale,
+            self.permuted_weights,
+        )
+        for _ in range(9):
+            fused_fp8_mlp_out = paddlenlp_ops.fused_fp8_mlp_new(
+                fused_fp8_mlp_out,
+                self.proj_weight,
+                self.up_weight,
+                self.down_weight,
+                self.d_hidden_states_scale,
+                self.d_proj_scale,
+                self.d_up_scale,
+                self.d_intermediaete_hidden_states_scales,
+                self.d_down_scale,
+                self.permuted_weights,
+            )
+        return fused_fp8_mlp_out
 
 
-def run_profile(my_profile_func):
+def run_profile(profile_model):
     prof = profiler.Profiler(
         targets=[profiler.ProfilerTarget.CPU, profiler.ProfilerTarget.CUSTOM_DEVICE],
+        scheduler=(0, 40),
         on_trace_ready=profiler.export_chrome_tracing("./profile"),
     )
     prof.start()
-    for iter in range(20):
+    for iter in range(40):
         with paddle.no_grad():
-            mlp_out = my_profile_func()
+            # mlp_out = profile_model.forward_profile()
+            mlp_out = profile_model.forward_profile_new()
+        paddle.device.synchronize()
+        prof.step()
     prof.stop()
 
 
-def run_accuracy_check(x, gate_weight, up_weight, down_weight, proj_weight):
-    ref_mlp = refMlpOP(x, gate_weight, up_weight, down_weight)
-    fused_mlp = fusedMlpOP(x, gate_weight, up_weight, down_weight)
-    fused_gate_up_mlp = fusedGateUpMlpOP(x, proj_weight, down_weight)
-
+def run_accuracy_check(
+    testcase,
+    hidden_states,
+    gate_weight,
+    up_weight,
+    down_weight,
+    d_proj_scale=None,
+    d_up_scale=None,
+    d_down_scale=None,
+    fused_res=None,
+    permuted_weights=False,
+):
+    ref_mlp = refMlpOP(
+        hidden_states,
+        gate_weight,
+        up_weight,
+        down_weight,
+        d_proj_scale,
+        d_up_scale,
+        d_down_scale,
+        permuted_weights,
+    )
     golden_res = ref_mlp()
-    fused_res = fused_mlp()
-    fused_gate_up_res = fused_gate_up_mlp()
 
-    print((fused_res == golden_res).all())
-    print((fused_gate_up_res == golden_res).all())
+    required_similarity = 0.99
+    passed = check_using_cosine_similarity(
+        fused_res, golden_res, required_similarity, None
+    )
+    if passed:
+        print(
+            f"------- {testcase} accuracy check passed (cosine similarity >= {required_similarity}). -------\n"
+        )
+    else:
+        print(
+            f"******* {testcase} accuracy check failed! (cosine similarity < {required_similarity}). *******\n"
+        )
+        print("fused_res: ", fused_res)
+        print("golden_res: ", golden_res)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Run profile or accuracy check")
-    parser.add_argument("--profile", action="store_true", help="Run profile")
-    parser.add_argument("--accuracy", action="store_true", help="Run accuracy check")
+    parser.add_argument(
+        "--profile", action="store_true", help="Run profile [default False]"
+    )
+    parser.add_argument(
+        "--accuracy",
+        action="store_true",
+        default=True,
+        help="Run accuracy check [default True]",
+    )
+    parser.add_argument(
+        "--testcase",
+        type=str,
+        default="all",
+        choices=[
+            "fuse_3D_bf16",
+            "fuse_2D_bf16",
+            "split_3D_bf16",
+            "split_2D_bf16",
+            "fuse_3D_fp8",
+            "fuse_2D_fp8",
+            "split_3D_fp8",
+            "split_2D_fp8",
+            "fuse_3D_permute_fp8",
+            "fuse_2D_permute_fp8",
+            "split_3D_permute_fp8",
+            "split_2D_permute_fp8",
+            "all",
+        ],
+        help="Test case to run.",
+    )
     args = parser.parse_args()
+    parser.print_help()
 
-    x, gate_weight, up_weight, down_weight, proj_weight = init_data()
+    if args.testcase == "all" or args.testcase == "fuse_3D_bf16":
+        hidden_states, ffn1_weight, up_weight, down_weight = init_data(
+            is_3D_hidden_states=True
+        )
+        fused_mlp = fusedMlpOP(hidden_states, ffn1_weight, None, down_weight)
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                "fuse_3D_bf16",
+                hidden_states,
+                ffn1_weight,
+                up_weight,
+                down_weight,
+                fused_res=fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "fuse_2D_bf16":
+        hidden_states, ffn1_weight, up_weight, down_weight = init_data()
+        fused_mlp = fusedMlpOP(hidden_states, ffn1_weight, None, down_weight)
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                "fuse_2D_bf16",
+                hidden_states,
+                ffn1_weight,
+                up_weight,
+                down_weight,
+                fused_res=fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_3D_bf16":
+        hidden_states, ffn1_weight, up_weight, down_weight = init_data(
+            is_3D_hidden_states=True, fused_ffn1=False
+        )
+        fused_mlp = fusedMlpOP(hidden_states, ffn1_weight, up_weight, down_weight)
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                "split_3D_bf16",
+                hidden_states,
+                ffn1_weight,
+                up_weight,
+                down_weight,
+                fused_res=fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_2D_bf16":
+        hidden_states, gate_weight, up_weight, down_weight = init_data(fused_ffn1=False)
+        fused_mlp = fusedMlpOP(hidden_states, gate_weight, up_weight, down_weight)
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                "split_2D_bf16",
+                hidden_states,
+                gate_weight,
+                up_weight,
+                down_weight,
+                fused_res=fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "fuse_3D_fp8":
+        testcase = "fuse_3D_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states, fused_ffn1=fused_ffn1, dtype=dtype
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "fuse_2D_fp8":
+        testcase = "fuse_2D_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states, fused_ffn1=fused_ffn1, dtype=dtype
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_3D_fp8":
+        testcase = "split_3D_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states, fused_ffn1=fused_ffn1, dtype=dtype
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_2D_fp8":
+        testcase = "split_2D_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states, fused_ffn1=fused_ffn1, dtype=dtype
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+            )
+
+    if args.testcase == "all" or args.testcase == "fuse_3D_permute_fp8":
+        testcase = "fuse_3D_permute_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        permuted_weights = True if "permute" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states,
+            fused_ffn1=fused_ffn1,
+            dtype=dtype,
+            permute_weights=permuted_weights,
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+            permuted_weights,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+                permuted_weights,
+            )
+
+    if args.testcase == "all" or args.testcase == "fuse_2D_permute_fp8":
+        testcase = "fuse_2D_permute_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        permuted_weights = True if "permute" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states,
+            fused_ffn1=fused_ffn1,
+            dtype=dtype,
+            permute_weights=permuted_weights,
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+            permuted_weights,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+                permuted_weights,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_3D_permute_fp8":
+        testcase = "split_3D_permute_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        permuted_weights = True if "permute" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states,
+            fused_ffn1=fused_ffn1,
+            dtype=dtype,
+            permute_weights=permuted_weights,
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+            permuted_weights,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+                permuted_weights,
+            )
+
+    if args.testcase == "all" or args.testcase == "split_2D_permute_fp8":
+        testcase = "split_2D_permute_fp8"
+        fused_ffn1 = True if "fuse" in testcase else False
+        is_3D_hidden_states = True if "3D" in testcase else False
+        permuted_weights = True if "permute" in testcase else False
+        dtype = "fp8" if "fp8" in testcase else "bfloat16"
+        (
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+        ) = init_data(
+            is_3D_hidden_states=is_3D_hidden_states,
+            fused_ffn1=fused_ffn1,
+            dtype=dtype,
+            permute_weights=permuted_weights,
+        )
+        fused_mlp = fusedFp8MlpOP(
+            hidden_states,
+            proj_weight,
+            up_weight,
+            down_weight,
+            hidden_states_scale,
+            d_hidden_states_scales,
+            d_proj_scale,
+            d_up_scale,
+            intermediate_hidden_states_scales,
+            d_intermediate_hidden_states_scales,
+            d_down_scale,
+            permuted_weights,
+        )
+        if args.accuracy:
+            fused_res = fused_mlp()
+            run_accuracy_check(
+                testcase,
+                hidden_states,
+                proj_weight,
+                up_weight,
+                down_weight,
+                d_proj_scale,
+                d_up_scale,
+                d_down_scale,
+                fused_res,
+                permuted_weights,
+            )
 
     if args.profile:
-        run_profile(fusedGateUpMlpOP(x, proj_weight, down_weight))
-        run_profile(fusedMlpOP(x, gate_weight, up_weight, down_weight))
-        run_profile(refMlpOP(x, gate_weight, up_weight, down_weight))
-    else:
-        run_accuracy_check(x, gate_weight, up_weight, down_weight, proj_weight)
+        run_profile(fused_mlp)
 
 
 if __name__ == "__main__":

--- a/backends/intel_hpu/tests/unittests/test_fused_gate_moe.py
+++ b/backends/intel_hpu/tests/unittests/test_fused_gate_moe.py
@@ -1,0 +1,927 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from parameterized import parameterized
+
+import logging
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+import paddlenlp_ops
+
+local_rank = dist.get_rank()
+world_size = dist.get_world_size()
+
+print(
+    f"**************************************\n"
+    f"      World size: {world_size}, Local rank: {local_rank}\n"
+    f"**************************************"
+)
+
+if world_size == 1:
+    intel_hpus_module_id = os.environ.get("FLAGS_selected_intel_hpus", 1)
+    paddle.device.set_device(f"intel_hpu:{intel_hpus_module_id}")
+else:
+    paddle.set_device("intel_hpu")
+    dist.init_parallel_env()
+
+np.random.seed(2049)
+paddle.seed(102)
+
+
+class FlushStreamHandler(logging.StreamHandler):
+    def emit(self, record):
+        super().emit(record)
+        self.flush()
+
+
+_first_run = True
+
+
+def setup_logging(ep_rank, tp_rank, enable_logging=False):
+    global _first_run
+
+    logger = logging.getLogger(f"moe_ep_rank_{ep_rank}_tp_rank{tp_rank}")
+    if enable_logging or os.getenv("ENABLE_LOGGING") == "1":
+        log_file = f"test_logs_ep_rank_{ep_rank}_tp_rank_{tp_rank}.log"
+        logger.setLevel(logging.DEBUG)
+        logger.handlers.clear()
+
+        mode = "w" if _first_run and os.path.exists(log_file) else "a"
+        file_handler = logging.FileHandler(log_file, mode=mode)
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s [%(levelname)s] ep_rank %(ep_rank)d tp_rank %(tp_rank)d: %(message)s"
+            )
+        )
+        logger.addHandler(file_handler)
+
+        stream_handler = FlushStreamHandler(sys.stdout)
+        stream_handler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s [%(levelname)s] ep_rank %(ep_rank)d tp_rank %(tp_rank)d: %(message)s"
+            )
+        )
+        logger.addHandler(stream_handler)
+        _first_run = False
+
+    logger.info(
+        "Logging initialized for ep_rank %d, tp_rank %d",
+        ep_rank,
+        tp_rank,
+        extra={"ep_rank": ep_rank, "tp_rank": tp_rank},
+    )
+    return logger
+
+
+def init_distributed(ep_size=1, tp_size=1):
+
+    if not dist.is_initialized():
+        try:
+            dist.init_parallel_env()
+        except Exception as e:
+            raise RuntimeError("Failed to initialize distributed environment") from e
+
+    global_rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    if world_size == 1:
+        ep_size, tp_size = 1, 1
+    elif ep_size == 1:
+        tp_size = world_size
+    elif tp_size == 1:
+        ep_size = world_size
+
+    if world_size != ep_size * tp_size:
+        raise ValueError(
+            f"Invalid configuration: ep_size ({ep_size}) * tp_size ({tp_size}) "
+            f"= {ep_size * tp_size} != world_size ({world_size})"
+        )
+
+    ep_rank = global_rank // tp_size
+    tp_rank = global_rank % tp_size
+
+    # Create TP group
+    if ep_size == 1:
+        tp_ranks = list(range(world_size))
+    else:
+        tp_ranks = [ep_rank * tp_size + i for i in range(tp_size)]
+    try:
+        tp_group = dist.new_group(tp_ranks)
+    except Exception as e:
+        raise ValueError(f"Failed to create tp_group with ranks={tp_ranks}: {e}")
+
+    # Create EP group
+    if tp_size == 1:
+        ep_ranks = list(range(world_size))
+    else:
+        ep_ranks = [i * tp_size + tp_rank for i in range(ep_size)]
+    try:
+        ep_group = dist.new_group(ep_ranks)
+    except Exception as e:
+        raise ValueError(f"Failed to create ep_group with ranks={ep_ranks}: {e}")
+
+    return (ep_rank, ep_size, ep_group), (tp_rank, tp_size, tp_group)
+
+
+def check_using_cosine_similarity(
+    final_states, final_states_ref, required_similarity, ep_rank, tp_rank, logger
+):
+    vec1 = final_states.reshape(-1)
+    vec2 = final_states_ref.reshape(-1)
+
+    norm1 = np.linalg.norm(vec1)
+    norm2 = np.linalg.norm(vec2)
+
+    if norm1 == 0 or norm2 == 0:
+        cos_sim = 1.0 if np.array_equal(vec1, vec2) else 0.0
+    else:
+        cos_sim = np.dot(vec1, vec2) / (norm1 * norm2)
+
+    logger.info(
+        f"Cosine similarity: {cos_sim}, \n"
+        f"required_similarity: {required_similarity}, ",
+        extra={"ep_rank": ep_rank, "tp_rank": tp_rank},
+    )
+    print(f"Cosine similarity: {cos_sim}")
+    return cos_sim >= required_similarity
+
+
+def tensorwise_quant_to_fp8(tensor):
+    """
+    x_abs = paddle.abs(tensor).astype(paddle.float32)
+    x_amax = paddle.amax(x_abs)
+    x_amax = paddle.clip(x_amax, min=1e-4)
+    scale = paddle.to_tensor(x_amax / 240.0, dtype=paddle.bfloat16)
+    x_scaled = (tensor / scale).astype(paddle.float8_e4m3fn)
+    return x_scaled, scale
+    """
+    return paddlenlp_ops.fused_quant(tensor)
+
+
+def tensorwise_cast_to_fp8(tensor, scale):
+    scale = paddle.to_tensor(scale, dtype=tensor.dtype)
+    x_scaled = (tensor * scale).cast(paddle.float8_e4m3fn)
+    return x_scaled
+
+
+def blockwise_quant_to_fp8(tensorlist, block_size):
+    q_tensor_list = []
+    q_tensor_scales = []
+
+    for x in tensorlist:
+        assert x.dim() == 2
+        m, n = x.shape
+        x_padded = paddle.zeros(
+            (
+                (m + block_size - 1) // block_size * block_size,
+                (n + block_size - 1) // block_size * block_size,
+            ),
+            dtype=x.dtype,
+        )
+        x_padded[:m, :n] = x
+        x_view = paddle.view(
+            x_padded, (-1, block_size, x_padded.shape[1] // block_size, block_size)
+        )
+
+        x_abs = paddle.abs(x_view).astype(paddle.float32)
+        x_amax = paddle.amax(x_abs, axis=(1, 3), keepdim=True)
+        x_amax = paddle.clip(x_amax, min=1e-4)
+        x_scaled = (x_view * (240.0 / x_amax)).astype(paddle.float8_e4m3fn)
+
+        q_tensor_list.append(x_scaled.view_as(x_padded)[:m, :n].contiguous())
+        q_tensor_scales.append(
+            paddle.view(x_amax / 240.0, (x_view.shape[0], x_view.shape[2]))
+        )
+
+    return (q_tensor_list, q_tensor_scales)
+
+
+def generate_tensors(
+    dtype,
+    num_tokens,
+    hidden_dim,
+    ffn_dim,
+    top_k,
+    num_experts,
+    permuted_weights,
+    fused_weights,
+    dynamic_scale=None,
+    fp8_scales=None,
+    hidden_states_dynamic_quant=False,
+    block_size=None,
+):
+    if dtype == "bfloat16":
+        paddle_dtype = paddle.bfloat16
+    elif dtype == "fp8":
+        paddle_dtype = paddle.bfloat16
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+    hidden_states = (paddle.rand([num_tokens, hidden_dim], dtype=paddle_dtype) * 10) - 5
+    route_gate_weight = (
+        paddle.rand([hidden_dim, num_experts], dtype=paddle.float32) * 0.6
+    ) - 0.3
+    gate_correction_bias = (
+        paddle.rand([1, num_experts], dtype=paddle.float32) * 128
+    ) - 64
+    up_weights = [
+        (paddle.rand([hidden_dim, ffn_dim], dtype=paddle_dtype) * 0.6) - 0.3
+        for _ in range(num_experts)
+    ]
+    gate_weights = [
+        (paddle.rand([hidden_dim, ffn_dim], dtype=paddle_dtype) * 0.6) - 0.3
+        for _ in range(num_experts)
+    ]
+    down_weights = [
+        (paddle.rand([ffn_dim, hidden_dim], dtype=paddle_dtype) * 0.6) - 0.3
+        for _ in range(num_experts)
+    ]
+
+    if permuted_weights:
+        up_weights = [w.transpose([1, 0]) for w in up_weights]
+        gate_weights = [w.transpose([1, 0]) for w in gate_weights]
+        down_weights = [w.transpose([1, 0]) for w in down_weights]
+
+    if fused_weights:
+        up_gate_weights = [
+            paddle.concat((w1, w2), axis=0)
+            if permuted_weights
+            else paddle.concat((w1, w2), axis=1)
+            for w1, w2 in zip(up_weights, gate_weights)
+        ]
+
+    # fp8 scale weights handling
+    if dtype == "bfloat16":
+        d_scales_up_gate = None
+        d_scales_down = None
+        d_scales_hidden_states = None
+        d_scales_intermediate_hidden_states = None
+    elif dtype == "fp8":
+        # weights cast to fp8, scales to tensor
+        if fused_weights:
+            up_gate_weights, d_scales_up_gate = zip(
+                *[tensorwise_quant_to_fp8(w) for w in up_gate_weights]
+            )
+            up_gate_weights = list(up_gate_weights)
+            d_scales_up_gate = list(d_scales_up_gate)
+        else:
+            up_weights, d_scales_up = zip(
+                *[tensorwise_quant_to_fp8(w) for w in up_weights]
+            )
+            up_weights = list(up_weights)
+            d_scales_up = list(d_scales_up)
+            gate_weights, d_scales_gate = zip(
+                *[tensorwise_quant_to_fp8(w) for w in gate_weights]
+            )
+            gate_weights = list(gate_weights)
+            d_scales_gate = list(d_scales_gate)
+        down_weights, d_scales_down = zip(
+            *[tensorwise_quant_to_fp8(w) for w in down_weights]
+        )
+        down_weights = list(down_weights)
+        d_scales_down = list(d_scales_down)
+
+        if dynamic_scale is False:
+            d_scales_intermediate_hidden_states = fp8_scales[
+                "d_scale_intermediate_hidden_states"
+            ]
+            d_scales_intermediate_hidden_states = [
+                paddle.to_tensor(scale, dtype=paddle_dtype)
+                for scale in d_scales_intermediate_hidden_states
+            ]
+        else:
+            d_scales_intermediate_hidden_states = None
+
+        if hidden_states_dynamic_quant is False:
+            _, d_scales_hidden_states = tensorwise_quant_to_fp8(hidden_states)
+            d_scales_hidden_states = paddle.to_tensor(
+                d_scales_hidden_states, dtype=paddle_dtype
+            )
+            d_scales_hidden_states = 1.0 / d_scales_hidden_states
+        else:
+            d_scales_hidden_states = None
+    elif dtype == "blockwise_fp8":
+        up_weights, d_scales_up = blockwise_quant_to_fp8(up_weights, block_size)
+        gate_weights, d_scales_gate = blockwise_quant_to_fp8(gate_weights, block_size)
+        down_weights, d_scales_down = blockwise_quant_to_fp8(down_weights, block_size)
+        # not done yet
+    else:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+    paddle_data = (
+        hidden_states,
+        gate_correction_bias,
+        route_gate_weight,
+        up_gate_weights,
+        down_weights,
+        d_scales_hidden_states,
+        d_scales_intermediate_hidden_states,
+        d_scales_up_gate,
+        d_scales_down,
+    )
+    return paddle_data
+
+
+class MixtralSparseMoeRef:
+    def __init__(self, dynamic_quant, dtype):
+        super().__init__()
+        self.dynamic_quant = dynamic_quant
+
+        if dtype == "fp8":
+            self.forward = self.forward_fp8
+        else:
+            self.forward = self.forward_bf16
+
+    def forward_fp8(
+        self,
+        hidden_states,
+        gate_weights,
+        gate_correction_bias,
+        up_gate_weights,
+        down_weights,
+        hidden_states_scales,
+        intermediate_hidden_states_scales,
+        gate_up_weights_scales,
+        down_weights_scales,
+        top_k,
+        norm_topk_prob,
+        permuted_weights,
+        experts_min,
+        experts_max,
+        chunk_size,
+    ):
+        gate_out = paddle.matmul(hidden_states.cast("float32"), gate_weights)
+
+        weights = paddle.nn.functional.softmax(gate_out, axis=-1)
+        if gate_correction_bias is not None:
+            scores = weights + gate_correction_bias
+            _, selected_experts = paddle.topk(scores, top_k, axis=-1)
+            routing_weights = paddle.index_sample(weights, selected_experts)
+        else:
+            routing_weights, selected_experts = paddle.topk(weights, top_k, axis=-1)
+        if norm_topk_prob:
+            routing_weights /= paddle.sum(routing_weights, axis=-1, keepdim=True)
+        routing_weights = routing_weights.cast("bfloat16")
+
+        if hidden_states_scales is None:
+            hidden_states, hidden_states_scales = tensorwise_quant_to_fp8(hidden_states)
+        else:
+            hidden_states = tensorwise_cast_to_fp8(
+                hidden_states, 1.0 / hidden_states_scales
+            )
+
+        common_inputs = (
+            hidden_states,
+            selected_experts,
+            routing_weights.cast("bfloat16"),
+        )
+        weights = (up_gate_weights, down_weights)
+
+        if self.dynamic_quant:
+            intermediate_hidden_states_scales = None
+
+        scales = (
+            hidden_states_scales,
+            intermediate_hidden_states_scales,
+            gate_up_weights_scales,
+            down_weights_scales,
+        )
+
+        common_params = (
+            permuted_weights,
+            "silu",  # activation,
+            experts_min,
+            experts_max,
+            self.dynamic_quant,
+            chunk_size,
+        )
+
+        fused_moe_out = paddlenlp_ops.mixture_of_experts_fp8(
+            *common_inputs, *weights, *scales, *common_params
+        )
+
+        return fused_moe_out
+
+    def forward_bf16(
+        self,
+        hidden_states,
+        gate_weights,
+        gate_correction_bias,
+        up_gate_weights,
+        down_weights,
+        hidden_states_scales,
+        intermediate_hidden_states_scales,
+        gate_up_weights_scales,
+        down_weights_scales,
+        top_k,
+        norm_topk_prob,
+        permuted_weights,
+        experts_min,
+        experts_max,
+        chunk_size,
+    ):
+        gate_out = paddle.matmul(hidden_states.cast("float32"), gate_weights)
+
+        weights = paddle.nn.functional.softmax(gate_out, axis=-1)
+        if gate_correction_bias is not None:
+            scores = weights + gate_correction_bias
+            _, selected_experts = paddle.topk(scores, top_k, axis=-1)
+            routing_weights = paddle.index_sample(weights, selected_experts)
+        else:
+            routing_weights, selected_experts = paddle.topk(weights, top_k, axis=-1)
+        if norm_topk_prob:
+            routing_weights /= paddle.sum(routing_weights, axis=-1, keepdim=True)
+        routing_weights = routing_weights.cast("bfloat16")
+
+        common_inputs = (hidden_states, selected_experts, routing_weights)
+        weights = (up_gate_weights, down_weights)
+
+        common_params = (
+            permuted_weights,
+            "silu",  # activation,
+            experts_min,
+            experts_max,
+            False,  # measurement_mode
+            chunk_size,
+        )
+
+        fused_moe_out, _ = paddlenlp_ops.mixture_of_experts(
+            *common_inputs, *weights, *common_params
+        )
+
+        return fused_moe_out
+
+
+class FusedGateMoE:
+    def __init__(
+        self,
+        num_experts,
+        top_k,
+        activation,
+        permuted_weights,
+        fused_weights,
+        slice_max_expert,
+        logger,
+        ep_rank,
+        ep_size,
+        ep_group=None,
+        tp_rank=0,
+        tp_size=1,
+        tp_group=None,
+        dtype="fp8",
+        dynamic_scale=None,
+        block_size=None,
+        chunk_size=0,
+    ):
+        self.num_experts = num_experts
+        self.permuted_weights = permuted_weights
+        self.fused_weights = fused_weights
+        self.dynamic_scale = dynamic_scale
+        self.activation = activation
+        self.ep_rank = ep_rank
+        self.ep_size = ep_size
+        self.ep_group = ep_group
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.tp_group = tp_group
+        self.logger = logger
+        self.dtype = dtype
+        self.block_size = block_size
+        self.top_k = top_k
+        self.chunk_size = chunk_size
+
+        if self.dtype == "bfloat16":
+            self.fn = paddlenlp_ops.fused_gate_moe
+        elif self.dtype == "fp8":
+            self.fn = paddlenlp_ops.fused_gate_moe_fp8
+        elif self.dtype == "blockwise_fp8":
+            self.fn = paddlenlp_ops.fused_gate_moe_blockwise_fp8
+        else:
+            raise ValueError(f"Unsupported dtype: {dtype}")
+
+        self.experts_per_rank = self.num_experts // self.ep_size
+        self.experts_min = self.ep_rank * self.experts_per_rank
+        self.experts_max = (self.ep_rank + 1) * self.experts_per_rank - 1
+        if self.ep_rank == self.ep_size - 1:
+            self.experts_max = self.num_experts - 1
+
+        self.expert_slice = max(
+            1, (self.experts_max - self.experts_min + 1) // slice_max_expert
+        )
+        self.expert_chunk = max(
+            1, (self.experts_max - self.experts_min + 1) // self.expert_slice
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        gate_weights,
+        gate_correction_bias,
+        expert_weights,
+        hidden_states_scale,
+        intermediate_states_scales,
+        weights_scales,
+        compute_amax=False,
+    ):
+        common_inputs = (hidden_states, gate_weights, gate_correction_bias)
+        # final_hidden_states = paddle.zeros_like(hidden_states)
+
+        amax_per_expert = (
+            paddle.zeros(self.num_experts, dtype="float32") if compute_amax else None
+        )
+
+        for idx in range(self.expert_slice):
+            slice_experts_min = self.experts_min + (self.expert_chunk * idx)
+            slice_experts_max = min(
+                slice_experts_min + self.expert_chunk - 1, self.experts_max
+            )
+            common_params = (
+                self.top_k,
+                True,  # norm_topk_prob
+                self.permuted_weights,
+                self.activation,
+                slice_experts_min,
+                slice_experts_max,
+            )
+            slice_weights = (
+                (
+                    expert_weights[0][slice_experts_min : slice_experts_max + 1],
+                    expert_weights[1][slice_experts_min : slice_experts_max + 1],
+                )
+                if self.fused_weights
+                else (
+                    expert_weights[0][slice_experts_min : slice_experts_max + 1]
+                    + expert_weights[1][slice_experts_min : slice_experts_max + 1],
+                    expert_weights[2][slice_experts_min : slice_experts_max + 1],
+                )
+            )
+            if self.dtype == "fp8":
+                slice_scales = (
+                    (
+                        hidden_states_scale,
+                        None
+                        if self.dynamic_scale
+                        else intermediate_states_scales[
+                            slice_experts_min : slice_experts_max + 1
+                        ],
+                        weights_scales[0][slice_experts_min : slice_experts_max + 1],
+                        weights_scales[1][slice_experts_min : slice_experts_max + 1],
+                    )
+                    if self.fused_weights
+                    else (
+                        hidden_states_scale,
+                        None
+                        if self.dynamic_scale
+                        else intermediate_states_scales[
+                            slice_experts_min : slice_experts_max + 1
+                        ],
+                        weights_scales[0][slice_experts_min : slice_experts_max + 1]
+                        + weights_scales[1][slice_experts_min : slice_experts_max + 1],
+                        weights_scales[2][slice_experts_min : slice_experts_max + 1],
+                    )
+                )
+            elif self.dtype == "blockwise_fp8":
+                slice_scales = (
+                    (
+                        weights_scales[0][slice_experts_min : slice_experts_max + 1],
+                        weights_scales[1][slice_experts_min : slice_experts_max + 1],
+                    )
+                    if self.fused_weights
+                    else (
+                        weights_scales[0][slice_experts_min : slice_experts_max + 1]
+                        + weights_scales[1][slice_experts_min : slice_experts_max + 1],
+                        weights_scales[2][slice_experts_min : slice_experts_max + 1],
+                    )
+                )
+
+            if self.dtype == "fp8":
+                slice_result = self.fn(
+                    *common_inputs,
+                    *slice_weights,
+                    *slice_scales,
+                    *common_params,
+                    self.chunk_size,
+                )
+            elif self.dtype == "blockwise_fp8":
+                slice_result = self.fn(
+                    *common_inputs,
+                    *slice_weights,
+                    *slice_scales,
+                    *common_params,
+                    self.block_size,
+                    self.chunk_size,
+                )
+            else:
+                slice_result = self.fn(
+                    *common_inputs,
+                    *slice_weights,
+                    *common_params,
+                    self.chunk_size,
+                )
+                # paddlenlp_ops.fused_gate_moe no requirement to return amax
+                slice_amax = None
+            if compute_amax:
+                amax_per_expert[slice_experts_min : slice_experts_max + 1] = slice_amax
+
+            final_hidden_states = slice_result
+
+        # EP: All-reduce for final output
+        if self.tp_size > 1:
+            try:
+                dist.all_reduce(
+                    final_hidden_states, op=dist.ReduceOp.SUM, group=self.tp_group
+                )
+                self.logger.info(
+                    "TP All-reduce for MoE successfully.",
+                    extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                )
+                if compute_amax:
+                    dist.all_reduce(
+                        amax_per_expert, op=dist.ReduceOp.MAX, group=self.tp_group
+                    )
+                    self.logger.info(
+                        "TP All-reduce for AMax successfully.",
+                        extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                    )
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to perform TP All-reduce: {str(e)}",
+                    extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                )
+                raise
+
+        if self.ep_size > 1:
+            try:
+                dist.all_reduce(
+                    final_hidden_states, op=dist.ReduceOp.SUM, group=self.ep_group
+                )
+                self.logger.info(
+                    "EP All-reduce for MoE successfully.",
+                    extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                )
+                if compute_amax:
+                    dist.all_reduce(
+                        amax_per_expert, op=dist.ReduceOp.MAX, group=self.ep_group
+                    )
+                    self.logger.info(
+                        "EP All-reduce for AMax successfully.",
+                        extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                    )
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to perform EP All-reduce: {str(e)}",
+                    extra={"ep_rank": self.ep_rank, "tp_rank": self.tp_rank},
+                )
+                raise
+
+        return final_hidden_states, amax_per_expert
+
+
+DTYPES = ["bfloat16", "fp8"]  # ["bfloat16", "fp8"]
+NUM_TOKENS = [32]
+HIDDEN_DIMS = [4096]
+FFN_DIMS = [2560]
+TOP_K = [2]
+NUM_EXPERTS = [8]
+SLICE_MAX_EXPERT = [8]
+FUSED_WEIGHTS = [True]  # [True, False]
+ACTIVATIONS = ["silu"]  # ["gelu", "relu", "silu"]
+PERMUTED_WEIGHTS = [False]  # [True, False]
+EP_SIZE = [world_size]
+TP_SIZE = [1]
+# for bfloat16 only
+COMPUTE_AMAX = [False]  # [True, False]
+# for fp8 only
+HIDDEN_STATES_DYNAMIC_SCALE = [True, False]
+MOE_DYNAMIC_SCALE = [True, False]
+FP8_SCALES = [
+    {
+        "d_scale_intermediate_hidden_states": [
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+        ],
+    },
+]
+# for blockwise_fp8 only
+BLOCK_SIZES = [128]
+
+
+class MoETest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                num_tokens,
+                hidden_dim,
+                ffn_dim,
+                top_k,
+                num_experts,
+                slice_max_expert,
+                fused_weights,
+                activation,
+                permuted_weights,
+                ep_size,
+                tp_size,
+                dynamic_scale,
+                fp8_scales,
+                hidden_states_dynamic_quant,
+                dtype,
+            )
+            for num_tokens in NUM_TOKENS
+            for hidden_dim in HIDDEN_DIMS
+            for ffn_dim in FFN_DIMS
+            for top_k in TOP_K
+            for num_experts in NUM_EXPERTS
+            for slice_max_expert in SLICE_MAX_EXPERT
+            for fused_weights in FUSED_WEIGHTS
+            for activation in ACTIVATIONS
+            for permuted_weights in PERMUTED_WEIGHTS
+            for ep_size in EP_SIZE
+            for tp_size in TP_SIZE
+            for dynamic_scale in MOE_DYNAMIC_SCALE
+            for fp8_scales in FP8_SCALES
+            for hidden_states_dynamic_quant in HIDDEN_STATES_DYNAMIC_SCALE
+            for dtype in DTYPES
+        ]
+    )
+    def test_fused_gate_moe(
+        self,
+        num_tokens,
+        hidden_dim,
+        ffn_dim,
+        top_k,
+        num_experts,
+        slice_max_expert,
+        fused_weights,
+        activation,
+        permuted_weights,
+        ep_size,
+        tp_size,
+        dynamic_scale,
+        fp8_scales,
+        hidden_states_dynamic_quant,
+        dtype="fp8",
+    ):
+        (ep_rank, ep_size, ep_group), (tp_rank, tp_size, tp_group) = init_distributed(
+            ep_size, tp_size
+        )
+        logger = setup_logging(ep_rank=ep_rank, tp_rank=tp_rank)
+        logger.debug(
+            f"\n\n======================================="
+            f"`test_mixture_of_experts_fp8`: \n"
+            f" num_tokens={num_tokens}, hidden_dim={hidden_dim}, ffn_dim={ffn_dim}, \n"
+            f" top_k={top_k}, num_experts={num_experts}, slice_max_expert={slice_max_expert}, \n"
+            f" fused_weights={fused_weights}, permuted_weights={permuted_weights}, activation={activation}, \n"
+            f" dtype={dtype}, dynamic_scale={dynamic_scale}, \n"
+            f" ep_size={ep_size}, tp_size={tp_size}, \n",
+            extra={"ep_rank": ep_rank, "tp_rank": tp_rank},
+        )
+
+        paddle.seed(ep_rank * 100 + tp_rank + 1024)
+        device = "intel_hpu"
+        out_tensors = generate_tensors(
+            num_tokens=num_tokens,
+            hidden_dim=hidden_dim,
+            ffn_dim=ffn_dim,
+            top_k=top_k,
+            num_experts=num_experts,
+            permuted_weights=permuted_weights,
+            fused_weights=fused_weights,
+            dynamic_scale=dynamic_scale,
+            fp8_scales=fp8_scales,
+            hidden_states_dynamic_quant=hidden_states_dynamic_quant,
+            dtype=dtype,
+        )
+
+        (
+            hidden_states,
+            gate_correction_bias,
+            gate_weights,
+            up_gate_weights,
+            down_weights,
+            d_scales_hidden_states,
+            d_scales_intermediate_hidden_states,
+            d_scales_up_gate,
+            d_scales_down,
+        ) = out_tensors
+
+        # CPU Reference Implementation
+        mixtral_ref = MixtralSparseMoeRef(dynamic_scale, dtype)
+
+        final_hidden_states_ref = mixtral_ref.forward(
+            hidden_states,
+            gate_weights,
+            gate_correction_bias,
+            up_gate_weights,
+            down_weights,
+            d_scales_hidden_states,
+            d_scales_intermediate_hidden_states,
+            d_scales_up_gate,
+            d_scales_down,
+            top_k,
+            norm_topk_prob=True,
+            permuted_weights=permuted_weights,
+            experts_min=0,
+            experts_max=num_experts - 1,
+            chunk_size=0,
+        )
+
+        logger.debug(
+            "\n===== Mixtral Moe numpy ref Output =====\n",
+            extra={
+                "ep_rank": ep_rank,
+                "tp_rank": tp_rank,
+                "final_hidden_states_ref_np": final_hidden_states_ref,
+                "shape": final_hidden_states_ref.shape,
+            },
+        )
+
+        # paddlenlp_ops.moe operator
+        fused_gate_moe = FusedGateMoE(
+            num_experts=num_experts,
+            top_k=top_k,
+            activation=activation,
+            permuted_weights=permuted_weights,
+            fused_weights=fused_weights,
+            dynamic_scale=dynamic_scale,
+            slice_max_expert=slice_max_expert,
+            logger=logger,
+            ep_rank=ep_rank,
+            ep_size=ep_size,
+            ep_group=ep_group,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            tp_group=tp_group,
+            dtype=dtype,
+            block_size=None,
+            chunk_size=0,
+        )
+
+        final_hidden_states, amax_per_expert = fused_gate_moe.forward(
+            hidden_states=hidden_states,
+            gate_weights=gate_weights,
+            gate_correction_bias=gate_correction_bias,
+            expert_weights=(up_gate_weights, down_weights),
+            hidden_states_scale=d_scales_hidden_states,
+            intermediate_states_scales=d_scales_intermediate_hidden_states,
+            weights_scales=(d_scales_up_gate, d_scales_down),
+        )
+        logger.debug(
+            "\n===== paddlenlp_ops.mixture_of_experts Output =====\n",
+            extra={
+                "ep_rank": ep_rank,
+                "tp_rank": tp_rank,
+                "amax_per_expert": amax_per_expert,
+                "final_hidden_states": final_hidden_states,
+            },
+        )
+
+        required_similarity = 0.99
+        similar = check_using_cosine_similarity(
+            final_hidden_states.to("float32").cpu().numpy(),
+            final_hidden_states_ref.to("float32").cpu().numpy(),
+            required_similarity,
+            ep_rank=ep_rank,
+            tp_rank=tp_rank,
+            logger=logger,
+        )
+        # print(f"--final_hidden_states_ref {final_hidden_states_ref}")
+        # print(f"--final_hidden_states {final_hidden_states}")
+        assert similar, f"Cosine similarity check failed: {similar}"
+
+
+if __name__ == "__main__":
+    # Set logging level to DEBUG to see debug messages
+    logging.getLogger().setLevel(logging.WARNING)
+
+    # Create a test suite
+    suite = unittest.TestLoader().loadTestsFromTestCase(MoETest)
+
+    # Create a test runner with the desired verbosity level
+    runner = unittest.TextTestRunner(
+        verbosity=2
+    )  # Set verbosity to 2 for detailed output
+
+    # Run the test suite
+    runner.run(suite)

--- a/backends/intel_hpu/tests/unittests/test_fused_mlp.py
+++ b/backends/intel_hpu/tests/unittests/test_fused_mlp.py
@@ -92,6 +92,12 @@ class Test_Fused_MLP_OP(unittest.TestCase):
             gate_weight,
             up_weight,
             down_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         return fused_mlp_out
 
@@ -101,6 +107,12 @@ class Test_Fused_MLP_OP(unittest.TestCase):
             proj_weight,
             None,
             down_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
         )
         return fused_gateup_mlp_out
 


### PR DESCRIPTION
# fused_mlp
- combine bf16/fp8 as unique kernel
- support fused/split up_gate weights, 2D & 3D shaped input, permuted/ or not weights, for both bf16 & fp8 mode

# fused_gate_moe
- fused gate matmul into kernel
- remove moe_use_gate_correction_bias flag, use gate_correction_bias instead directly
- add 'hidden_states_scales' to fp8 kernel as static quant for hidden_states.