### PR TITLE
【CUDA Kernel No.65】Include kldiv_loss_kernel.h

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/kldiv_loss_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/kldiv_loss_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/kldiv_loss_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/kldiv_loss_kernel.h"
 PD_CUSTOM_KERNEL_REGISTER(
     kldiv_loss, iluvatar_gpu, ALL_LAYOUT, phi::KLDivLossKernel, float, double) {
 }

--- a/backends/metax_gpu/CMakeLists.txt
+++ b/backends/metax_gpu/CMakeLists.txt
@@ -205,6 +205,7 @@ file(
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/index_put_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/index_put_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/kldiv_loss_grad_kernel.cu
+  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/kldiv_loss_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/p_norm_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
   ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/pad_kernel.cu

--- a/backends/metax_gpu/kernels/cuda_kernels/kldiv_loss_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/kldiv_loss_kernel_register.cu
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/kldiv_loss_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/kldiv_loss_kernel.h"
 PD_CUSTOM_KERNEL_REGISTER(
     kldiv_loss, metax_gpu, ALL_LAYOUT, phi::KLDivLossKernel, float, double) {}


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description
- Include kldiv_loss_kernel.h to replace .cu file include
- Add kldiv_loss_kernel.cu to metax_gpu's cmakelists

ℹ️The .h file already exists in the Paddle repo: paddle/phi/kernels/kldiv_loss_kernel.h

ℹ️The kldiv_loss_kernel.cu file has been included in iluvatar_gpu's cmakelists starting from line 276.
```cmake
file(
  GLOB
  CUDA_SRCS2
  ...
  ${PADDLE_SOURCE_DIR}/paddle/phi/kernels/gpu/kldiv_loss_kernel.cu
  ...
)
...
set(CUDA_SRCS ${CUDA_SRCS1} ${CUDA_SRCS2})
list(REMOVE_DUPLICATES CUDA_SRCS)
```
**Used AI Studio**