### PR TITLE
[ILUVATAR] Register `complex64` for remainder op

### DIFF
--- a/backends/iluvatar_gpu/kernels/cuda_kernels/elementwise_kernel_register.cc
+++ b/backends/iluvatar_gpu/kernels/cuda_kernels/elementwise_kernel_register.cc
@@ -15,6 +15,10 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/kps/elementwise_kernel.cu"  // NOLINT
 
+using float16 = phi::dtype::float16;
+using bfloat16 = phi::dtype::bfloat16;
+using complex64 = ::phi::dtype::complex<float>;
+
 PD_CUSTOM_KERNEL_REGISTER(maximum,
                           iluvatar_gpu,
                           ALL_LAYOUT,
@@ -22,8 +26,8 @@ PD_CUSTOM_KERNEL_REGISTER(maximum,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          float16,
+                          bfloat16) {}
 
 PD_CUSTOM_KERNEL_REGISTER(minimum,
                           iluvatar_gpu,
@@ -32,8 +36,8 @@ PD_CUSTOM_KERNEL_REGISTER(minimum,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          float16,
+                          bfloat16) {}
 
 PD_CUSTOM_KERNEL_REGISTER(remainder,
                           iluvatar_gpu,
@@ -42,8 +46,9 @@ PD_CUSTOM_KERNEL_REGISTER(remainder,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          float16,
+                          bfloat16,
+                          complex64) {}
 
 PD_CUSTOM_KERNEL_REGISTER(floor_divide,
                           iluvatar_gpu,
@@ -55,8 +60,8 @@ PD_CUSTOM_KERNEL_REGISTER(floor_divide,
                           int,
                           int64_t,
                           float,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          float16,
+                          bfloat16) {}
 
 PD_CUSTOM_KERNEL_REGISTER(elementwise_pow,
                           iluvatar_gpu,
@@ -65,8 +70,8 @@ PD_CUSTOM_KERNEL_REGISTER(elementwise_pow,
                           float,
                           int,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          float16,
+                          bfloat16) {}
 
 PD_CUSTOM_KERNEL_REGISTER(copysign,
                           iluvatar_gpu,
@@ -79,12 +84,8 @@ PD_CUSTOM_KERNEL_REGISTER(copysign,
                           int,
                           int64_t,
                           float,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
-
-using float16 = phi::dtype::float16;
-using bfloat16 = phi::dtype::bfloat16;
-using complex64 = ::phi::dtype::complex<float>;
+                          float16,
+                          bfloat16) {}
 
 PD_CUSTOM_KERNEL_REGISTER(fmax,
                           iluvatar_gpu,
@@ -127,8 +128,8 @@ PD_CUSTOM_KERNEL_REGISTER(add,
                           uint8_t,
                           int8_t,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16,
+                          float16,
+                          bfloat16,
                           complex64) {}
 
 PD_CUSTOM_KERNEL_REGISTER(grad_add,
@@ -142,8 +143,8 @@ PD_CUSTOM_KERNEL_REGISTER(grad_add,
                           uint8_t,
                           int8_t,
                           int64_t,
-                          phi::dtype::float16,
-                          phi::dtype::bfloat16,
+                          float16,
+                          bfloat16,
                           complex64) {}
 
 PD_CUSTOM_KERNEL_REGISTER(divide,


### PR DESCRIPTION
This pull request refactors the kernel registration code for elementwise operations on the `iluvatar_gpu` backend to simplify type usage and improve maintainability. The main improvement is the introduction of type aliases for commonly used data types, which are then used throughout the kernel registrations. Additionally, support for `complex64` is explicitly added to the `remainder` kernel.

**Type aliasing and code simplification:**

* Introduced type aliases `float16`, `bfloat16`, and `complex64` at the top of `elementwise_kernel_register.cc` to replace repeated use of `phi::dtype::float16`, `phi::dtype::bfloat16`, and `::phi::dtype::complex<float>` in kernel registrations.
* Updated all relevant `PD_CUSTOM_KERNEL_REGISTER` calls (`maximum`, `minimum`, `remainder`, `floor_divide`, `elementwise_pow`, `copysign`, `add`, `grad_add`) to use these new type aliases instead of the longer type names. [[1]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aR18-R30) [[2]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL35-R40) [[3]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL45-R51) [[4]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL58-R64) [[5]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL68-R74) [[6]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL82-R88) [[7]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL130-R132) [[8]](diffhunk://#diff-d1245e5da4e04917ec3aa3e23dfef7a62964c3e5980737f0ed9e7a6d2739e61aL145-R147)

**Kernel support updates:**

* Added `complex64` as a supported type to the `remainder` kernel registration, enabling complex number operations for this kernel.
    test code：
    ```py
    x = paddle.to_tensor([3.0 + 4.0j, 5.0 + 12.0j], dtype='complex64')
    y = paddle.to_tensor([2.0 + 1.0j, 3.0 + 2.0j], dtype='complex64')
    result = x % y
    print(result)
    ```