### PR TITLE
Disable test_match_matrix_tensor_op

### DIFF
--- a/backends/iluvatar_gpu/tests/disabled_test.txt
+++ b/backends/iluvatar_gpu/tests/disabled_test.txt
@@ -548,5 +548,6 @@ test_linear_interp_v2_op.py
 test_nearest_interp_v2_op.py
 test_poisson_op.py
 test_rrelu_op.py
+test_match_matrix_tensor_op.py
 test_set_grad.py
 test_batched_gemm.py


### PR DESCRIPTION
Disable test_match_matrix_tensor_op, as Paddle-CPU built by paddle ci doesn't support AVX.