### PR TITLE
【CUDA Kernel No.58】Include group_norm_grad_kernel.h

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/group_norm_grad_kernel_register.cu
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/group_norm_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/group_norm_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/group_norm_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(group_norm_grad,
                           iluvatar_gpu,

--- a/backends/metax_gpu/kernels/cuda_kernels/group_norm_grad_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/group_norm_grad_kernel_register.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/gpu/group_norm_grad_kernel.cu"  // NOLINT
+#include "paddle/phi/kernels/group_norm_grad_kernel.h"
 
 PD_CUSTOM_KERNEL_REGISTER(group_norm_grad,
                           metax_gpu,


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Improvements

### Description
- Include group_norm_grad_kernel.h to replace .cu file include

ℹ️The .h file already exists in the Paddle repo: paddle/phi/kernels/group_norm_grad_kernel.h

ℹ️The .cu files are already included in the cmakelists of metax_gpu and iluvatar_gpu

**Used AI Studio**
