### PR TITLE
[Metax] Support compelx64 dtype for remainder op

### DIFF
--- a/backends/metax_gpu/kernels/cuda_kernels/elementwise_kernel_register.cu
+++ b/backends/metax_gpu/kernels/cuda_kernels/elementwise_kernel_register.cu
@@ -45,7 +45,8 @@ PD_CUSTOM_KERNEL_REGISTER(remainder,
                           int,
                           int64_t,
                           phi::dtype::float16,
-                          phi::dtype::bfloat16) {}
+                          phi::dtype::bfloat16,
+                          phi::dtype::complex<float>) {}
 PD_CUSTOM_KERNEL_REGISTER(floor_divide,
                           metax_gpu,
                           ALL_LAYOUT,


### PR DESCRIPTION
This pull request makes a small update to the kernel registration in the CUDA backend to add support for an additional data type.

- Added support for the `phi::dtype::complex<float>` data type to the `remainder` kernel registration in `elementwise_kernel_register.cu`.