### PR TITLE
[Metax] rename build_in_metax  in readme doc

### DIFF
--- a/backends/metax_gpu/README.md
+++ b/backends/metax_gpu/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/PaddlePaddle/PaddleCustomDevice
 
 # Compile Source Code
 cd backends/metax_gpu
-bash build_in_metax.sh
+bash build_in_custom.sh
 # or
 bash change_patch.sh #Only execute once
 bash compile.sh      #Can be executed multiple times

--- a/backends/metax_gpu/README_cn.md
+++ b/backends/metax_gpu/README_cn.md
@@ -17,7 +17,7 @@ git clone https://github.com/PaddlePaddle/PaddleCustomDevice
 
 # 编译安装
 cd backends/metax_gpu
-bash build_in_metax.sh
+bash build_in_custom.sh
 # 或者
 bash change_patch.sh #只执行一次
 bash compile.sh      # 可执行多次


### PR DESCRIPTION
https://github.com/PaddlePaddle/PaddleCustomDevice/pull/2364/ 中已修改名称

build_in_metax 修改为 build_in_custom 

关联到issue https://github.com/PaddlePaddle/PaddleCustomDevice/issues/2498
