### PR TITLE
Security: GCUEngine is copyable despite owning a raw executable handle (possible double-free/UAF)

### DIFF
--- a/backends/gcu/custom_engine/gcu_engine.h
+++ b/backends/gcu/custom_engine/gcu_engine.h
@@ -29,6 +29,8 @@ namespace custom_engine {
 class GCUEngine {
  public:
   GCUEngine() = default;
+  GCUEngine(const GCUEngine &) = delete;
+  GCUEngine &operator=(const GCUEngine &) = delete;
   GCUEngine(const std::string &engine_key,
             topsExecutable_t tops_exec,
             const std::vector<const phi::DenseTensor *> &tensor_args,


### PR DESCRIPTION
## Summary

Security: GCUEngine is copyable despite owning a raw executable handle (possible double-free/UAF)

## Problem

**Severity**: `High` | **File**: `backends/gcu/custom_engine/gcu_engine.h:L22`

The `GCUEngine` class owns `tops_exec_` and destroys it in its destructor, but it does not define or delete copy/move constructors and assignment operators. The compiler-generated copy operations will shallow-copy `tops_exec_`, so multiple `GCUEngine` instances can end up destroying the same handle. This can cause double-free, use-after-free, or process crashes.

## Solution

Apply Rule of Five: delete copy constructor/assignment (`GCUEngine(const GCUEngine&) = delete; GCUEngine& operator=(const GCUEngine&) = delete;`) and implement safe move semantics, or wrap `topsExecutable_t` in a unique RAII wrapper with clear ownership.

## Changes

- `backends/gcu/custom_engine/gcu_engine.h` (modified)